### PR TITLE
Enhance Atlaskit integration and add process polyfill for Vite (#145)

### DIFF
--- a/src/components/Neotro/AtlaskitDescriptionEditor.tsx
+++ b/src/components/Neotro/AtlaskitDescriptionEditor.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useCallback, useImperativeHandle, forwardRef } from 'rea
 import { IntlProvider } from 'react-intl-next';
 import { SmartCardProvider, CardClient } from '@atlaskit/link-provider';
 import { jiraAtlaskitIntlMessages } from '@/lib/jiraAtlaskitIntlMessages';
+import { ensureAtlaskitFeatureGates } from '@/lib/ensureAtlaskitFeatureGates';
 import type EditorActions from '@atlaskit/editor-core/actions';
 
 export interface AtlaskitDescriptionEditorHandle {
@@ -37,12 +38,24 @@ const AtlaskitDescriptionEditorInner: React.ForwardRefRenderFunction<
 
   React.useEffect(() => {
     let cancelled = false;
-    import('prosemirror-state').then(({ Selection }) => {
-      const orig = Selection.jsonID;
-      Selection.jsonID = function (id: string, cls: any) {
-        try { return orig.call(this, id, cls); } catch { return cls; }
-      };
-    }).catch(() => {}).then(() => import('@atlaskit/editor-core'))
+    ensureAtlaskitFeatureGates()
+      .then(() => {
+        if (cancelled) return;
+        return import('prosemirror-state');
+      })
+      .then((pm) => {
+        if (cancelled || !pm) return;
+        const { Selection } = pm;
+        const orig = Selection.jsonID;
+        Selection.jsonID = function (id: string, cls: any) {
+          try { return orig.call(this, id, cls); } catch { return cls; }
+        };
+      })
+      .catch(() => {})
+      .then(() => {
+        if (cancelled) return;
+        return import('@atlaskit/editor-core');
+      })
       .then((mod) => {
         if (cancelled) return;
         const Comp = (mod as any).default ?? (mod as any).Editor;

--- a/src/lib/ensureAtlaskitFeatureGates.ts
+++ b/src/lib/ensureAtlaskitFeatureGates.ts
@@ -1,0 +1,31 @@
+import FeatureGates, { FeatureGateEnvironment } from '@atlaskit/feature-gate-js-client';
+
+let initPromise: Promise<void> | null = null;
+
+/**
+ * Atlaskit Editor calls FeatureGates.checkGate at runtime. Outside Jira/Confluence the client
+ * is never bootstrapped. This bootstraps with empty values and localMode (no Atlassian API).
+ */
+export function ensureAtlaskitFeatureGates(): Promise<void> {
+  if (initPromise) return initPromise;
+
+  initPromise = FeatureGates.initializeFromValues(
+    {
+      environment: import.meta.env.PROD
+        ? FeatureGateEnvironment.Production
+        : FeatureGateEnvironment.Development,
+      targetApp: 'jira_web',
+      localMode: true,
+    },
+    {},
+    {},
+    {},
+  ).then(
+    () => undefined,
+    (err: unknown) => {
+      console.warn('[ensureAtlaskitFeatureGates] initialization failed', err);
+    },
+  );
+
+  return initPromise;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,4 @@
+import './processPolyfill';
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'

--- a/src/processPolyfill.ts
+++ b/src/processPolyfill.ts
@@ -1,0 +1,8 @@
+/** Atlaskit bundles reference `process` in the browser; Vite only replaces `process.env`. */
+const nodeEnv = import.meta.env.PROD ? 'production' : 'development';
+const g = globalThis as typeof globalThis & { process?: { env?: Record<string, string>; browser?: boolean } };
+if (typeof g.process === 'undefined') {
+  g.process = { env: { NODE_ENV: nodeEnv }, browser: true };
+} else {
+  g.process.env = { NODE_ENV: nodeEnv, ...g.process.env };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,6 +30,7 @@ export default defineConfig(({ mode, command }) => {
       },
       dedupe: [
         "react-intl-next",
+        "@atlaskit/feature-gate-js-client",
         "@atlaskit/link-provider",
         "prosemirror-state",
         "prosemirror-model",


### PR DESCRIPTION
- Added a new `processPolyfill.ts` file to define a global `process` object for compatibility with Atlaskit bundles in the browser.
- Updated `vite.config.ts` to include `@atlaskit/feature-gate-js-client` in the dedupe list for improved dependency management.
- Imported the new polyfill in `main.tsx` to ensure it is available throughout the application.
- Refactored the `AtlaskitDescriptionEditor` component to utilize `ensureAtlaskitFeatureGates` for better feature gate management during dynamic imports.

These changes improve the integration of Atlaskit components and enhance the application's compatibility with browser environments.