### PR TITLE
Integrate PokerLocalAdvisorSelfUpdate component into PokerAdvisorPanel

### DIFF
--- a/src/components/Neotro/PokerAdvisorPanel.tsx
+++ b/src/components/Neotro/PokerAdvisorPanel.tsx
@@ -604,6 +604,8 @@ export const PokerAdvisorPanel: React.FC = () => {
                             placeholder="Optional instructions sent with each /advise request…"
                           />
                         </div>
+
+                        <PokerLocalAdvisorSelfUpdate baseUrl={draftBaseUrl.trim()} />
                       </div>
 
                       <DialogFooter>
@@ -643,11 +645,6 @@ export const PokerAdvisorPanel: React.FC = () => {
                   </Button>
                 </div>
               </div>
-
-              <PokerLocalAdvisorSelfUpdate
-                baseUrl={(profile?.poker_advisor_base_url || '').trim()}
-                compact
-              />
 
               {paused && (
                 <p className="text-xs text-amber-700 dark:text-amber-500/90">


### PR DESCRIPTION
- Added the PokerLocalAdvisorSelfUpdate component to the PokerAdvisorPanel, allowing users to manage updates directly within the UI.
- Removed the previous instance of PokerLocalAdvisorSelfUpdate that used the profile's base URL, streamlining the update process.

These changes enhance the user experience by providing a more cohesive and accessible update management feature for the Poker Local Advisor.