### PR TITLE
Add loadBoardSprints function for paginated sprint retrieval from Jira (#150)

### DIFF
--- a/supabase/functions/_shared/loadBoardSprints.ts
+++ b/supabase/functions/_shared/loadBoardSprints.ts
@@ -1,0 +1,113 @@
+/** Paginated board sprint loading — mirrors get-jira-sprint-options (state=future,active avoids first-page closed-only results). */
+
+export type BoardSprintRow = {
+  id: number;
+  name?: string;
+  state?: string;
+  startDate?: string;
+};
+
+function pushSprintRows(
+  rows: Array<{ id?: number; name?: string; state?: string; startDate?: string }>,
+  sprintIdToName: Map<number | string, string>,
+  sprintIdToStartDate: Map<number | string, string>,
+  out: BoardSprintRow[],
+  stateFilter: Set<string> | null,
+): void {
+  for (const s of rows) {
+    if (s?.id == null) continue;
+    const id = typeof s.id === 'number' ? s.id : parseInt(String(s.id), 10);
+    if (Number.isNaN(id)) continue;
+    const st = String(s.state ?? '').toLowerCase();
+    if (stateFilter && !stateFilter.has(st)) continue;
+    const name = typeof s.name === 'string' && s.name.trim() ? s.name.trim() : undefined;
+    const startDate = typeof s.startDate === 'string' && s.startDate ? s.startDate : undefined;
+    if (name) sprintIdToName.set(id, name);
+    if (startDate) sprintIdToStartDate.set(id, startDate);
+    out.push({ id, name, state: s.state, startDate });
+  }
+}
+
+async function paginateBoardSprints(
+  baseUrl: string,
+  authHeaders: Record<string, string>,
+  boardId: number,
+  sprintIdToName: Map<number | string, string>,
+  sprintIdToStartDate: Map<number | string, string>,
+  stateFilter: Set<string> | null,
+  stateQuery: string | undefined,
+  maxPages: number,
+): Promise<BoardSprintRow[]> {
+  const out: BoardSprintRow[] = [];
+  let startAt = 0;
+  const maxResults = 50;
+
+  for (let page = 0; page < maxPages; page++) {
+    const q = new URLSearchParams();
+    q.set('maxResults', String(maxResults));
+    q.set('startAt', String(startAt));
+    if (stateQuery) q.set('state', stateQuery);
+
+    const res = await fetch(`${baseUrl}/rest/agile/1.0/board/${boardId}/sprint?${q.toString()}`, {
+      headers: authHeaders,
+    });
+    if (!res.ok) break;
+
+    const data = await res.json();
+    const values = (data?.values ?? []) as Array<{ id?: number; name?: string; state?: string; startDate?: string }>;
+    pushSprintRows(values, sprintIdToName, sprintIdToStartDate, out, stateFilter);
+
+    const isLast = data?.isLast === true || values.length === 0;
+    if (isLast) break;
+    startAt += values.length;
+  }
+
+  return out;
+}
+
+/** Active + future sprints on the board (paginated). Use for ranked sprint/issue fetch. */
+export async function loadBoardActiveFutureSprints(
+  baseUrl: string,
+  authHeaders: Record<string, string>,
+  boardId: number,
+  sprintIdToName: Map<number | string, string>,
+  sprintIdToStartDate: Map<number | string, string>,
+): Promise<BoardSprintRow[]> {
+  const activeFuture = new Set(['active', 'future']);
+  const rows = await paginateBoardSprints(
+    baseUrl,
+    authHeaders,
+    boardId,
+    sprintIdToName,
+    sprintIdToStartDate,
+    activeFuture,
+    'future,active',
+    30,
+  );
+
+  if (rows.length > 0) {
+    return dedupeSprintsById(rows);
+  }
+
+  // Fallback: paginate all sprints and keep active/future (older Jira without state query param).
+  const fallback = await paginateBoardSprints(
+    baseUrl,
+    authHeaders,
+    boardId,
+    sprintIdToName,
+    sprintIdToStartDate,
+    activeFuture,
+    undefined,
+    30,
+  );
+  return dedupeSprintsById(fallback);
+}
+
+function dedupeSprintsById(rows: BoardSprintRow[]): BoardSprintRow[] {
+  const seen = new Set<number>();
+  return rows.filter((s) => {
+    if (seen.has(s.id)) return false;
+    seen.add(s.id);
+    return true;
+  });
+}

--- a/supabase/functions/get-jira-board-issues/index.ts
+++ b/supabase/functions/get-jira-board-issues/index.ts
@@ -6,6 +6,7 @@ import {
   JIRA_STORY_POINT_FIELD_FALLBACK_IDS,
 } from '../_shared/jiraStoryPoints.ts';
 import { createGetSprintMeta } from '../_shared/jiraSprintFields.ts';
+import { loadBoardActiveFutureSprints } from '../_shared/loadBoardSprints.ts';
 
 const DEFAULT_STORY_POINTS_JQL_FIELD_NAME = 'Story Points';
 
@@ -120,6 +121,52 @@ async function fetchAllAgileSprintIssuesPaginated(
     if (total !== undefined && startAt >= total) break;
   }
   return issueObjects;
+}
+
+/** Sprint ids with matching issues outside the board active/future set (e.g. closed refinement buckets). */
+async function discoverOrphanBoardSprintIds(
+  baseUrl: string,
+  authHeaders: Record<string, string>,
+  auxiliaryJqlParts: string[],
+  excludeSprintIds: number[],
+  fieldsParam: string,
+  getSprintMeta: ReturnType<typeof createGetSprintMeta>,
+  maxPages: number,
+): Promise<number[]> {
+  const jqlParts = [...auxiliaryJqlParts, 'sprint is not EMPTY'];
+  if (excludeSprintIds.length > 0) {
+    jqlParts.push(`sprint not in (${excludeSprintIds.join(', ')})`);
+  }
+  const jql = jqlParts.join(' AND ');
+  const orphanIds = new Set<number>();
+  const pageSize = 100;
+  let nextPageToken: string | undefined = undefined;
+
+  for (let page = 0; page < maxPages; page++) {
+    const body: Record<string, unknown> = {
+      jql,
+      maxResults: pageSize,
+      fields: fieldsParam.split(','),
+    };
+    if (nextPageToken) body.nextPageToken = nextPageToken;
+
+    const res = await fetch(`${baseUrl}/rest/api/3/search/jql`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) break;
+    const data = await res.json();
+    const batch = data.issues || [];
+    for (const issue of batch) {
+      const meta = getSprintMeta(issue?.fields as Record<string, unknown>);
+      if (meta.sprintId != null) orphanIds.add(meta.sprintId);
+    }
+    if (batch.length === 0 || !data.nextPageToken) break;
+    nextPageToken = data.nextPageToken;
+  }
+
+  return [...orphanIds];
 }
 
 /** Board backlog ordering matches manual backlog ordering on this board's backlog view. */
@@ -393,23 +440,15 @@ Deno.serve(async (req) => {
     let boardActiveFutureSprints: { id: number; startDate?: string; name?: string }[] = [];
     if (resolvedBoardId != null) {
       try {
-        const sprintsRes = await fetch(`${baseUrl}/rest/agile/1.0/board/${resolvedBoardId}/sprint`, { headers: authHeaders });
-        if (sprintsRes.ok) {
-          const sprintsData = await sprintsRes.json();
-          // deno-lint-ignore no-explicit-any
-          const openSprints = (sprintsData?.values || []).filter((s: any) => s?.id != null && (s?.state === 'future' || s?.state === 'active'));
-          boardActiveFutureSprints = openSprints.map((s: any) => {
-            const id = typeof s.id === 'number' ? s.id : parseInt(String(s.id), 10);
-            const startDate = typeof s?.startDate === 'string' && s.startDate ? s.startDate : undefined;
-            const name = typeof s?.name === 'string' && s.name.trim() ? s.name : undefined;
-            if (name) sprintIdToName.set(id, name);
-            if (startDate) sprintIdToStartDate.set(id, startDate);
-            return { id, startDate, name };
-          });
-          if (sprintScope === 'board-open-backlog' && openSprints.length > 0) {
-            // deno-lint-ignore no-explicit-any
-            sprintJql = `(sprint in (${openSprints.map((s: any) => s.id).join(', ')}) OR sprint is EMPTY)`;
-          }
+        boardActiveFutureSprints = await loadBoardActiveFutureSprints(
+          baseUrl,
+          authHeaders,
+          resolvedBoardId,
+          sprintIdToName,
+          sprintIdToStartDate,
+        );
+        if (sprintScope === 'board-open-backlog' && boardActiveFutureSprints.length > 0) {
+          sprintJql = `(sprint in (${boardActiveFutureSprints.map((s) => s.id).join(', ')}) OR sprint is EMPTY)`;
         }
       } catch (_) {
         /* ignore */
@@ -457,6 +496,26 @@ Deno.serve(async (req) => {
           baseUrl,
           authHeaders,
           s.id,
+          fieldsParam,
+          auxiliaryJqlForBoardBrowse,
+          maxPagesOrLoops,
+        );
+        pushUniqueIssues(chunk);
+      }
+      const orphanSprintIds = await discoverOrphanBoardSprintIds(
+        baseUrl,
+        authHeaders,
+        auxiliaryJqlParts,
+        orderedSprints.map((s) => s.id),
+        fieldsParam,
+        getSprintMeta,
+        maxPagesOrLoops,
+      );
+      for (const orphanId of orphanSprintIds) {
+        const chunk = await fetchAllAgileSprintIssuesPaginated(
+          baseUrl,
+          authHeaders,
+          orphanId,
           fieldsParam,
           auxiliaryJqlForBoardBrowse,
           maxPagesOrLoops,


### PR DESCRIPTION
- Introduced a new function, loadBoardActiveFutureSprints, to fetch active and future sprints from a Jira board with pagination support.
- Implemented helper functions for processing sprint data, including deduplication and state filtering.
- Updated get-jira-board-issues function to utilize the new sprint loading functionality, enhancing the efficiency of issue fetching.

These changes improve the integration with Jira by providing a more streamlined approach to managing board sprints and their associated issues.