### PR TITLE
Implement Jira issue linking functionality in JiraIssueDrawer and add JiraIssueLinksSection component

### DIFF
--- a/src/components/Neotro/JiraIssueDrawer.tsx
+++ b/src/components/Neotro/JiraIssueDrawer.tsx
@@ -22,6 +22,11 @@ import { parentBadgeClassName } from '@/lib/parentBadgeTone';
 import { broadcastPokerSessionJiraStoryPoints } from '@/lib/pokerJiraStoryPointsBroadcast';
 import { getSprintBucketFromIssueFields } from '@/lib/jiraSprintFromFields';
 import {
+  normalizeIssueLinks,
+  type JiraIssueLinkRaw,
+} from '@/lib/jiraIssueLinks';
+import { JiraIssueLinksSection } from '@/components/Neotro/JiraIssueLinksSection';
+import {
   buildSprintPickerDataFromCacheAndIssue,
   getCachedTeamSprintPickerOptions,
   setCachedTeamSprintPickerOptions,
@@ -117,6 +122,8 @@ interface JiraIssueFields {
   /** Present when the issue is under a parent (same shape as Jira browse lists). */
   parent?: { key: string; fields?: { summary?: string } } | null;
   labels?: string[];
+  /** Linked work items (e.g. Blocks, Relates to). */
+  issuelinks?: JiraIssueLinkRaw[];
   comment?: { comments: JiraComment[]; total: number };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
@@ -1066,6 +1073,7 @@ export const JiraIssueDrawer: React.FC<JiraIssueDrawerProps> = ({
           priorities: data.priorities ?? [],
           issueTypes: data.issueTypes ?? [],
           transitions: data.transitions ?? [],
+          linkTypes: data.linkTypes ?? [],
         };
         setCachedIssueFieldOptions(teamId, issueData.key, payload);
         setFieldOptions(payload);
@@ -1567,13 +1575,14 @@ export const JiraIssueDrawer: React.FC<JiraIssueDrawerProps> = ({
                     </NeotroPressableButton>
                   ) : externalUrl ? (
                     <NeotroPressableButton
-                      href={externalUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
+                      type="button"
+                      onClick={() => window.open(externalUrl, '_blank', 'noopener,noreferrer')}
                       size="compact"
                       isActive
                       activeShowsPressed={false}
                       className="gap-1.5 shrink-0"
+                      aria-label="Open in Jira (new tab)"
+                      title="Open in Jira (new tab)"
                     >
                       <ExternalLink className="h-3 w-3" />
                       Open in Jira
@@ -2343,6 +2352,26 @@ export const JiraIssueDrawer: React.FC<JiraIssueDrawerProps> = ({
                     </div>
                   )}
                 </div>
+
+                {/* Linked work items */}
+                {!isPreviewMode && (
+                  <JiraIssueLinksSection
+                    teamId={teamId}
+                    issueKey={issueData?.key ?? null}
+                    jiraDomain={jiraDomain ?? undefined}
+                    links={normalizeIssueLinks(fields.issuelinks)}
+                    linkTypes={fieldOptions?.linkTypes ?? []}
+                    canEdit={canEditJira}
+                    noApiCredentials={noApiCredentials}
+                    portalContainer={jiraDialogPortalContainer}
+                    onLinksChanged={async () => {
+                      if (!teamId || !issueIdOrKey) return;
+                      invalidateJiraIssueCache(teamId, issueIdOrKey);
+                      await fetchIssue(false, { skipCache: true, keepPreviousData: true });
+                    }}
+                  />
+                )}
+
                 {/* Comments */}
                 <Separator />
                 <div>

--- a/src/components/Neotro/JiraIssueLinksSection.tsx
+++ b/src/components/Neotro/JiraIssueLinksSection.tsx
@@ -1,0 +1,421 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Link2, Loader2, Plus, AlertCircle } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Separator } from '@/components/ui/separator';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { supabase } from '@/integrations/supabase/client';
+import { useToast } from '@/hooks/use-toast';
+import { cn } from '@/lib/utils';
+import {
+  buildLinkTypeOptions,
+  looksLikeJiraIssueKey,
+  type JiraIssueLinkDisplay,
+  type JiraLinkTypeOption,
+  type JiraLinkTypeRaw,
+} from '@/lib/jiraIssueLinks';
+
+const statusColorMap: Record<string, string> = {
+  'blue-gray': 'bg-muted text-muted-foreground',
+  'yellow': 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+  'green': 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+  'medium-gray': 'bg-muted text-muted-foreground',
+};
+
+function statusBadgeClassName(colorName?: string): string {
+  if (!colorName) return 'bg-muted text-muted-foreground';
+  return statusColorMap[colorName] || 'bg-muted text-muted-foreground';
+}
+
+interface JiraIssueLinksSectionProps {
+  teamId: string | null;
+  issueKey: string | null;
+  jiraDomain?: string;
+  links: JiraIssueLinkDisplay[];
+  linkTypes: JiraLinkTypeRaw[];
+  canEdit: boolean;
+  noApiCredentials: boolean;
+  /** Container for the popover so it renders inside the dialog and isn't scroll-locked. */
+  portalContainer?: HTMLElement | null;
+  /** Called after a successful add/remove so the parent can refresh the issue. */
+  onLinksChanged: () => void | Promise<void>;
+}
+
+interface IssuePreview {
+  key: string;
+  summary: string;
+  status?: { name: string; colorName?: string };
+  issueTypeIconUrl?: string;
+  issueTypeName?: string;
+}
+
+export function JiraIssueLinksSection({
+  teamId,
+  issueKey,
+  jiraDomain,
+  links,
+  linkTypes,
+  canEdit,
+  noApiCredentials,
+  portalContainer,
+  onLinksChanged,
+}: JiraIssueLinksSectionProps) {
+  const { toast } = useToast();
+
+  const linkTypeOptions = useMemo<JiraLinkTypeOption[]>(
+    () => buildLinkTypeOptions(linkTypes),
+    [linkTypes],
+  );
+
+  const [addOpen, setAddOpen] = useState(false);
+  const [selectedOptionKey, setSelectedOptionKey] = useState<string>('');
+  const [targetKeyDraft, setTargetKeyDraft] = useState('');
+  const [preview, setPreview] = useState<IssuePreview | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  // Reset transient state when the popover closes.
+  useEffect(() => {
+    if (!addOpen) {
+      setTargetKeyDraft('');
+      setPreview(null);
+      setPreviewError(null);
+      setPreviewLoading(false);
+    }
+  }, [addOpen]);
+
+  // Default link type selection once options arrive.
+  useEffect(() => {
+    if (!selectedOptionKey && linkTypeOptions.length > 0) {
+      // Prefer "relates to" as a sensible default when present.
+      const relates = linkTypeOptions.find((o) => /^relates(\s|$)/i.test(o.label));
+      setSelectedOptionKey((relates ?? linkTypeOptions[0]).key);
+    }
+  }, [linkTypeOptions, selectedOptionKey]);
+
+  const selectedOption = useMemo<JiraLinkTypeOption | undefined>(
+    () => linkTypeOptions.find((o) => o.key === selectedOptionKey),
+    [linkTypeOptions, selectedOptionKey],
+  );
+
+  // Debounced preview lookup. `get-jira-issue` is reused here so we don't need a new search endpoint.
+  const previewSeqRef = useRef(0);
+  useEffect(() => {
+    if (!addOpen) return;
+    const trimmed = targetKeyDraft.trim();
+    setPreviewError(null);
+    if (!trimmed) {
+      setPreview(null);
+      setPreviewLoading(false);
+      return;
+    }
+    if (!looksLikeJiraIssueKey(trimmed)) {
+      setPreview(null);
+      setPreviewLoading(false);
+      setPreviewError('Enter a full issue key (e.g. PROJ-123)');
+      return;
+    }
+    if (!teamId) return;
+
+    const seq = ++previewSeqRef.current;
+    setPreviewLoading(true);
+    const handle = setTimeout(async () => {
+      try {
+        const { data, error } = await supabase.functions.invoke('get-jira-issue', {
+          body: { issueIdOrKey: trimmed, teamId },
+        });
+        if (seq !== previewSeqRef.current) return;
+        if (error || data?.error) {
+          setPreview(null);
+          setPreviewError("Couldn't find that issue. Check the key.");
+          return;
+        }
+        const fields = data?.fields ?? {};
+        setPreview({
+          key: String(data?.key ?? trimmed.toUpperCase()),
+          summary: String(fields?.summary ?? ''),
+          status: fields?.status?.name
+            ? {
+                name: String(fields.status.name),
+                colorName: fields.status.statusCategory?.colorName
+                  ? String(fields.status.statusCategory.colorName)
+                  : undefined,
+              }
+            : undefined,
+          issueTypeIconUrl: fields?.issuetype?.iconUrl ? String(fields.issuetype.iconUrl) : undefined,
+          issueTypeName: fields?.issuetype?.name ? String(fields.issuetype.name) : undefined,
+        });
+      } catch {
+        if (seq !== previewSeqRef.current) return;
+        setPreview(null);
+        setPreviewError("Couldn't load the issue.");
+      } finally {
+        if (seq === previewSeqRef.current) setPreviewLoading(false);
+      }
+    }, 320);
+    return () => clearTimeout(handle);
+  }, [addOpen, targetKeyDraft, teamId]);
+
+  const handleCreate = async () => {
+    if (!teamId || !issueKey || !selectedOption) return;
+    const target = targetKeyDraft.trim();
+    if (!target) return;
+    if (!looksLikeJiraIssueKey(target)) {
+      setPreviewError('Enter a full issue key (e.g. PROJ-123)');
+      return;
+    }
+    if (target.toUpperCase() === issueKey.toUpperCase()) {
+      toast({
+        title: "Can't link an issue to itself",
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const { data, error } = await supabase.functions.invoke('manage-jira-issue-link', {
+        body: {
+          action: 'create',
+          teamId,
+          issueKey,
+          targetIssueKey: target,
+          linkTypeName: selectedOption.typeName,
+          direction: selectedOption.direction,
+        },
+      });
+      if (error || data?.error) {
+        const msg = (data?.error as string | undefined) ?? error?.message ?? 'Failed to link issue.';
+        toast({ title: 'Could not link issue', description: msg, variant: 'destructive' });
+        return;
+      }
+      setAddOpen(false);
+      await onLinksChanged();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Group links by relationship label so e.g. all "blocks" links appear together (matches Jira UX).
+  const grouped = useMemo(() => {
+    const map = new Map<string, JiraIssueLinkDisplay[]>();
+    for (const link of links) {
+      const list = map.get(link.relationshipLabel) ?? [];
+      list.push(link);
+      map.set(link.relationshipLabel, list);
+    }
+    return Array.from(map.entries()).sort(([a], [b]) =>
+      a.localeCompare(b, undefined, { sensitivity: 'base' }),
+    );
+  }, [links]);
+
+  const showAddButton = canEdit && !noApiCredentials && linkTypeOptions.length > 0;
+
+  if (links.length === 0 && !showAddButton) {
+    // Nothing to show and no way to add — hide the section entirely.
+    return null;
+  }
+
+  return (
+    <>
+      <Separator />
+      <div>
+        <div className="flex items-center justify-between gap-2 mb-2">
+          <div className="flex items-center gap-1">
+            <Link2 className="h-3.5 w-3.5 text-muted-foreground" />
+            <p className="text-[10px] uppercase tracking-wider text-muted-foreground">
+              Linked work items ({links.length})
+            </p>
+          </div>
+          {showAddButton && (
+            <Popover open={addOpen} onOpenChange={setAddOpen}>
+              <PopoverTrigger asChild>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  className="h-7 gap-1.5 px-2 text-xs"
+                  disabled={saving}
+                >
+                  <Plus className="h-3.5 w-3.5" />
+                  Link issue
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent
+                container={portalContainer ?? undefined}
+                className="w-[min(100vw-2rem,340px)] p-3 space-y-2.5"
+                align="end"
+              >
+                <div className="space-y-1.5">
+                  <p className="text-[10px] uppercase tracking-wider text-muted-foreground">Relationship</p>
+                  <Select value={selectedOptionKey} onValueChange={setSelectedOptionKey}>
+                    <SelectTrigger className="h-8 text-sm">
+                      <SelectValue placeholder="Select a relationship" />
+                    </SelectTrigger>
+                    <SelectContent container={portalContainer ?? undefined}>
+                      {linkTypeOptions.map((opt) => (
+                        <SelectItem key={opt.key} value={opt.key} className="text-sm">
+                          {opt.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-1.5">
+                  <p className="text-[10px] uppercase tracking-wider text-muted-foreground">Issue key</p>
+                  <Input
+                    autoFocus
+                    placeholder="PROJ-123"
+                    value={targetKeyDraft}
+                    onChange={(e) => setTargetKeyDraft(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' && preview && !saving) {
+                        e.preventDefault();
+                        void handleCreate();
+                      }
+                    }}
+                    disabled={saving}
+                    className="h-8 text-sm"
+                  />
+                  <div className="min-h-[36px]">
+                    {previewLoading ? (
+                      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                        <Loader2 className="h-3 w-3 animate-spin" /> Looking up issue…
+                      </div>
+                    ) : previewError ? (
+                      <div className="flex items-center gap-1.5 text-xs text-destructive">
+                        <AlertCircle className="h-3 w-3 shrink-0" />
+                        <span>{previewError}</span>
+                      </div>
+                    ) : preview ? (
+                      <div className="flex items-center gap-2 rounded-md border bg-muted/30 p-1.5 text-xs">
+                        {preview.issueTypeIconUrl ? (
+                          <img
+                            src={preview.issueTypeIconUrl}
+                            alt={preview.issueTypeName ?? ''}
+                            className="h-3.5 w-3.5 shrink-0"
+                          />
+                        ) : null}
+                        <span className="font-mono font-medium text-foreground shrink-0">{preview.key}</span>
+                        <span className="text-muted-foreground truncate">{preview.summary}</span>
+                        {preview.status?.name && (
+                          <Badge
+                            variant="outline"
+                            className={cn(
+                              'shrink-0 text-[10px] py-0 px-1.5',
+                              statusBadgeClassName(preview.status.colorName),
+                            )}
+                          >
+                            {preview.status.name}
+                          </Badge>
+                        )}
+                      </div>
+                    ) : null}
+                  </div>
+                </div>
+                <div className="flex justify-end gap-2 pt-1">
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => setAddOpen(false)}
+                    disabled={saving}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    onClick={() => void handleCreate()}
+                    disabled={saving || !preview || !selectedOption}
+                  >
+                    {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : 'Link'}
+                  </Button>
+                </div>
+              </PopoverContent>
+            </Popover>
+          )}
+        </div>
+
+        {links.length === 0 ? (
+          <p className="text-sm text-muted-foreground italic">No linked work items.</p>
+        ) : (
+          <div className="space-y-3">
+            {grouped.map(([label, group]) => (
+              <div key={label} className="space-y-1">
+                <p className="text-[11px] font-medium text-muted-foreground capitalize">{label}</p>
+                <ul className="space-y-1">
+                  {group.map((link) => {
+                    const href = jiraDomain ? `${jiraDomain}/browse/${link.issue.key}` : null;
+                    const colorName = link.issue.status?.statusCategory?.colorName;
+                    const rowClassName = cn(
+                      'flex items-center gap-2 rounded-md border bg-card/50 px-2 py-1.5 text-sm',
+                      href && 'transition-colors hover:bg-muted/50',
+                    );
+                    const rowContent = (
+                      <>
+                        {link.issue.issuetype?.iconUrl ? (
+                          <img
+                            src={link.issue.issuetype.iconUrl}
+                            alt={link.issue.issuetype.name}
+                            className="h-4 w-4 shrink-0"
+                          />
+                        ) : null}
+                        <span className="font-mono text-xs font-medium text-primary shrink-0">
+                          {link.issue.key}
+                        </span>
+                        <span
+                          className="min-w-0 flex-1 truncate text-sm text-foreground"
+                          title={link.issue.summary}
+                        >
+                          {link.issue.summary || <span className="text-muted-foreground italic">No summary</span>}
+                        </span>
+                        {link.issue.status?.name && (
+                          <Badge
+                            variant="outline"
+                            className={cn(
+                              'shrink-0 text-[10px] py-0 px-1.5',
+                              statusBadgeClassName(colorName),
+                            )}
+                          >
+                            {link.issue.status.name}
+                          </Badge>
+                        )}
+                      </>
+                    );
+                    return (
+                      <li key={link.id}>
+                        {href ? (
+                          <a
+                            href={href}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className={rowClassName}
+                            title={`Open ${link.issue.key} in Jira`}
+                          >
+                            {rowContent}
+                          </a>
+                        ) : (
+                          <div className={rowClassName}>{rowContent}</div>
+                        )}
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -65,11 +65,16 @@ const SelectScrollDownButton = React.forwardRef<
 SelectScrollDownButton.displayName =
   SelectPrimitive.ScrollDownButton.displayName
 
+type SelectContentProps = React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content> & {
+  /** Optional portal container so the dropdown renders inside the right scroll context (e.g. inside a Dialog). */
+  container?: React.ComponentProps<typeof SelectPrimitive.Portal>["container"];
+};
+
 const SelectContent = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = "popper", ...props }, ref) => (
-  <SelectPrimitive.Portal>
+  SelectContentProps
+>(({ className, children, position = "popper", container, ...props }, ref) => (
+  <SelectPrimitive.Portal container={container}>
     <SelectPrimitive.Content
       ref={ref}
       className={cn(

--- a/src/lib/jiraIssueFieldOptionsCache.ts
+++ b/src/lib/jiraIssueFieldOptionsCache.ts
@@ -6,6 +6,7 @@ export type JiraFieldOptionsPayload = {
   priorities: Array<{ id: string; name: string; iconUrl?: string }>;
   issueTypes: Array<{ id: string; name: string; iconUrl?: string }>;
   transitions: Array<{ id: string; name: string; toStatusName?: string }>;
+  linkTypes: Array<{ id: string; name: string; inward: string; outward: string }>;
 };
 
 type Entry = { data: JiraFieldOptionsPayload; expiresAt: number };

--- a/src/lib/jiraIssueLinks.ts
+++ b/src/lib/jiraIssueLinks.ts
@@ -1,0 +1,200 @@
+/**
+ * Types and normalization helpers for Jira "Linked work items" (issue links).
+ *
+ * Jira's `issuelinks` field is symmetric: each entry contains either an
+ * `inwardIssue` (the other side of an inward relationship from current issue's
+ * perspective) or an `outwardIssue` (outward side). The relationship label
+ * comes from `type.inward` or `type.outward` accordingly.
+ */
+
+export type JiraIssueLinkDirection = 'inward' | 'outward';
+
+export interface JiraIssueLinkRaw {
+  id: string;
+  type?: {
+    id?: string;
+    name?: string;
+    inward?: string;
+    outward?: string;
+  };
+  inwardIssue?: {
+    key?: string;
+    fields?: {
+      summary?: string;
+      status?: { name?: string; statusCategory?: { colorName?: string; key?: string } };
+      issuetype?: { name?: string; iconUrl?: string };
+      priority?: { name?: string; iconUrl?: string };
+    };
+  };
+  outwardIssue?: {
+    key?: string;
+    fields?: {
+      summary?: string;
+      status?: { name?: string; statusCategory?: { colorName?: string; key?: string } };
+      issuetype?: { name?: string; iconUrl?: string };
+      priority?: { name?: string; iconUrl?: string };
+    };
+  };
+}
+
+export interface JiraLinkedIssueSummary {
+  key: string;
+  summary: string;
+  status?: { name: string; statusCategory?: { colorName?: string; key?: string } };
+  issuetype?: { name: string; iconUrl?: string };
+  priority?: { name: string; iconUrl?: string };
+}
+
+export interface JiraIssueLinkDisplay {
+  id: string;
+  relationshipLabel: string;
+  /** Direction relative to the *current* issue: outward means current issue is the outward side. */
+  direction: JiraIssueLinkDirection;
+  /** The Jira link type name (e.g. "Blocks", "Relates"); needed to recreate after delete. */
+  linkTypeName: string;
+  issue: JiraLinkedIssueSummary;
+}
+
+export interface JiraLinkTypeRaw {
+  id: string;
+  name: string;
+  inward: string;
+  outward: string;
+}
+
+export interface JiraLinkTypeOption {
+  /** Unique key for React lists: `${typeName}|${direction}`. */
+  key: string;
+  /** Jira link type name (e.g. "Blocks", "Relates"); sent back to the API. */
+  typeName: string;
+  /** Which side the *current* issue plays in this relationship. */
+  direction: JiraIssueLinkDirection;
+  /** Human-readable label such as "blocks", "is blocked by", "relates to". */
+  label: string;
+}
+
+function asString(v: unknown): string {
+  return typeof v === 'string' ? v : '';
+}
+
+function pickIssueSummary(issue: NonNullable<JiraIssueLinkRaw['inwardIssue' | 'outwardIssue']>): JiraLinkedIssueSummary {
+  const key = asString(issue.key);
+  const fields = issue.fields ?? {};
+  return {
+    key,
+    summary: asString(fields.summary),
+    status: fields.status?.name
+      ? {
+          name: asString(fields.status.name),
+          statusCategory: fields.status.statusCategory
+            ? {
+                colorName: fields.status.statusCategory.colorName
+                  ? asString(fields.status.statusCategory.colorName)
+                  : undefined,
+                key: fields.status.statusCategory.key
+                  ? asString(fields.status.statusCategory.key)
+                  : undefined,
+              }
+            : undefined,
+        }
+      : undefined,
+    issuetype: fields.issuetype?.name
+      ? {
+          name: asString(fields.issuetype.name),
+          iconUrl: fields.issuetype.iconUrl ? asString(fields.issuetype.iconUrl) : undefined,
+        }
+      : undefined,
+    priority: fields.priority?.name
+      ? {
+          name: asString(fields.priority.name),
+          iconUrl: fields.priority.iconUrl ? asString(fields.priority.iconUrl) : undefined,
+        }
+      : undefined,
+  };
+}
+
+/**
+ * Convert raw Jira `issuelinks` into a display-friendly list. The relationship
+ * label is always phrased from the current issue's perspective.
+ *
+ *   Current issue has link: { type: { inward: "is blocked by", outward: "blocks" }, outwardIssue: TARGET }
+ *   → label: "blocks", direction: "outward", issue: TARGET
+ *
+ *   Current issue has link: { type: { ... }, inwardIssue: SOURCE }
+ *   → label: "is blocked by", direction: "inward", issue: SOURCE
+ */
+export function normalizeIssueLinks(
+  issuelinks: readonly JiraIssueLinkRaw[] | undefined | null,
+): JiraIssueLinkDisplay[] {
+  if (!Array.isArray(issuelinks)) return [];
+  const out: JiraIssueLinkDisplay[] = [];
+  for (const link of issuelinks) {
+    if (!link?.id) continue;
+    const typeName = asString(link.type?.name);
+    if (link.outwardIssue?.key) {
+      out.push({
+        id: String(link.id),
+        relationshipLabel: asString(link.type?.outward) || typeName || 'relates to',
+        direction: 'outward',
+        linkTypeName: typeName,
+        issue: pickIssueSummary(link.outwardIssue),
+      });
+    } else if (link.inwardIssue?.key) {
+      out.push({
+        id: String(link.id),
+        relationshipLabel: asString(link.type?.inward) || typeName || 'relates to',
+        direction: 'inward',
+        linkTypeName: typeName,
+        issue: pickIssueSummary(link.inwardIssue),
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Expand each link type into one or two options. Symmetric types (where
+ * inward === outward, e.g. "relates to") collapse to a single option.
+ * Options are sorted alphabetically by label for a stable picker.
+ */
+export function buildLinkTypeOptions(
+  linkTypes: readonly JiraLinkTypeRaw[] | undefined | null,
+): JiraLinkTypeOption[] {
+  if (!Array.isArray(linkTypes)) return [];
+  const opts: JiraLinkTypeOption[] = [];
+  for (const t of linkTypes) {
+    const name = asString(t?.name);
+    if (!name) continue;
+    const outward = asString(t.outward);
+    const inward = asString(t.inward);
+    const symmetric = outward && inward && outward.trim().toLowerCase() === inward.trim().toLowerCase();
+    if (outward) {
+      opts.push({
+        key: `${name}|outward`,
+        typeName: name,
+        direction: 'outward',
+        label: outward,
+      });
+    }
+    if (inward && !symmetric) {
+      opts.push({
+        key: `${name}|inward`,
+        typeName: name,
+        direction: 'inward',
+        label: inward,
+      });
+    }
+  }
+  return opts.sort((a, b) => a.label.localeCompare(b.label, undefined, { sensitivity: 'base' }));
+}
+
+/**
+ * Validate that a string looks like a Jira issue key (e.g. PROJ-123). Allows
+ * `123` as a shorthand the edge function will prefix with the team's ticket prefix.
+ */
+export function looksLikeJiraIssueKey(raw: string): boolean {
+  const t = raw.trim();
+  if (!t) return false;
+  if (/^\d+$/.test(t)) return true;
+  return /^[A-Za-z][A-Za-z0-9_]*-\d+$/.test(t);
+}

--- a/supabase/functions/get-jira-issue-field-options/index.ts
+++ b/supabase/functions/get-jira-issue-field-options/index.ts
@@ -52,10 +52,11 @@ Deno.serve(async (req) => {
 
     const base = `${jira_domain}/rest/api/2/issue/${encodeURIComponent(resolvedKey)}`;
 
-    const [editmetaRes, transitionsRes, issueProjectRes] = await Promise.all([
+    const [editmetaRes, transitionsRes, issueProjectRes, linkTypesRes] = await Promise.all([
       fetch(`${base}/editmeta`, { headers }),
       fetch(`${base}/transitions`, { headers }),
       fetch(`${base}?fields=project`, { headers }),
+      fetch(`${jira_domain}/rest/api/3/issueLinkType`, { headers }),
     ]);
 
     if (!editmetaRes.ok) {
@@ -108,12 +109,26 @@ Deno.serve(async (req) => {
       toStatusName: t.to?.name != null ? String(t.to.name) : undefined,
     }));
 
+    // Issue link types — best-effort; not all Jira deployments have link types or expose them to all users.
+    let linkTypes: { id: string; name: string; inward: string; outward: string }[] = [];
+    if (linkTypesRes.ok) {
+      const linkTypesData = await linkTypesRes.json();
+      const list = Array.isArray(linkTypesData?.issueLinkTypes) ? linkTypesData.issueLinkTypes : [];
+      linkTypes = list.map((t: { id?: string | number; name?: string; inward?: string; outward?: string }) => ({
+        id: String(t.id ?? ''),
+        name: String(t.name ?? ''),
+        inward: String(t.inward ?? ''),
+        outward: String(t.outward ?? ''),
+      })).filter((t: { id: string; name: string }) => t.name && t.id);
+    }
+
     return new Response(
       JSON.stringify({
         issueKey: resolvedKey,
         priorities,
         issueTypes,
         transitions,
+        linkTypes,
       }),
       {
         headers: { ...corsHeaders, 'Content-Type': 'application/json' },

--- a/supabase/functions/manage-jira-issue-link/index.ts
+++ b/supabase/functions/manage-jira-issue-link/index.ts
@@ -1,0 +1,167 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { corsHeaders } from '../_shared/cors.ts';
+
+type CreateLinkBody = {
+  action: 'create';
+  teamId: string;
+  issueKey: string;
+  targetIssueKey: string;
+  linkTypeName: string;
+  /** outward = current issue is the "outward" side (e.g. current blocks target); inward = current is "inward" (e.g. current is blocked by target). */
+  direction: 'inward' | 'outward';
+};
+
+type DeleteLinkBody = {
+  action: 'delete';
+  teamId: string;
+  linkId: string;
+};
+
+type ManageLinkBody = CreateLinkBody | DeleteLinkBody;
+
+function makeResolveKey(jiraTicketPrefix: string | null | undefined): (k: string) => string {
+  return (k: string) => {
+    if (!k.includes('-') && jiraTicketPrefix) {
+      return `${jiraTicketPrefix}-${k}`;
+    }
+    return k;
+  };
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const body = (await req.json()) as Partial<ManageLinkBody>;
+    const action = body.action;
+    const teamId = body.teamId;
+
+    if (!teamId) {
+      throw new Error('Missing required parameter: teamId');
+    }
+    if (action !== 'create' && action !== 'delete') {
+      throw new Error("action must be 'create' or 'delete'");
+    }
+
+    const supabaseClient = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_ANON_KEY') ?? '',
+      { global: { headers: { Authorization: req.headers.get('Authorization')! } } },
+    );
+
+    const { data: authData, error: authError } = await supabaseClient.auth.getUser();
+    if (authError || !authData?.user) {
+      return new Response(
+        JSON.stringify({ error: 'You must be signed in to modify Jira issue links.' }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+      );
+    }
+
+    const { data: teamData, error: teamError } = await supabaseClient
+      .from('teams')
+      .select('jira_domain, jira_email, jira_api_key, jira_ticket_prefix')
+      .eq('id', teamId)
+      .single();
+
+    if (teamError) throw teamError;
+
+    const { jira_domain, jira_email, jira_api_key, jira_ticket_prefix } = teamData;
+
+    if (!jira_domain || !jira_email || !jira_api_key) {
+      return new Response(
+        JSON.stringify({ error: 'Jira is not fully configured for this team.' }),
+        { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 400 },
+      );
+    }
+
+    const auth = btoa(`${jira_email}:${jira_api_key}`);
+    const authHeader = `Basic ${auth}`;
+    const resolveKey = makeResolveKey(jira_ticket_prefix);
+
+    if (action === 'create') {
+      const create = body as CreateLinkBody;
+      if (!create.issueKey || !create.targetIssueKey || !create.linkTypeName) {
+        throw new Error('Missing required parameters: issueKey, targetIssueKey, linkTypeName');
+      }
+      if (create.direction !== 'inward' && create.direction !== 'outward') {
+        throw new Error("direction must be 'inward' or 'outward'");
+      }
+
+      const sourceKey = resolveKey(create.issueKey);
+      const targetKey = resolveKey(create.targetIssueKey);
+
+      if (sourceKey.toUpperCase() === targetKey.toUpperCase()) {
+        return new Response(
+          JSON.stringify({ error: 'Cannot link an issue to itself.' }),
+          { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 400 },
+        );
+      }
+
+      // Direction tells us which side of the relationship the current issue plays.
+      // outward: current issue is the "outward" side (e.g. "blocks" target → current blocks target)
+      // inward:  current issue is the "inward"  side (e.g. "is blocked by" target → current is blocked by target)
+      const outwardIssueKey = create.direction === 'outward' ? sourceKey : targetKey;
+      const inwardIssueKey = create.direction === 'outward' ? targetKey : sourceKey;
+
+      const payload = {
+        type: { name: create.linkTypeName },
+        inwardIssue: { key: inwardIssueKey },
+        outwardIssue: { key: outwardIssueKey },
+      };
+
+      const res = await fetch(`${jira_domain}/rest/api/3/issueLink`, {
+        method: 'POST',
+        headers: {
+          'Authorization': authHeader,
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        const errorBody = await res.text();
+        throw new Error(`Jira API error (${res.status}): ${errorBody}`);
+      }
+
+      return new Response(
+        JSON.stringify({ success: true }),
+        { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 200 },
+      );
+    }
+
+    // delete
+    const del = body as DeleteLinkBody;
+    if (!del.linkId) {
+      throw new Error('Missing required parameter: linkId');
+    }
+
+    const delRes = await fetch(
+      `${jira_domain}/rest/api/3/issueLink/${encodeURIComponent(String(del.linkId))}`,
+      {
+        method: 'DELETE',
+        headers: {
+          'Authorization': authHeader,
+          'Accept': 'application/json',
+        },
+      },
+    );
+
+    if (!delRes.ok) {
+      const errorBody = await delRes.text();
+      throw new Error(`Jira API error (${delRes.status}): ${errorBody}`);
+    }
+
+    return new Response(
+      JSON.stringify({ success: true }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 200 },
+    );
+  } catch (error) {
+    return new Response(
+      JSON.stringify({ error: error instanceof Error ? error.message : 'Unknown error' }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 400 },
+    );
+  }
+});


### PR DESCRIPTION
- Introduced the JiraIssueLinksSection component to manage linked work items within the JiraIssueDrawer.
- Enhanced the JiraIssueDrawer to support displaying and editing issue links, including fetching link types from Jira.
- Added normalization and utility functions for handling Jira issue links, improving data management and user interaction.
- Updated Supabase functions to support creating and deleting issue links, ensuring seamless integration with Jira's API.

These changes enhance the user experience by providing a comprehensive interface for managing linked issues in Jira.