### PR TITLE
Add react-intl-next dependency and implement Atlaskit editor common stubs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,7 @@
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.53.0",
+        "react-intl-next": "npm:react-intl@^5.25.1",
         "react-markdown": "^10.1.0",
         "react-resizable-panels": "^2.1.3",
         "react-router-dom": "^7.6.2",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.53.0",
+    "react-intl-next": "npm:react-intl@^5.25.1",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^2.1.3",
     "react-router-dom": "^7.6.2",

--- a/scripts/atlaskit-editor-common-stubs.mjs
+++ b/scripts/atlaskit-editor-common-stubs.mjs
@@ -1,0 +1,68 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const stubsDir = path.join(root, 'src/lib/atlaskit-stubs');
+
+/**
+ * Subpaths that newer Atlaskit editor plugins import but @atlaskit/editor-common
+ * does not publish as standalone entry points in npm (breaks Vite/Rollup on Lovable).
+ * Do not alias other stubs — real modules like `utils` and `analytics` exist and
+ * need nested imports (e.g. `@atlaskit/editor-common/utils/foo`).
+ */
+const MISSING_SUBPATH_STUB_FILES = {
+  'block-type': 'editor-common-block-type.ts',
+};
+
+const NODE_SELECTION_STUB = 'editor-common-node-selection.ts';
+
+function editorCommonSubpathExists(subpath) {
+  const indexPath = path.join(
+    root,
+    'node_modules/@atlaskit/editor-common/dist/esm',
+    subpath,
+    'index.js',
+  );
+  const flatPath = path.join(
+    root,
+    'node_modules/@atlaskit/editor-common/dist/esm',
+    `${subpath}.js`,
+  );
+  return fs.existsSync(indexPath) || fs.existsSync(flatPath);
+}
+
+/** @returns {Map<string, string>} import id → absolute stub file path */
+export function loadAtlaskitEditorCommonStubAliases() {
+  const aliases = new Map();
+  for (const [subpath, file] of Object.entries(MISSING_SUBPATH_STUB_FILES)) {
+    const filePath = path.join(stubsDir, file);
+    if (fs.existsSync(filePath)) {
+      aliases.set(`@atlaskit/editor-common/${subpath}`, filePath);
+    }
+  }
+  if (!editorCommonSubpathExists('node-selection')) {
+    const filePath = path.join(stubsDir, NODE_SELECTION_STUB);
+    if (fs.existsSync(filePath)) {
+      aliases.set('@atlaskit/editor-common/node-selection', filePath);
+    }
+  }
+  return aliases;
+}
+
+/** Vite plugin: resolve missing @atlaskit/editor-common/* subpaths (Lovable/bun uses newer editor plugins). */
+export function atlaskitEditorCommonStubsPlugin() {
+  const aliases = loadAtlaskitEditorCommonStubAliases();
+  return {
+    name: 'atlaskit-editor-common-stubs',
+    enforce: 'pre',
+    resolveId(source) {
+      return aliases.get(source) ?? null;
+    },
+  };
+}
+
+/** Plain object for vite resolve.alias */
+export function atlaskitEditorCommonStubAliasObject() {
+  return Object.fromEntries(loadAtlaskitEditorCommonStubAliases());
+}

--- a/src/lib/atlaskit-stubs/editor-common-node-selection.ts
+++ b/src/lib/atlaskit-stubs/editor-common-node-selection.ts
@@ -1,5 +1,34 @@
-// Stub for @atlaskit/editor-common/node-selection (not present in installed version).
-// editor-plugin-block-controls expects selectNodeAtPos; provide a safe no-op.
-export function selectNodeAtPos(tr: any, _pos: number) {
+// Stub for @atlaskit/editor-common/node-selection when the subpath is absent from the installed package.
+import { NodeSelection } from '@atlaskit/editor-prosemirror/state';
+import { selectTableClosestToPos } from '@atlaskit/editor-tables/utils';
+
+export function getNodeSelectionForPos(doc: { nodeAt: (pos: number) => { type: { name: string }; childCount: number } | null; resolve: (pos: number) => unknown }, start: number) {
+  const node = doc.nodeAt(start);
+  if (!node) {
+    return false;
+  }
+  if (node.type.name === 'mediaGroup' && node.childCount === 1) {
+    return new NodeSelection(doc.resolve(start + 1) as ConstructorParameters<typeof NodeSelection>[0]);
+  }
+  return new NodeSelection(doc.resolve(start) as ConstructorParameters<typeof NodeSelection>[0]);
+}
+
+export function selectTableNodeAtPos(tr: { doc: { resolve: (pos: number) => unknown } }, tableNodePos: number) {
+  selectTableClosestToPos(tr as Parameters<typeof selectTableClosestToPos>[0], tr.doc.resolve(tableNodePos + 1) as Parameters<typeof selectTableClosestToPos>[1]);
+  return tr;
+}
+
+export function selectNodeAtPos(
+  tr: { doc: Parameters<typeof getNodeSelectionForPos>[0]; setSelection: (sel: NodeSelection) => void },
+  nodePos: number,
+  nodeType?: string,
+) {
+  if (nodeType === 'table') {
+    return selectTableNodeAtPos(tr, nodePos);
+  }
+  const selection = getNodeSelectionForPos(tr.doc, nodePos);
+  if (selection) {
+    tr.setSelection(selection);
+  }
   return tr;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,10 @@ import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import { componentTagger } from "lovable-tagger";
+import {
+  atlaskitEditorCommonStubAliasObject,
+  atlaskitEditorCommonStubsPlugin,
+} from "./scripts/atlaskit-editor-common-stubs.mjs";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode, command }) => {
@@ -20,6 +24,7 @@ export default defineConfig(({ mode, command }) => {
     // Avoid inlineDynamicImports: one giant chunk made @atlaskit/editor-core hit TDZ errors
     // in production ("Cannot access '…' before initialization") due to circular ESM + minify.
     plugins: [
+      atlaskitEditorCommonStubsPlugin(),
       react(),
       mode === 'development' &&
       componentTagger(),
@@ -27,8 +32,9 @@ export default defineConfig(({ mode, command }) => {
     resolve: {
       alias: {
         "@": path.resolve(__dirname, "./src"),
-        "@atlaskit/editor-common/node-selection": path.resolve(__dirname, "./src/lib/atlaskit-stubs/editor-common-node-selection.ts"),
-        "@atlaskit/editor-common/block-type": path.resolve(__dirname, "./src/lib/atlaskit-stubs/editor-common-block-type.ts"),
+        // Atlaskit packages import `react-intl`; app uses the react-intl-next npm alias package.
+        "react-intl": path.resolve(__dirname, "./node_modules/react-intl-next"),
+        ...atlaskitEditorCommonStubAliasObject(),
       },
       dedupe: [
         "react-intl-next",


### PR DESCRIPTION
- Added `react-intl-next` as a dependency in `package.json` and `package-lock.json`.
- Introduced a new script for handling missing subpath stubs for Atlaskit editor common.
- Updated Vite configuration to use the new stubs plugin and alias for `react-intl`.
- Enhanced the node-selection stub to support additional functionality for table nodes.