### PR TITLE
Fix retro board link wrapping and add markdown link labels (DUN-58)

### DIFF
--- a/src/components/RetroItemComments.tsx
+++ b/src/components/RetroItemComments.tsx
@@ -4,8 +4,10 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { MessageSquare, Send, Trash2 } from 'lucide-react';
 import { UserAvatar } from '@/components/ui/UserAvatar';
-import { TiptapEditorWithMentions, processMentionsForDisplay } from '@/components/shared/TiptapEditorWithMentions';
+import { TiptapEditorWithMentions, processRichTextForDisplay } from '@/components/shared/TiptapEditorWithMentions';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { RICH_TEXT_DISPLAY_CLASS } from '@/lib/richTextDisplay';
+import { cn } from '@/lib/utils';
 
 interface RetroComment {
   id: string;
@@ -153,8 +155,8 @@ export const RetroItemComments: React.FC<RetroItemCommentsProps> = ({
                       )}
                     </div>
                     <div
-                      className="text-sm text-gray-700 dark:text-gray-300 prose dark:prose-invert max-w-none"
-                      dangerouslySetInnerHTML={{ __html: processMentionsForDisplay(makeImagesClickable(comment.text)) }}
+                      className={cn('text-sm text-gray-700 dark:text-gray-300 prose dark:prose-invert max-w-none', RICH_TEXT_DISPLAY_CLASS)}
+                      dangerouslySetInnerHTML={{ __html: processRichTextForDisplay(makeImagesClickable(comment.text)) }}
                       onClick={handleImageClick}
                     />
                   </div>

--- a/src/components/retro/FocusedCardBanner.tsx
+++ b/src/components/retro/FocusedCardBanner.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { X, Crosshair, ChevronLeft, ChevronRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { processMentionsForDisplay } from '../shared/TiptapEditorWithMentions';
+import { processRichTextForDisplay } from '../shared/TiptapEditorWithMentions';
 import { RetroItemComments } from '../RetroItemComments';
+import { RICH_TEXT_DISPLAY_CLASS } from '@/lib/richTextDisplay';
+import { cn } from '@/lib/utils';
 
 interface RetroComment {
   id: string;
@@ -163,8 +165,8 @@ export const FocusedCardBanner: React.FC<FocusedCardBannerProps> = ({
               </span>
             </div>
             <div
-              className="text-sm text-foreground prose dark:prose-invert max-w-none"
-              dangerouslySetInnerHTML={{ __html: processMentionsForDisplay(itemText) }}
+              className={cn('text-sm text-foreground prose dark:prose-invert max-w-none', RICH_TEXT_DISPLAY_CLASS)}
+              dangerouslySetInnerHTML={{ __html: processRichTextForDisplay(itemText) }}
             />
             {/* Comments section */}
             {onAddComment && onDeleteComment && (

--- a/src/components/retro/PreviousActionItemsColumn.tsx
+++ b/src/components/retro/PreviousActionItemsColumn.tsx
@@ -11,8 +11,10 @@ interface PreviousActionItemsColumnProps {
   teamMembers?: { user_id: string; profiles?: { full_name: string | null } | null }[];
   teamId?: string | null;
 }
-import { processMentionsForDisplay } from '@/components/shared/TiptapEditorWithMentions';
+import { processRichTextForDisplay } from '@/components/shared/TiptapEditorWithMentions';
 import { TeamActionItemsComments } from '@/components/team/TeamActionItemsComments';
+import { RICH_TEXT_DISPLAY_CLASS } from '@/lib/richTextDisplay';
+import { cn } from '@/lib/utils';
 
 export const PreviousActionItemsColumn: React.FC<PreviousActionItemsColumnProps> = ({ items, onMarkDone, onAssign, isArchived, teamMembers = [], teamId }) => {
   return (
@@ -30,11 +32,11 @@ export const PreviousActionItemsColumn: React.FC<PreviousActionItemsColumnProps>
             <div className="text-sm text-gray-500 dark:text-gray-400">No open action items from previous retros.</div>
           )}
           {items.map(item => (
-            <Card key={item.id} className="bg-white/90 dark:bg-gray-700/90 backdrop-blur-sm">
-              <CardContent className="p-4">
+            <Card key={item.id} className="bg-white/90 dark:bg-gray-700/90 backdrop-blur-sm overflow-hidden">
+              <CardContent className="p-4 min-w-0">
                 <div
-                  className="text-gray-800 dark:text-gray-200 prose dark:prose-invert max-w-none mb-3"
-                  dangerouslySetInnerHTML={{ __html: processMentionsForDisplay(item.text) }}
+                  className={cn('text-gray-800 dark:text-gray-200 prose dark:prose-invert max-w-none mb-3', RICH_TEXT_DISPLAY_CLASS)}
+                  dangerouslySetInnerHTML={{ __html: processRichTextForDisplay(item.text) }}
                 />
                 <div className="flex items-center justify-between gap-2">
                   <div className="text-xs text-gray-600 dark:text-gray-300 flex items-center gap-2">

--- a/src/components/retro/RetroColumn.tsx
+++ b/src/components/retro/RetroColumn.tsx
@@ -14,8 +14,10 @@ import { useFeatureFlags } from '@/contexts/FeatureFlagContext';
 
 import { AudioSummaryState, RetroStage } from '@/hooks/useRetroBoard';
 import { SummaryButton } from './SummaryButton';
-import { TiptapEditorWithMentions, processMentionsForDisplay } from '../shared/TiptapEditorWithMentions';
+import { TiptapEditorWithMentions, processRichTextForDisplay } from '../shared/TiptapEditorWithMentions';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { RICH_TEXT_DISPLAY_CLASS } from '@/lib/richTextDisplay';
+import { cn } from '@/lib/utils';
 
 interface RetroItem {
   id: string;
@@ -421,8 +423,8 @@ export const RetroColumn: React.FC<RetroColumnProps> = ({
           )}
 
           {sortedItems.map(item => (
-            <Card key={item.id} className={`bg-white/90 dark:bg-gray-700/90 backdrop-blur-sm hover:shadow-md transition-shadow ${focusedItemId === item.id ? 'ring-2 ring-amber-400 dark:ring-amber-500' : ''}`}>
-              <CardContent className={`p-4 ${isActionItemsColumn(column) && (actionStatusMap?.[item.id]?.done ?? false) ? 'opacity-60' : ''}`}>
+            <Card key={item.id} className={`bg-white/90 dark:bg-gray-700/90 backdrop-blur-sm hover:shadow-md transition-shadow overflow-hidden ${focusedItemId === item.id ? 'ring-2 ring-amber-400 dark:ring-amber-500' : ''}`}>
+              <CardContent className={`p-4 min-w-0 ${isActionItemsColumn(column) && (actionStatusMap?.[item.id]?.done ?? false) ? 'opacity-60' : ''}`}>
                 {editingItem === item.id ? (
                   <div className="space-y-2">
                     <TiptapEditorWithMentions
@@ -441,8 +443,8 @@ export const RetroColumn: React.FC<RetroColumnProps> = ({
                 ) : (
                   <>
                     <div
-                      className="text-gray-800 dark:text-gray-200 mb-3 prose dark:prose-invert max-w-none"
-                      dangerouslySetInnerHTML={{ __html: processMentionsForDisplay(makeImagesClickable(item.text)) }}
+                      className={cn('text-gray-800 dark:text-gray-200 mb-3 prose dark:prose-invert max-w-none', RICH_TEXT_DISPLAY_CLASS)}
+                      dangerouslySetInnerHTML={{ __html: processRichTextForDisplay(makeImagesClickable(item.text)) }}
                       onClick={handleImageClick}
                     />
 

--- a/src/components/shared/TiptapEditor.tsx
+++ b/src/components/shared/TiptapEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect } from 'react';
 import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import Image from '@tiptap/extension-image';
@@ -22,8 +22,6 @@ export const TiptapEditor: React.FC<TiptapEditorProps> = ({
   placeholder,
   uploadImage,
 }) => {
-  const editorRef = useRef<ReturnType<typeof useEditor>>(null);
-
   const editor = useEditor({
     extensions: [
       StarterKit.configure({
@@ -80,11 +78,7 @@ export const TiptapEditor: React.FC<TiptapEditorProps> = ({
           return true;
         }
 
-        if (
-          tryPasteMarkdownLinks(event, (html) => {
-            editorRef.current?.commands.insertContent(html);
-          })
-        ) {
+        if (tryPasteMarkdownLinks(view, event)) {
           return true;
         }
 
@@ -92,10 +86,6 @@ export const TiptapEditor: React.FC<TiptapEditorProps> = ({
       },
     },
   });
-
-  useEffect(() => {
-    editorRef.current = editor;
-  }, [editor]);
 
   useEffect(() => {
     if (editor && !editor.isDestroyed && editor.getHTML() !== content) {

--- a/src/components/shared/TiptapEditor.tsx
+++ b/src/components/shared/TiptapEditor.tsx
@@ -1,10 +1,11 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
-import Link from '@tiptap/extension-link';
 import Image from '@tiptap/extension-image';
 import Placeholder from '@tiptap/extension-placeholder';
 import type { UploadImageFn } from '@/hooks/usePokerSessionChat';
+import { RICH_TEXT_EDITOR_CLASS } from '@/lib/richTextDisplay';
+import { MarkdownLink, tryPasteMarkdownLinks } from '@/lib/tiptapMarkdownLink';
 
 interface TiptapEditorProps {
   content: string;
@@ -21,6 +22,8 @@ export const TiptapEditor: React.FC<TiptapEditorProps> = ({
   placeholder,
   uploadImage,
 }) => {
+  const editorRef = useRef<ReturnType<typeof useEditor>>(null);
+
   const editor = useEditor({
     extensions: [
       StarterKit.configure({
@@ -31,12 +34,7 @@ export const TiptapEditor: React.FC<TiptapEditorProps> = ({
         blockquote: false,
         horizontalRule: false,
       }),
-      Link.configure({
-        openOnClick: true,
-        autolink: true,
-        linkOnPaste: true,
-        validate: href => /^https?:\/\//.test(href),
-      }),
+      MarkdownLink,
       Image.configure({
         inline: true,
         allowBase64: false,
@@ -51,7 +49,7 @@ export const TiptapEditor: React.FC<TiptapEditorProps> = ({
     },
     editorProps: {
       attributes: {
-        class: 'prose dark:prose-invert min-w-full max-w-full focus:outline-none p-2 rounded-md border border-input min-h-[40px] max-h-[120px] overflow-y-auto text-sm',
+        class: RICH_TEXT_EDITOR_CLASS,
       },
       handleKeyDown: (view, event) => {
         if (event.key === 'Enter' && !event.shiftKey) {
@@ -81,10 +79,23 @@ export const TiptapEditor: React.FC<TiptapEditorProps> = ({
           });
           return true;
         }
+
+        if (
+          tryPasteMarkdownLinks(event, (html) => {
+            editorRef.current?.commands.insertContent(html);
+          })
+        ) {
+          return true;
+        }
+
         return false;
       },
     },
   });
+
+  useEffect(() => {
+    editorRef.current = editor;
+  }, [editor]);
 
   useEffect(() => {
     if (editor && !editor.isDestroyed && editor.getHTML() !== content) {
@@ -93,4 +104,4 @@ export const TiptapEditor: React.FC<TiptapEditorProps> = ({
   }, [content, editor]);
 
   return <EditorContent editor={editor} />;
-}; 
+};

--- a/src/components/shared/TiptapEditorWithMentions.tsx
+++ b/src/components/shared/TiptapEditorWithMentions.tsx
@@ -3,11 +3,12 @@ import { createPortal } from 'react-dom';
 import { useEditor, EditorContent } from '@tiptap/react';
 import { Node, mergeAttributes } from '@tiptap/core';
 import StarterKit from '@tiptap/starter-kit';
-import Link from '@tiptap/extension-link';
 import Image from '@tiptap/extension-image';
 import Placeholder from '@tiptap/extension-placeholder';
 import { MentionSuggestions, MentionSuggestionsRef } from './MentionSuggestions';
 import type { UploadImageFn } from '@/hooks/usePokerSessionChat';
+import { convertMarkdownLinksToHtml, RICH_TEXT_EDITOR_CLASS } from '@/lib/richTextDisplay';
+import { MarkdownLink, tryPasteMarkdownLinks } from '@/lib/tiptapMarkdownLink';
 
 interface TeamMember {
     id: string;
@@ -105,6 +106,11 @@ export const processMentionsForDisplay = (htmlContent: string): string => {
     );
 };
 
+/** Mentions + markdown `[label](url)` friendly links for card/comment display. */
+export const processRichTextForDisplay = (htmlContent: string): string => {
+    return processMentionsForDisplay(convertMarkdownLinksToHtml(htmlContent));
+};
+
 // Function to extract mentions from content for searching/filtering
 export const extractMentions = (htmlContent: string): Array<{ userId: string; name: string }> => {
     const mentions: Array<{ userId: string; name: string }> = [];
@@ -165,12 +171,7 @@ export const TiptapEditorWithMentions: React.FC<TiptapEditorWithMentionsProps> =
                 blockquote: false,
                 horizontalRule: false,
             }),
-            Link.configure({
-                openOnClick: true,
-                autolink: true,
-                linkOnPaste: true,
-                validate: href => /^https?:\/\//.test(href),
-            }),
+            MarkdownLink,
             Image.configure({
                 inline: true,
                 allowBase64: false,
@@ -237,7 +238,7 @@ export const TiptapEditorWithMentions: React.FC<TiptapEditorWithMentionsProps> =
         },
         editorProps: {
             attributes: {
-                class: 'prose dark:prose-invert min-w-full max-w-full focus:outline-none p-2 rounded-md border border-input min-h-[40px] max-h-[120px] overflow-y-auto text-sm',
+                class: RICH_TEXT_EDITOR_CLASS,
             },
             handleKeyDown: (view, event) => {
                 // Handle mention suggestions navigation
@@ -285,6 +286,15 @@ export const TiptapEditorWithMentions: React.FC<TiptapEditorWithMentionsProps> =
                     });
                     return true;
                 }
+
+                if (
+                    tryPasteMarkdownLinks(event, (html) => {
+                        editorRef.current?.commands.insertContent(html);
+                    })
+                ) {
+                    return true;
+                }
+
                 return false;
             },
         },

--- a/src/components/shared/TiptapEditorWithMentions.tsx
+++ b/src/components/shared/TiptapEditorWithMentions.tsx
@@ -287,11 +287,7 @@ export const TiptapEditorWithMentions: React.FC<TiptapEditorWithMentionsProps> =
                     return true;
                 }
 
-                if (
-                    tryPasteMarkdownLinks(event, (html) => {
-                        editorRef.current?.commands.insertContent(html);
-                    })
-                ) {
+                if (tryPasteMarkdownLinks(view, event)) {
                     return true;
                 }
 

--- a/src/lib/richTextDisplay.test.ts
+++ b/src/lib/richTextDisplay.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import {
+  convertMarkdownLinksToHtml,
+  decodeHtmlEntities,
+  escapeHtml,
+  parseSingleMarkdownLink,
+  plainTextContainsMarkdownLink,
+  plainTextWithMarkdownLinksToHtml,
+} from './richTextDisplay';
+
+describe('escapeHtml', () => {
+  it('escapes HTML special characters', () => {
+    expect(escapeHtml(`<script>"x"&'y'</script>`)).toBe(
+      '&lt;script&gt;&quot;x&quot;&amp;&#39;y&#39;&lt;/script&gt;'
+    );
+  });
+});
+
+describe('decodeHtmlEntities', () => {
+  it('decodes common entities without corrupting sequences', () => {
+    expect(decodeHtmlEntities('a &amp; b &lt;c&gt; &quot;d&quot;')).toBe('a & b <c> "d"');
+    expect(decodeHtmlEntities('&amp;lt;')).toBe('&lt;');
+  });
+});
+
+describe('parseSingleMarkdownLink', () => {
+  it('parses a full-string markdown link', () => {
+    expect(parseSingleMarkdownLink('[Sprint Report](https://example.com/path?x=1)')).toEqual({
+      label: 'Sprint Report',
+      href: 'https://example.com/path?x=1',
+    });
+  });
+
+  it('rejects non-http schemes and partial matches', () => {
+    expect(parseSingleMarkdownLink('[x](javascript:alert(1))')).toBeNull();
+    expect(parseSingleMarkdownLink('see [x](https://example.com) please')).toBeNull();
+  });
+});
+
+describe('convertMarkdownLinksToHtml', () => {
+  it('converts markdown links inside HTML text nodes', () => {
+    const input =
+      '<p>Sprint Report: [Board](https://outsystemsrd.atlassian.net/jira/software/c/projects/RNMT/retrospective?sprint=30031)</p>';
+    const output = convertMarkdownLinksToHtml(input);
+    expect(output).toContain(
+      '<a href="https://outsystemsrd.atlassian.net/jira/software/c/projects/RNMT/retrospective?sprint=30031"'
+    );
+    expect(output).toContain('>Board</a>');
+    expect(output).toContain('target="_blank"');
+    expect(output).toContain('rel="noopener noreferrer nofollow"');
+    expect(output).not.toContain('[Board]');
+  });
+
+  it('does not double-encode entities already present in TipTap HTML', () => {
+    const input = '<p>[click &amp; me](https://example.com?a=1&amp;b=2)</p>';
+    const output = convertMarkdownLinksToHtml(input);
+    expect(output).toContain('>click &amp; me</a>');
+    expect(output).toContain('href="https://example.com?a=1&amp;b=2"');
+    expect(output).not.toContain('&amp;amp;');
+  });
+
+  it('neutralizes quote breakouts in URLs', () => {
+    const input = '<p>[x](https://example.com/"onclick="evil)</p>';
+    const output = convertMarkdownLinksToHtml(input);
+    expect(output).toContain('href="https://example.com/&quot;onclick=&quot;evil"');
+    expect(output).not.toMatch(/\sonclick=/i);
+  });
+
+  it('does not rewrite existing anchor tags', () => {
+    const input = '<a href="https://example.com">plain</a>';
+    expect(convertMarkdownLinksToHtml(input)).toBe(input);
+  });
+
+  it('leaves bare long URLs unchanged (wrapping is CSS)', () => {
+    const url =
+      'https://outsystemsrd.atlassian.net/jira/software/c/projects/RNMT/retrospective?sprint=30031';
+    const input = `<p><a href="${url}">${url}</a></p>`;
+    expect(convertMarkdownLinksToHtml(input)).toBe(input);
+  });
+});
+
+describe('plainTextWithMarkdownLinksToHtml', () => {
+  it('returns empty when no markdown links are present', () => {
+    expect(plainTextWithMarkdownLinksToHtml('just text https://example.com')).toBe('');
+  });
+
+  it('converts inline markdown links and escapes surrounding text', () => {
+    const html = plainTextWithMarkdownLinksToHtml('See [Docs](https://example.com) <script>');
+    expect(html).toContain('<a href="https://example.com"');
+    expect(html).toContain('>Docs</a>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+});
+
+describe('plainTextContainsMarkdownLink', () => {
+  it('detects markdown links', () => {
+    expect(plainTextContainsMarkdownLink('[x](https://a.com)')).toBe(true);
+    expect(plainTextContainsMarkdownLink('https://a.com')).toBe(false);
+  });
+});

--- a/src/lib/richTextDisplay.ts
+++ b/src/lib/richTextDisplay.ts
@@ -1,0 +1,111 @@
+/** CSS classes so long URLs/text wrap inside retro card containers. */
+export const RICH_TEXT_DISPLAY_CLASS =
+  'break-words [overflow-wrap:anywhere] [&_a]:break-all';
+
+/** CSS classes for TipTap editors so long links wrap while editing. */
+export const RICH_TEXT_EDITOR_CLASS =
+  'prose dark:prose-invert min-w-full max-w-full focus:outline-none p-2 rounded-md border border-input min-h-[40px] max-h-[120px] overflow-y-auto text-sm break-words [overflow-wrap:anywhere] [&_a]:break-all';
+
+const MARKDOWN_LINK_RE = /\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/g;
+
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/** Decode common entities found in TipTap HTML text nodes before re-escaping. */
+export function decodeHtmlEntities(text: string): string {
+  return text
+    .replace(/&quot;/g, '"')
+    .replace(/&#0*39;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&');
+}
+
+function isSafeHttpUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function markdownLinkToAnchor(labelRaw: string, urlRaw: string): string {
+  const label = decodeHtmlEntities(labelRaw);
+  const url = decodeHtmlEntities(urlRaw);
+  if (!isSafeHttpUrl(url)) {
+    return `[${escapeHtml(label)}](${escapeHtml(url)})`;
+  }
+  return `<a href="${escapeHtml(url)}" target="_blank" rel="noopener noreferrer nofollow">${escapeHtml(label)}</a>`;
+}
+
+/** Parse a single markdown link that is the entire string. */
+export function parseSingleMarkdownLink(
+  text: string
+): { label: string; href: string } | null {
+  const trimmed = text.trim();
+  const match = /^\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)$/.exec(trimmed);
+  if (!match) return null;
+  const href = match[2];
+  if (!isSafeHttpUrl(href)) return null;
+  return { label: match[1], href };
+}
+
+/**
+ * Convert markdown links `[label](https://url)` in HTML text nodes to anchors.
+ * Only http(s) URLs are accepted; labels/URLs are safely escaped for HTML.
+ */
+export function convertMarkdownLinksToHtml(html: string): string {
+  if (!html) return html;
+
+  return html.replace(/(<[^>]+>)|([^<]+)/g, (match, tag: string | undefined, text: string | undefined) => {
+    if (tag) return tag;
+    if (!text) return match;
+
+    return text.replace(MARKDOWN_LINK_RE, (_full, label: string, url: string) => {
+      return markdownLinkToAnchor(label, url);
+    });
+  });
+}
+
+/**
+ * Convert markdown links in plain text to HTML suitable for TipTap insertContent.
+ * Escapes non-link text so pasted content cannot inject HTML.
+ * Returns empty string when no markdown links are present.
+ */
+export function plainTextWithMarkdownLinksToHtml(text: string): string {
+  const parts: string[] = [];
+  let lastIndex = 0;
+  const re = new RegExp(MARKDOWN_LINK_RE.source, 'g');
+  let match: RegExpExecArray | null;
+  let found = false;
+
+  while ((match = re.exec(text)) !== null) {
+    found = true;
+    if (match.index > lastIndex) {
+      parts.push(escapeHtml(text.slice(lastIndex, match.index)).replace(/\n/g, '<br>'));
+    }
+    parts.push(markdownLinkToAnchor(match[1], match[2]));
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (!found) {
+    return '';
+  }
+
+  if (lastIndex < text.length) {
+    parts.push(escapeHtml(text.slice(lastIndex)).replace(/\n/g, '<br>'));
+  }
+
+  return parts.join('');
+}
+
+export function plainTextContainsMarkdownLink(text: string): boolean {
+  return new RegExp(MARKDOWN_LINK_RE.source).test(text);
+}

--- a/src/lib/tiptapMarkdownLink.ts
+++ b/src/lib/tiptapMarkdownLink.ts
@@ -1,4 +1,6 @@
 import { InputRule } from '@tiptap/core';
+import { DOMParser as ProseMirrorDOMParser } from '@tiptap/pm/model';
+import type { EditorView } from '@tiptap/pm/view';
 import Link from '@tiptap/extension-link';
 import {
   escapeHtml,
@@ -53,14 +55,18 @@ export const MarkdownLink = Link.extend({
   },
 });
 
+function insertHtmlAtSelection(view: EditorView, html: string) {
+  const element = document.createElement('div');
+  element.innerHTML = html;
+  const slice = ProseMirrorDOMParser.fromSchema(view.state.schema).parseSlice(element);
+  view.dispatch(view.state.tr.replaceSelection(slice));
+}
+
 /**
  * If clipboard plain text contains markdown links, insert them as TipTap links.
  * Returns true when handled (caller should skip default paste).
  */
-export function tryPasteMarkdownLinks(
-  event: ClipboardEvent,
-  insertHtml: (html: string) => void
-): boolean {
+export function tryPasteMarkdownLinks(view: EditorView, event: ClipboardEvent): boolean {
   const text = event.clipboardData?.getData('text/plain');
   if (!text || !plainTextContainsMarkdownLink(text)) {
     return false;
@@ -69,7 +75,8 @@ export function tryPasteMarkdownLinks(
   const single = parseSingleMarkdownLink(text);
   if (single) {
     event.preventDefault();
-    insertHtml(
+    insertHtmlAtSelection(
+      view,
       `<a href="${escapeHtml(single.href)}" target="_blank" rel="noopener noreferrer nofollow">${escapeHtml(single.label)}</a>`
     );
     return true;
@@ -79,6 +86,6 @@ export function tryPasteMarkdownLinks(
   if (!html) return false;
 
   event.preventDefault();
-  insertHtml(html);
+  insertHtmlAtSelection(view, html);
   return true;
 }

--- a/src/lib/tiptapMarkdownLink.ts
+++ b/src/lib/tiptapMarkdownLink.ts
@@ -1,0 +1,84 @@
+import { InputRule } from '@tiptap/core';
+import Link from '@tiptap/extension-link';
+import {
+  escapeHtml,
+  parseSingleMarkdownLink,
+  plainTextContainsMarkdownLink,
+  plainTextWithMarkdownLinksToHtml,
+} from '@/lib/richTextDisplay';
+
+/** TipTap Link with markdown `[label](url)` input rule and wrap-friendly attrs. */
+export const MarkdownLink = Link.extend({
+  addInputRules() {
+    return [
+      ...(this.parent?.() ?? []),
+      new InputRule({
+        find: /\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)$/,
+        handler: ({ chain, range, match }) => {
+          const label = match[1];
+          const href = match[2];
+          if (!label || !href) return;
+
+          chain()
+            .focus()
+            .deleteRange(range)
+            .insertContent({
+              type: 'text',
+              text: label,
+              marks: [
+                {
+                  type: this.name,
+                  attrs: {
+                    href,
+                    target: '_blank',
+                    rel: 'noopener noreferrer nofollow',
+                  },
+                },
+              ],
+            })
+            .run();
+        },
+      }),
+    ];
+  },
+}).configure({
+  openOnClick: true,
+  autolink: true,
+  linkOnPaste: true,
+  validate: (href) => /^https?:\/\//.test(href),
+  HTMLAttributes: {
+    class: 'break-all',
+    target: '_blank',
+    rel: 'noopener noreferrer nofollow',
+  },
+});
+
+/**
+ * If clipboard plain text contains markdown links, insert them as TipTap links.
+ * Returns true when handled (caller should skip default paste).
+ */
+export function tryPasteMarkdownLinks(
+  event: ClipboardEvent,
+  insertHtml: (html: string) => void
+): boolean {
+  const text = event.clipboardData?.getData('text/plain');
+  if (!text || !plainTextContainsMarkdownLink(text)) {
+    return false;
+  }
+
+  const single = parseSingleMarkdownLink(text);
+  if (single) {
+    event.preventDefault();
+    insertHtml(
+      `<a href="${escapeHtml(single.href)}" target="_blank" rel="noopener noreferrer nofollow">${escapeHtml(single.label)}</a>`
+    );
+    return true;
+  }
+
+  const html = plainTextWithMarkdownLinksToHtml(text);
+  if (!html) return false;
+
+  event.preventDefault();
+  insertHtml(html);
+  return true;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes [DUN-58](https://linear.app): long links on the retro board overrun card width, and friendly markdown link labels were not supported.

- Prevent long URLs/text from overflowing retro cards by applying overflow-wrap styles on card/comment display and TipTap editors.
- Add markdown `[Friendly Name](https://url)` support: converted safely on display, plus TipTap input-rule and paste handling so friendly labels become real links while editing.

### Demo
![Link wrap and markdown friendly name demo](https://cursor.com/artifacts/c/art-63ae612c-4c44-4367-aae9-21437f6bb1ca)

## Test plan
- [x] `npx vitest run src/lib/richTextDisplay.test.ts`
- [x] Visual CSS fixture confirms long URLs wrap and markdown labels render
- [ ] Paste a long bare URL into a retro card and confirm it wraps within the card width
- [ ] Type or paste `[Sprint Report](https://example.com/very/long/path)` and confirm the card shows a clickable “Sprint Report” label
- [ ] Confirm mentions and images in cards/comments still render correctly
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-58](https://linear.app/dungeon-dwellers/issue/DUN-58/links-in-retro-board-should-be-wrapped)

<div><a href="https://cursor.com/agents/bc-a1c1471b-064c-41df-be25-c3b917af6463?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1c1471b-064c-41df-be25-c3b917af6463&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

