### PR TITLE
feat(poker): enable changing ticket order in round selector (DUN-60)

### DIFF
--- a/src/components/Neotro/PokerTableComponent/DesktopView.tsx
+++ b/src/components/Neotro/PokerTableComponent/DesktopView.tsx
@@ -33,6 +33,7 @@ import { RoundSelector } from '@/components/Neotro/RoundSelector';
 import { PlayingFieldRoundSlide } from '@/components/Neotro/PlayingFieldRoundSlide';
 import type { PokerSessionRound } from '@/hooks/usePokerSessionHistory';
 import { displayTicketLabel, isSyntheticRoundTicket } from '@/lib/pokerRoundTicketPlaceholder';
+import { compareRoundsBySortOrder } from '@/lib/pokerRoundSortOrder';
 
 function QueuePanelCard({
   teamId,
@@ -204,7 +205,7 @@ export const DesktopView: React.FC = () => {
     } = usePokerTable();
 
     const activeRoundsSorted = useMemo(
-        () => rounds.filter((r) => r.is_active).slice().sort((a, b) => a.round_number - b.round_number),
+        () => rounds.filter((r) => r.is_active).slice().sort(compareRoundsBySortOrder),
         [rounds]
     );
 

--- a/src/components/Neotro/PokerTableComponent/MobileView.tsx
+++ b/src/components/Neotro/PokerTableComponent/MobileView.tsx
@@ -26,6 +26,7 @@ import { useSwipeNavigation } from '@/hooks/use-swipe-navigation';
 import { DragToPlayProvider, DropZoneOverlay } from '@/components/Neotro/DragToPlay';
 import { useJiraTicketMetadata } from '@/hooks/use-jira-ticket-metadata';
 import { displayTicketLabel, isSyntheticRoundTicket } from '@/lib/pokerRoundTicketPlaceholder';
+import { compareRoundsBySortOrder } from '@/lib/pokerRoundSortOrder';
 
 const getGridColumns = (playerCount: number) => {
     if (playerCount <= 2) return 'grid-cols-2';
@@ -103,7 +104,7 @@ export const MobileView: React.FC = () => {
     const { height } = useWindowSize();
 
     const activeRoundsSorted = useMemo(
-        () => rounds.filter((r) => r.is_active).slice().sort((a, b) => a.round_number - b.round_number),
+        () => rounds.filter((r) => r.is_active).slice().sort(compareRoundsBySortOrder),
         [rounds]
     );
 

--- a/src/components/Neotro/PokerTableComponent/context.tsx
+++ b/src/components/Neotro/PokerTableComponent/context.tsx
@@ -37,6 +37,7 @@ import { isSyntheticRoundTicket, roundTicketPlaceholder } from '@/lib/pokerRound
 import { usePokerSpotlightClientId } from '@/hooks/use-poker-spotlight-client-id';
 import { deriveDisplayGameState } from '@/lib/pokerRoundDisplayGameState';
 import { POKER_DECK_POINT_VALUES } from '@/lib/pokerPointDeck';
+import { compareRoundsBySortOrder } from '@/lib/pokerRoundSortOrder';
 
 interface PokerTableContextProps {
   session: PokerSessionState | null;
@@ -94,6 +95,8 @@ interface PokerTableContextProps {
   goToCurrentRound: () => void;
   goToRound: (roundNumber: number) => void;
   deleteRound: (roundId: string, options?: { suppressToast?: boolean }) => Promise<boolean>;
+  /** Persist a new display order for round selector chips (by round id). */
+  reorderRounds: (orderedRoundIds: string[]) => Promise<boolean>;
   chatMessagesForRound: ReturnType<typeof usePokerSessionChat>['messages'];
   /** New chat messages on other rounds while viewing a different round (for round strip badges). */
   chatNewMessageCountByRound: Record<number, number>;
@@ -302,6 +305,7 @@ export const PokerTableProvider: React.FC<PokerTableProviderProps> = ({ children
     goToCurrentRound,
     goToRound,
     deleteRound,
+    reorderRounds,
   } = usePokerSessionHistory(
     session?.session_id || null,
     historyInitialRound ?? undefined,
@@ -575,7 +579,7 @@ export const PokerTableProvider: React.FC<PokerTableProviderProps> = ({ children
   }, [rounds, optimisticRoundsById]);
 
   const activeRounds = useMemo(
-    () => roundsForUI.filter((r) => r.is_active).slice().sort((a, b) => a.round_number - b.round_number),
+    () => roundsForUI.filter((r) => r.is_active).slice().sort(compareRoundsBySortOrder),
     [roundsForUI]
   );
 
@@ -1463,6 +1467,7 @@ export const PokerTableProvider: React.FC<PokerTableProviderProps> = ({ children
     goToCurrentRound: goToCurrentRoundWithGuardClear,
     goToRound: goToRoundWithGuardClear,
     deleteRound,
+    reorderRounds,
     chatMessagesForRound,
     chatNewMessageCountByRound,
     chatUnreadCount,

--- a/src/components/Neotro/RoundSelector.tsx
+++ b/src/components/Neotro/RoundSelector.tsx
@@ -1,5 +1,18 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ArrowLeft, ChevronLeft, ChevronRight, Play, Power, Ticket, Trash2, Settings, Eye, EyeOff, Spotlight } from 'lucide-react';
+import {
+  ArrowLeft,
+  ChevronLeft,
+  ChevronRight,
+  GripVertical,
+  Play,
+  Power,
+  Ticket,
+  Trash2,
+  Settings,
+  Eye,
+  EyeOff,
+  Spotlight,
+} from 'lucide-react';
 import useEmblaCarousel from 'embla-carousel-react';
 import { WheelGesturesPlugin } from 'embla-carousel-wheel-gestures';
 import { NeotroPressableButton } from '@/components/Neotro/NeotroPressableButton';
@@ -10,6 +23,7 @@ import { deriveDisplayGameState } from '@/lib/pokerRoundDisplayGameState';
 import type { JiraTicketMeta } from '@/hooks/use-jira-ticket-metadata';
 import type { PokerSessionRound } from '@/hooks/usePokerSessionHistory';
 import { displayTicketLabel, isSyntheticRoundTicket } from '@/lib/pokerRoundTicketPlaceholder';
+import { compareRoundsBySortOrder, moveItemInOrder } from '@/lib/pokerRoundSortOrder';
 import {
   ContextMenu,
   ContextMenuContent,
@@ -79,11 +93,16 @@ export const RoundSelector: React.FC<RoundSelectorProps> = ({
 }) => {
   const { theme, toggleTheme } = useTheme();
   const userInteractingRef = useRef(false);
+  const dragFromIndexRef = useRef<number | null>(null);
+  const dragOverIndexRef = useRef<number | null>(null);
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+  const [isReordering, setIsReordering] = useState(false);
   const {
     spotlightRoundNumber,
     isSpotlightMine,
     onSpotlightClick,
     activateRoundById,
+    reorderRounds,
   } = usePokerTable();
 
   const currentPointsLabel = useMemo(() => {
@@ -128,7 +147,7 @@ export const RoundSelector: React.FC<RoundSelectorProps> = ({
 
   const ticketStripItems = useMemo(() => {
     // List every round so completed / inactive rounds without tickets stay reachable (legacy sessions).
-    const sortedRounds = rounds.slice().sort((a, b) => a.round_number - b.round_number);
+    const sortedRounds = rounds.slice().sort(compareRoundsBySortOrder);
     const hasRoundForPointer = sortedRounds.some((r) => r.round_number === sessionPointer);
     const stripCurrentNumber =
       hasRoundForPointer
@@ -208,6 +227,12 @@ export const RoundSelector: React.FC<RoundSelectorProps> = ({
       containScroll: false as const,
       startIndex: selectedStripIndex,
       dragFree: false,
+      // Keep carousel swipe, but let the grip handle own pointer events for reorder DnD.
+      watchDrag: (_api: unknown, event: Event) => {
+        const target = event.target;
+        if (!(target instanceof Element)) return true;
+        return !target.closest('[data-round-drag-handle]');
+      },
     }),
     [] // eslint-disable-line react-hooks/exhaustive-deps -- startIndex only needed on mount
   );
@@ -221,8 +246,47 @@ export const RoundSelector: React.FC<RoundSelectorProps> = ({
   const [activeSnapIndex, setActiveSnapIndex] = useState(selectedStripIndex);
 
   const activeRoundsSorted = useMemo(
-    () => rounds.filter((r) => r.is_active).slice().sort((a, b) => a.round_number - b.round_number),
+    () => rounds.filter((r) => r.is_active).slice().sort(compareRoundsBySortOrder),
     [rounds]
+  );
+
+  const canReorderStrip = ticketStripItems.filter((item) => item.roundId).length > 1;
+
+  const persistStripOrder = useCallback(
+    async (fromIndex: number, toIndex: number) => {
+      if (fromIndex === toIndex || isReordering) return;
+      const orderedIds = ticketStripItems
+        .map((item) => item.roundId)
+        .filter((id): id is string => typeof id === 'string' && id.length > 0);
+      if (orderedIds.length < 2) return;
+
+      // Strip indexes include only real rounds in normal sessions; map via roundId list order.
+      const fromItem = ticketStripItems[fromIndex];
+      const toItem = ticketStripItems[toIndex];
+      if (!fromItem?.roundId || !toItem?.roundId) return;
+
+      const fromIdIndex = orderedIds.indexOf(fromItem.roundId);
+      const toIdIndex = orderedIds.indexOf(toItem.roundId);
+      if (fromIdIndex < 0 || toIdIndex < 0 || fromIdIndex === toIdIndex) return;
+
+      const nextIds = moveItemInOrder(orderedIds, fromIdIndex, toIdIndex);
+      setIsReordering(true);
+      try {
+        await reorderRounds(nextIds);
+      } finally {
+        setIsReordering(false);
+      }
+    },
+    [isReordering, reorderRounds, ticketStripItems]
+  );
+
+  const moveStripItem = useCallback(
+    (index: number, direction: -1 | 1) => {
+      const target = index + direction;
+      if (target < 0 || target >= ticketStripItems.length) return;
+      void persistStripOrder(index, target);
+    },
+    [persistStripOrder, ticketStripItems.length]
   );
 
   const goToNextActiveRound = useCallback(() => {
@@ -488,15 +552,44 @@ export const RoundSelector: React.FC<RoundSelectorProps> = ({
 
                 const canDelete = isAdmin && deleteRound && item.roundId && ticketStripItems.filter(i => i.roundId).length > 1;
                 const deleteActionLabel = item.isActive ? 'Cancel round' : 'Delete round';
-                const showRoundContextMenu = !!item.roundId && (canDelete || canActivateRound);
+                const canMoveLeft = canReorderStrip && !!item.roundId && index > 0;
+                const canMoveRight =
+                  canReorderStrip && !!item.roundId && index < ticketStripItems.length - 1;
+                const showRoundContextMenu =
+                  !!item.roundId && (canDelete || canActivateRound || canMoveLeft || canMoveRight);
                 const newChatCount =
                   item.roundNumber != null ? chatNewMessageCountByRound[item.roundNumber] ?? 0 : 0;
                 const isSpotlightRound =
                   spotlightRoundNumber != null &&
                   item.roundNumber != null &&
                   item.roundNumber === spotlightRoundNumber;
+                const isDropTarget = dragOverIndex === index && dragFromIndexRef.current !== index;
                 const chipButton = (
-                  <div className="relative inline-flex">
+                  <div
+                    className={`relative inline-flex ${isDropTarget ? 'ring-2 ring-primary/50 rounded-md' : ''}`}
+                    onDragOver={
+                      canReorderStrip && item.roundId
+                        ? (e) => {
+                            e.preventDefault();
+                            dragOverIndexRef.current = index;
+                            setDragOverIndex(index);
+                          }
+                        : undefined
+                    }
+                    onDrop={
+                      canReorderStrip && item.roundId
+                        ? (e) => {
+                            e.preventDefault();
+                            const from = dragFromIndexRef.current;
+                            const to = index;
+                            dragFromIndexRef.current = null;
+                            dragOverIndexRef.current = null;
+                            setDragOverIndex(null);
+                            if (from != null) void persistStripOrder(from, to);
+                          }
+                        : undefined
+                    }
+                  >
                     {newChatCount > 0 && (
                       <span
                         className="pointer-events-none absolute -right-1 -top-1 z-10 flex h-4 min-w-4 items-center justify-center rounded-full bg-red-600 px-1 text-[10px] font-bold leading-none text-white shadow-sm tabular-nums"
@@ -505,50 +598,82 @@ export const RoundSelector: React.FC<RoundSelectorProps> = ({
                         {newChatCount > 9 ? '9+' : newChatCount}
                       </span>
                     )}
-                    <div className="relative inline-flex">
+                    <div
+                      className={`relative inline-flex items-stretch overflow-hidden rounded-md border transition-all duration-200 ${
+                        isSelected
+                          ? isRoundActive
+                            ? 'bg-emerald-500/15 border-emerald-400/80 text-foreground scale-110 ring-1 ring-emerald-400/30 shadow-[0_0_14px_rgba(16,185,129,0.35)]'
+                            : 'bg-primary/15 border-primary/80 text-foreground scale-110'
+                          : isRoundActive
+                            ? 'bg-emerald-500/10 border-emerald-400/70 text-foreground ring-1 ring-emerald-400/20 shadow-[0_0_10px_rgba(16,185,129,0.32)]'
+                            : 'bg-card hover:bg-accent/50 opacity-75'
+                      }${
+                        isSpotlightRound
+                          ? ' overflow-visible !border-2 !border-solid !border-amber-400 ring-0 shadow-none'
+                          : ''
+                      }${isReordering ? ' opacity-80' : ''}`}
+                    >
+                      {isSpotlightRound && (
+                        <div
+                          className="pointer-events-none z-0 neotro-spotlight-overlay"
+                          aria-hidden
+                        >
+                          <div className="neotro-spotlight-cone" />
+                        </div>
+                      )}
+                      {canReorderStrip && item.roundId && (
+                        <span
+                          role="button"
+                          tabIndex={0}
+                          data-round-drag-handle
+                          draggable={!isReordering}
+                          onDragStart={(e) => {
+                            dragFromIndexRef.current = index;
+                            e.dataTransfer.effectAllowed = 'move';
+                            e.dataTransfer.setData('text/plain', item.roundId!);
+                          }}
+                          onDragEnd={() => {
+                            dragFromIndexRef.current = null;
+                            dragOverIndexRef.current = null;
+                            setDragOverIndex(null);
+                          }}
+                          onKeyDown={(e) => {
+                            if (e.key === 'ArrowLeft') {
+                              e.preventDefault();
+                              moveStripItem(index, -1);
+                            } else if (e.key === 'ArrowRight') {
+                              e.preventDefault();
+                              moveStripItem(index, 1);
+                            }
+                          }}
+                          className="relative z-[1] inline-flex cursor-grab items-center px-1 active:cursor-grabbing touch-none text-muted-foreground hover:text-foreground"
+                          aria-label={`Drag to reorder ${item.ticketKey}`}
+                          title="Drag to reorder"
+                        >
+                          <GripVertical className="h-3.5 w-3.5" />
+                        </span>
+                      )}
                       <button
                         type="button"
-                        className={`relative inline-flex items-center gap-2 rounded-md border px-2 py-1.5 text-xs whitespace-nowrap transition-all duration-200 ${
-                          isSelected
-                            ? isRoundActive
-                              ? 'bg-emerald-500/15 border-emerald-400/80 text-foreground scale-110 ring-1 ring-emerald-400/30 shadow-[0_0_14px_rgba(16,185,129,0.35)]'
-                              : 'bg-primary/15 border-primary/80 text-foreground scale-110'
-                            : isRoundActive
-                              ? 'bg-emerald-500/10 border-emerald-400/70 text-foreground ring-1 ring-emerald-400/20 shadow-[0_0_10px_rgba(16,185,129,0.32)]'
-                              : 'bg-card hover:bg-accent/50 opacity-75'
-                        }${
-                          isSpotlightRound
-                            ? ' overflow-visible !border-2 !border-solid !border-amber-400 ring-0 shadow-none'
-                            : ''
-                        }`}
+                        className="relative z-[1] inline-flex items-center gap-2 px-2 py-1.5 text-xs whitespace-nowrap"
                         onClick={() => handleChipClick(index)}
                       >
-                        {isSpotlightRound && (
-                          <div
-                            className="pointer-events-none z-0 neotro-spotlight-overlay"
-                            aria-hidden
-                          >
-                            <div className="neotro-spotlight-cone" />
-                          </div>
+                        {iconUrl ? (
+                          <img src={iconUrl} alt="" className="h-3.5 w-3.5 shrink-0" />
+                        ) : (
+                          <Ticket className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                         )}
-                        <span className="relative z-[1] inline-flex items-center gap-2">
-                          {iconUrl ? (
-                            <img src={iconUrl} alt="" className="h-3.5 w-3.5 shrink-0" />
-                          ) : (
-                            <Ticket className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                          )}
-                          <span className="font-mono font-semibold">{item.ticketKey}</span>
-                          {item.isPendingRound && (
-                            <span className="rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-medium text-amber-800 dark:text-amber-300">
-                              Pending
-                            </span>
-                          )}
-                          {item.pointsLabel && (
-                            <span className="rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary">
-                              {item.pointsLabel}
-                            </span>
-                          )}
-                        </span>
+                        <span className="font-mono font-semibold">{item.ticketKey}</span>
+                        {item.isPendingRound && (
+                          <span className="rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-medium text-amber-800 dark:text-amber-300">
+                            Pending
+                          </span>
+                        )}
+                        {item.pointsLabel && (
+                          <span className="rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary">
+                            {item.pointsLabel}
+                          </span>
+                        )}
                       </button>
                     </div>
                   </div>
@@ -561,6 +686,18 @@ export const RoundSelector: React.FC<RoundSelectorProps> = ({
                           {chipButton}
                         </ContextMenuTrigger>
                         <ContextMenuContent>
+                          {canMoveLeft && (
+                            <ContextMenuItem onClick={() => moveStripItem(index, -1)}>
+                              <ChevronLeft className="h-4 w-4 mr-2" />
+                              Move left
+                            </ContextMenuItem>
+                          )}
+                          {canMoveRight && (
+                            <ContextMenuItem onClick={() => moveStripItem(index, 1)}>
+                              <ChevronRight className="h-4 w-4 mr-2" />
+                              Move right
+                            </ContextMenuItem>
+                          )}
                           {canActivateRound && (
                             <ContextMenuItem onClick={() => void activateRoundById(item.roundId!)}>
                               <Power className="h-4 w-4 mr-2" />

--- a/src/hooks/usePokerSession.ts
+++ b/src/hooks/usePokerSession.ts
@@ -279,6 +279,7 @@ export const usePokerSession = (
         .insert({
           session_id: sessionData.id,
           round_number: sessionData.current_round_number,
+          sort_order: sessionData.current_round_number,
           selections: initialSelections,
           ticket_number: roundTicketPlaceholder(sessionData.current_round_number),
           is_active: true,
@@ -747,6 +748,7 @@ export const usePokerSession = (
     const { error: newRoundError } = await supabase.from('poker_session_rounds').insert({
         session_id: session.session_id,
         round_number: newRoundNumber,
+        sort_order: newRoundNumber,
         selections: resetSelections,
         ticket_number: newTicketNumber?.trim() || roundTicketPlaceholder(newRoundNumber),
         is_active: true,
@@ -821,6 +823,7 @@ export const usePokerSession = (
       .insert({
         session_id: session.session_id,
         round_number: newRoundNumber,
+        sort_order: newRoundNumber,
         selections: resetSelections,
         ticket_number: ticketToStore,
         ticket_title: newTicketTitle ?? null,
@@ -915,17 +918,21 @@ export const usePokerSession = (
     }
 
     const startingRoundNumber = Math.max(session.round_number, highestRoundData?.round_number ?? 0);
-    const roundsToInsert = normalizedTickets.map((ticket, index) => ({
-      session_id: session.session_id,
-      round_number: startingRoundNumber + index + 1,
-      selections: resetSelections,
-      ticket_number: ticket.ticketNumber,
-      ticket_title: ticket.ticketTitle,
-      ticket_parent_key: ticket.ticketParent?.key ?? null,
-      ticket_parent_summary: ticket.ticketParent?.summary ?? null,
-      is_active: true,
-      game_state: 'Selection' as const,
-    }));
+    const roundsToInsert = normalizedTickets.map((ticket, index) => {
+      const roundNumber = startingRoundNumber + index + 1;
+      return {
+        session_id: session.session_id,
+        round_number: roundNumber,
+        sort_order: roundNumber,
+        selections: resetSelections,
+        ticket_number: ticket.ticketNumber,
+        ticket_title: ticket.ticketTitle,
+        ticket_parent_key: ticket.ticketParent?.key ?? null,
+        ticket_parent_summary: ticket.ticketParent?.summary ?? null,
+        is_active: true,
+        game_state: 'Selection' as const,
+      };
+    });
 
     const { error: newRoundsError } = await supabase
       .from('poker_session_rounds')

--- a/src/hooks/usePokerSessionHistory.ts
+++ b/src/hooks/usePokerSessionHistory.ts
@@ -4,6 +4,11 @@ import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 import { GameState } from './usePokerSession';
 import { isUuidLike } from '@/lib/pokerSessionPathSlug';
+import {
+  buildDensifiedSortOrderUpdates,
+  compareRoundsBySortOrder,
+  roundSortKey,
+} from '@/lib/pokerRoundSortOrder';
 
 /** Team poker URLs: resolve DB session id from team + slug so history never depends on merged UI state alone. */
 export type PokerHistoryTeamRoute = { teamId: string; slug: string };
@@ -42,6 +47,8 @@ export interface PokerSessionRound {
   id: string;
   session_id: string;
   round_number: number;
+  /** Display order in the round selector; independent of round_number identity. */
+  sort_order?: number;
   selections: any;
   average_points: number;
   ticket_number: string | null;
@@ -119,7 +126,7 @@ function applyRealtimePayload(
     const merged = { ...prev[idx], ...row } as PokerSessionRound;
     const next = [...prev];
     next[idx] = merged;
-    next.sort((a, b) => a.round_number - b.round_number);
+    next.sort(compareRoundsBySortOrder);
     return { ok: true, next };
   }
 
@@ -131,7 +138,7 @@ function applyRealtimePayload(
     if (prev.some((r) => r.id === row.id)) {
       return { ok: true, next: prev };
     }
-    const next = [...prev, toPokerSessionRound(row)].sort((a, b) => a.round_number - b.round_number);
+    const next = [...prev, toPokerSessionRound(row)].sort(compareRoundsBySortOrder);
     return { ok: true, next };
   }
 
@@ -197,6 +204,7 @@ export const usePokerSessionHistory = (
         .from('poker_session_rounds')
         .select('*')
         .eq('session_id', pk)
+        .order('sort_order', { ascending: true })
         .order('round_number', { ascending: true });
 
       if (error) {
@@ -205,7 +213,7 @@ export const usePokerSessionHistory = (
         return;
       }
 
-      const list = data || [];
+      const list = (data || []).slice().sort(compareRoundsBySortOrder);
       setRounds(list);
 
       const idx = pickRoundIndexForRounds(
@@ -324,6 +332,7 @@ export const usePokerSessionHistory = (
         .insert({
           session_id: sessionId,
           round_number: roundNumber,
+          sort_order: roundNumber,
           selections,
           average_points: averagePoints,
           ticket_number: ticketNumber,
@@ -357,15 +366,91 @@ export const usePokerSessionHistory = (
   };
 
   const goToCurrentRound = () => {
-    if (rounds.length > 0) {
-      setCurrentRoundIndex(rounds.length - 1);
+    if (rounds.length === 0) return;
+    // Prefer the highest round_number (session identity), not the last strip position
+    // after tickets have been reordered via sort_order.
+    let bestIdx = 0;
+    let bestRoundNumber = rounds[0].round_number;
+    for (let i = 1; i < rounds.length; i++) {
+      if (rounds[i].round_number > bestRoundNumber) {
+        bestRoundNumber = rounds[i].round_number;
+        bestIdx = i;
+      }
     }
+    setCurrentRoundIndex(bestIdx);
   };
 
   const goToRound = (roundNumber: number) => {
     const targetIndex = rounds.findIndex((round) => round.round_number === roundNumber);
     if (targetIndex !== -1) {
       setCurrentRoundIndex(targetIndex);
+    }
+  };
+
+  const reorderRounds = async (orderedRoundIds: string[]): Promise<boolean> => {
+    const pk = resolvedSessionPk;
+    if (!pk) return false;
+
+    const current = roundsRef.current;
+    const updates = buildDensifiedSortOrderUpdates(current, orderedRoundIds);
+    if (!updates) return false;
+
+    const unchanged = updates.every((u) => {
+      const existing = current.find((r) => r.id === u.id);
+      return existing != null && roundSortKey(existing) === u.sort_order;
+    });
+    if (unchanged) return true;
+
+    const previous = current;
+    const byId = new Map(updates.map((u) => [u.id, u.sort_order]));
+    const optimistic = current
+      .map((r) => (byId.has(r.id) ? { ...r, sort_order: byId.get(r.id)! } : r))
+      .sort(compareRoundsBySortOrder);
+    roundsRef.current = optimistic;
+    setRounds(optimistic);
+    setCurrentRoundIndex(
+      pickRoundIndexForRounds(
+        optimistic,
+        selectedRoundNumberRef.current,
+        initialRoundNumberRef.current
+      )
+    );
+
+    try {
+      const results = await Promise.all(
+        updates.map((u) =>
+          supabase.from('poker_session_rounds').update({ sort_order: u.sort_order }).eq('id', u.id)
+        )
+      );
+      const firstError = results.find((r) => r.error)?.error;
+      if (firstError) {
+        console.error('Error reordering rounds:', firstError);
+        roundsRef.current = previous;
+        setRounds(previous);
+        setCurrentRoundIndex(
+          pickRoundIndexForRounds(
+            previous,
+            selectedRoundNumberRef.current,
+            initialRoundNumberRef.current
+          )
+        );
+        toast({ title: 'Error reordering tickets', variant: 'destructive' });
+        return false;
+      }
+      return true;
+    } catch (error) {
+      console.error('Error reordering rounds:', error);
+      roundsRef.current = previous;
+      setRounds(previous);
+      setCurrentRoundIndex(
+        pickRoundIndexForRounds(
+          previous,
+          selectedRoundNumberRef.current,
+          initialRoundNumberRef.current
+        )
+      );
+      toast({ title: 'Error reordering tickets', variant: 'destructive' });
+      return false;
     }
   };
 
@@ -474,6 +559,7 @@ export const usePokerSessionHistory = (
     goToCurrentRound,
     goToRound,
     deleteRound,
+    reorderRounds,
     fetchRounds,
   };
 };

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -781,6 +781,7 @@ export type Database = {
           session_id: string
           slack_channel_id: string | null
           slack_message_ts: string | null
+          sort_order: number
           ticket_number: string | null
           ticket_parent_key: string | null
           ticket_parent_summary: string | null
@@ -800,6 +801,7 @@ export type Database = {
           session_id: string
           slack_channel_id?: string | null
           slack_message_ts?: string | null
+          sort_order?: number
           ticket_number?: string | null
           ticket_parent_key?: string | null
           ticket_parent_summary?: string | null
@@ -819,6 +821,7 @@ export type Database = {
           session_id?: string
           slack_channel_id?: string | null
           slack_message_ts?: string | null
+          sort_order?: number
           ticket_number?: string | null
           ticket_parent_key?: string | null
           ticket_parent_summary?: string | null

--- a/src/lib/pokerRoundSortOrder.test.ts
+++ b/src/lib/pokerRoundSortOrder.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildDensifiedSortOrderUpdates,
+  compareRoundsBySortOrder,
+  moveItemInOrder,
+  roundSortKey,
+} from './pokerRoundSortOrder';
+
+describe('roundSortKey', () => {
+  it('uses sort_order when present', () => {
+    expect(roundSortKey({ sort_order: 2, round_number: 9 })).toBe(2);
+  });
+
+  it('falls back to round_number when sort_order is missing', () => {
+    expect(roundSortKey({ round_number: 4 })).toBe(4);
+    expect(roundSortKey({ sort_order: null, round_number: 4 })).toBe(4);
+  });
+});
+
+describe('compareRoundsBySortOrder', () => {
+  it('orders by sort_order then round_number', () => {
+    const rounds = [
+      { id: 'c', sort_order: 3, round_number: 1 },
+      { id: 'a', sort_order: 1, round_number: 3 },
+      { id: 'b', sort_order: 2, round_number: 2 },
+    ];
+    expect([...rounds].sort(compareRoundsBySortOrder).map((r) => r.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('falls back to round_number for legacy rows', () => {
+    const rounds = [
+      { id: 'b', round_number: 2 },
+      { id: 'a', round_number: 1 },
+    ];
+    expect([...rounds].sort(compareRoundsBySortOrder).map((r) => r.id)).toEqual(['a', 'b']);
+  });
+});
+
+describe('buildDensifiedSortOrderUpdates', () => {
+  const rounds = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+
+  it('densifies to 1..n for a valid permutation', () => {
+    expect(buildDensifiedSortOrderUpdates(rounds, ['c', 'a', 'b'])).toEqual([
+      { id: 'c', sort_order: 1 },
+      { id: 'a', sort_order: 2 },
+      { id: 'b', sort_order: 3 },
+    ]);
+  });
+
+  it('rejects incomplete or unknown id lists', () => {
+    expect(buildDensifiedSortOrderUpdates(rounds, ['a', 'b'])).toBeNull();
+    expect(buildDensifiedSortOrderUpdates(rounds, ['a', 'b', 'x'])).toBeNull();
+    expect(buildDensifiedSortOrderUpdates(rounds, ['a', 'a', 'b'])).toBeNull();
+    expect(buildDensifiedSortOrderUpdates(rounds, [])).toBeNull();
+  });
+});
+
+describe('moveItemInOrder', () => {
+  it('moves an item to a new index', () => {
+    expect(moveItemInOrder(['a', 'b', 'c'], 0, 2)).toEqual(['b', 'c', 'a']);
+    expect(moveItemInOrder(['a', 'b', 'c'], 2, 0)).toEqual(['c', 'a', 'b']);
+  });
+
+  it('returns a copy when indexes are invalid or unchanged', () => {
+    const items = ['a', 'b'];
+    expect(moveItemInOrder(items, 0, 0)).toEqual(['a', 'b']);
+    expect(moveItemInOrder(items, -1, 0)).toEqual(['a', 'b']);
+    expect(moveItemInOrder(items, 0, 5)).toEqual(['a', 'b']);
+  });
+});

--- a/src/lib/pokerRoundSortOrder.ts
+++ b/src/lib/pokerRoundSortOrder.ts
@@ -1,0 +1,52 @@
+/** Round fields needed to order the poker round selector strip. */
+export type RoundSortable = {
+  sort_order?: number | null;
+  round_number: number;
+};
+
+/** Prefer explicit sort_order; fall back to round_number for legacy rows. */
+export function roundSortKey(round: RoundSortable): number {
+  return typeof round.sort_order === 'number' ? round.sort_order : round.round_number;
+}
+
+export function compareRoundsBySortOrder(a: RoundSortable, b: RoundSortable): number {
+  const bySort = roundSortKey(a) - roundSortKey(b);
+  if (bySort !== 0) return bySort;
+  return a.round_number - b.round_number;
+}
+
+/**
+ * Densify display order to 1..n for the given round id sequence.
+ * Returns null when the ordered ids are empty or not a permutation of `rounds`.
+ */
+export function buildDensifiedSortOrderUpdates<T extends { id: string }>(
+  rounds: T[],
+  orderedRoundIds: string[]
+): Array<{ id: string; sort_order: number }> | null {
+  if (orderedRoundIds.length === 0) return null;
+  if (orderedRoundIds.length !== rounds.length) return null;
+
+  const idSet = new Set(rounds.map((r) => r.id));
+  if (idSet.size !== rounds.length) return null;
+  if (orderedRoundIds.some((id) => !idSet.has(id))) return null;
+  if (new Set(orderedRoundIds).size !== orderedRoundIds.length) return null;
+
+  return orderedRoundIds.map((id, index) => ({ id, sort_order: index + 1 }));
+}
+
+/** Move the item at `fromIndex` to `toIndex` (array splice semantics). */
+export function moveItemInOrder<T>(items: T[], fromIndex: number, toIndex: number): T[] {
+  if (
+    fromIndex < 0 ||
+    toIndex < 0 ||
+    fromIndex >= items.length ||
+    toIndex >= items.length ||
+    fromIndex === toIndex
+  ) {
+    return items.slice();
+  }
+  const next = items.slice();
+  const [removed] = next.splice(fromIndex, 1);
+  next.splice(toIndex, 0, removed);
+  return next;
+}

--- a/supabase/functions/slack-poke/index.ts
+++ b/supabase/functions/slack-poke/index.ts
@@ -271,6 +271,7 @@ export async function createNewRound(
       .insert({
         session_id: sessionId,
         round_number: newRoundNumber,
+        sort_order: newRoundNumber,
         ticket_number: effectiveTicket,
         ticket_title: ticketTitle,
         selections: {},

--- a/supabase/migrations/20260806170000_poker_session_rounds_sort_order.sql
+++ b/supabase/migrations/20260806170000_poker_session_rounds_sort_order.sql
@@ -1,0 +1,17 @@
+-- Display order for poker round selector chips (independent of stable round_number identity).
+ALTER TABLE public.poker_session_rounds
+  ADD COLUMN IF NOT EXISTS sort_order integer;
+
+UPDATE public.poker_session_rounds
+SET sort_order = round_number
+WHERE sort_order IS NULL;
+
+ALTER TABLE public.poker_session_rounds
+  ALTER COLUMN sort_order SET DEFAULT 0,
+  ALTER COLUMN sort_order SET NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_poker_session_rounds_sort_order
+  ON public.poker_session_rounds(session_id, sort_order);
+
+COMMENT ON COLUMN public.poker_session_rounds.sort_order IS
+  'Order of this round in the poker session round selector strip; may differ from round_number after reordering.';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Resolves **DUN-60**: facilitators can reorder tickets in the poker session round selector at the top of the screen.

## Changes
- Add `poker_session_rounds.sort_order` (migration + types) so strip order is independent of `round_number` identity (chat, spotlight, and `?round=` stay stable).
- Persist reorder via `reorderRounds()` with optimistic updates and realtime refresh.
- Round selector UI:
  - Grip handle to drag chips into a new order
  - Context menu **Move left** / **Move right**
  - Keyboard arrows on the grip handle
- New rounds get `sort_order` so they continue to append at the end of the strip.
- Active-round “next” navigation follows strip order.

## Testing
- `npx vitest run src/lib/pokerRoundSortOrder.test.ts`
- `npx tsc --noEmit -p tsconfig.app.json`

## Deploy note
Apply migration `supabase/migrations/20260806170000_poker_session_rounds_sort_order.sql` before/with this frontend change.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-60](https://linear.app/dungeon-dwellers/issue/DUN-60/poker-enable-changing-ticket-order)

<div><a href="https://cursor.com/agents/bc-ad9e3d55-5fc1-4bea-9f11-d77f8ce7ced5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad9e3d55-5fc1-4bea-9f11-d77f8ce7ced5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

