### PR TITLE
fix(poker): stop round history error when sort_order column missing (DUN-61)

### DIFF
--- a/src/hooks/usePokerSession.ts
+++ b/src/hooks/usePokerSession.ts
@@ -13,6 +13,10 @@ import {
   pokerSessionSettingsFromPreviousRow,
 } from '@/lib/pokerSessionCloneSettings';
 import { roundTicketPlaceholder } from '@/lib/pokerRoundTicketPlaceholder';
+import {
+  isMissingSortOrderColumnError,
+  omitSortOrder,
+} from '@/lib/pokerRoundSortOrder';
 
 function emitSpotlightServerAligned(sessionId: string, roundNumber: number) {
   window.dispatchEvent(
@@ -274,19 +278,27 @@ export const usePokerSession = (
         };
       }
 
-      const { data: newRound, error: newRoundError } = await supabase
+      const firstRoundRow = {
+        session_id: sessionData.id,
+        round_number: sessionData.current_round_number,
+        sort_order: sessionData.current_round_number,
+        selections: initialSelections,
+        ticket_number: roundTicketPlaceholder(sessionData.current_round_number),
+        is_active: true,
+        game_state: 'Selection' as const,
+      };
+      let { data: newRound, error: newRoundError } = await supabase
         .from('poker_session_rounds')
-        .insert({
-          session_id: sessionData.id,
-          round_number: sessionData.current_round_number,
-          sort_order: sessionData.current_round_number,
-          selections: initialSelections,
-          ticket_number: roundTicketPlaceholder(sessionData.current_round_number),
-          is_active: true,
-          game_state: 'Selection',
-        })
+        .insert(firstRoundRow)
         .select()
         .single();
+      if (isMissingSortOrderColumnError(newRoundError)) {
+        ({ data: newRound, error: newRoundError } = await supabase
+          .from('poker_session_rounds')
+          .insert(omitSortOrder(firstRoundRow))
+          .select()
+          .single());
+      }
 
       if (newRoundError) throw newRoundError;
       roundData = newRound;
@@ -745,15 +757,21 @@ export const usePokerSession = (
       .eq('session_id', session.session_id)
       .eq('is_active', true);
 
-    const { error: newRoundError } = await supabase.from('poker_session_rounds').insert({
+    const nextRoundRow = {
         session_id: session.session_id,
         round_number: newRoundNumber,
         sort_order: newRoundNumber,
         selections: resetSelections,
         ticket_number: newTicketNumber?.trim() || roundTicketPlaceholder(newRoundNumber),
         is_active: true,
-        game_state: 'Selection',
-    });
+        game_state: 'Selection' as const,
+    };
+    let { error: newRoundError } = await supabase.from('poker_session_rounds').insert(nextRoundRow);
+    if (isMissingSortOrderColumnError(newRoundError)) {
+      ({ error: newRoundError } = await supabase
+        .from('poker_session_rounds')
+        .insert(omitSortOrder(nextRoundRow)));
+    }
 
     if (newRoundError) {
         console.error('Error creating new round', newRoundError);
@@ -818,23 +836,31 @@ export const usePokerSession = (
       });
     }
 
-    const { data: insertedRound, error: newRoundError } = await supabase
+    const startRoundRow = {
+      session_id: session.session_id,
+      round_number: newRoundNumber,
+      sort_order: newRoundNumber,
+      selections: resetSelections,
+      ticket_number: ticketToStore,
+      ticket_title: newTicketTitle ?? null,
+      ticket_parent_key: ticketParent?.key ?? null,
+      ticket_parent_summary: ticketParent?.summary ?? null,
+      is_active: true,
+      is_pending_round: options?.pendingRound === true,
+      game_state: 'Selection' as const,
+    };
+    let { data: insertedRound, error: newRoundError } = await supabase
       .from('poker_session_rounds')
-      .insert({
-        session_id: session.session_id,
-        round_number: newRoundNumber,
-        sort_order: newRoundNumber,
-        selections: resetSelections,
-        ticket_number: ticketToStore,
-        ticket_title: newTicketTitle ?? null,
-        ticket_parent_key: ticketParent?.key ?? null,
-        ticket_parent_summary: ticketParent?.summary ?? null,
-        is_active: true,
-        is_pending_round: options?.pendingRound === true,
-        game_state: 'Selection',
-      })
+      .insert(startRoundRow)
       .select('id')
       .single();
+    if (isMissingSortOrderColumnError(newRoundError)) {
+      ({ data: insertedRound, error: newRoundError } = await supabase
+        .from('poker_session_rounds')
+        .insert(omitSortOrder(startRoundRow))
+        .select('id')
+        .single());
+    }
 
     if (newRoundError) {
       console.error('Error creating new round', newRoundError);
@@ -934,9 +960,14 @@ export const usePokerSession = (
       };
     });
 
-    const { error: newRoundsError } = await supabase
+    let { error: newRoundsError } = await supabase
       .from('poker_session_rounds')
       .insert(roundsToInsert);
+    if (isMissingSortOrderColumnError(newRoundsError)) {
+      ({ error: newRoundsError } = await supabase
+        .from('poker_session_rounds')
+        .insert(roundsToInsert.map((row) => omitSortOrder(row))));
+    }
 
     if (newRoundsError) {
       console.error('Error creating new rounds', newRoundsError);

--- a/src/hooks/usePokerSessionHistory.ts
+++ b/src/hooks/usePokerSessionHistory.ts
@@ -7,6 +7,8 @@ import { isUuidLike } from '@/lib/pokerSessionPathSlug';
 import {
   buildDensifiedSortOrderUpdates,
   compareRoundsBySortOrder,
+  isMissingSortOrderColumnError,
+  omitSortOrder,
   roundSortKey,
 } from '@/lib/pokerRoundSortOrder';
 
@@ -200,11 +202,13 @@ export const usePokerSessionHistory = (
 
     setLoading(true);
     try {
+      // Order only by round_number in SQL — sort_order may not exist until the
+      // migration is applied. Client-side compareRoundsBySortOrder prefers
+      // sort_order when present and falls back to round_number otherwise.
       const { data, error } = await supabase
         .from('poker_session_rounds')
         .select('*')
         .eq('session_id', pk)
-        .order('sort_order', { ascending: true })
         .order('round_number', { ascending: true });
 
       if (error) {
@@ -327,17 +331,19 @@ export const usePokerSessionHistory = (
     ticketTitle?: string
   ) => {
     try {
-      const { error } = await supabase
-        .from('poker_session_rounds')
-        .insert({
-          session_id: sessionId,
-          round_number: roundNumber,
-          sort_order: roundNumber,
-          selections,
-          average_points: averagePoints,
-          ticket_number: ticketNumber,
-          ticket_title: ticketTitle,
-        });
+      const roundRow = {
+        session_id: sessionId,
+        round_number: roundNumber,
+        sort_order: roundNumber,
+        selections,
+        average_points: averagePoints,
+        ticket_number: ticketNumber,
+        ticket_title: ticketTitle,
+      };
+      let { error } = await supabase.from('poker_session_rounds').insert(roundRow);
+      if (isMissingSortOrderColumnError(error)) {
+        ({ error } = await supabase.from('poker_session_rounds').insert(omitSortOrder(roundRow)));
+      }
 
       if (error) {
         console.error('Error saving round:', error);
@@ -434,7 +440,12 @@ export const usePokerSessionHistory = (
             initialRoundNumberRef.current
           )
         );
-        toast({ title: 'Error reordering tickets', variant: 'destructive' });
+        toast({
+          title: isMissingSortOrderColumnError(firstError)
+            ? 'Ticket reorder requires a database update'
+            : 'Error reordering tickets',
+          variant: 'destructive',
+        });
         return false;
       }
       return true;

--- a/src/lib/pokerRoundSortOrder.test.ts
+++ b/src/lib/pokerRoundSortOrder.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import {
   buildDensifiedSortOrderUpdates,
   compareRoundsBySortOrder,
+  isMissingSortOrderColumnError,
   moveItemInOrder,
+  omitSortOrder,
   roundSortKey,
 } from './pokerRoundSortOrder';
 
@@ -66,5 +68,41 @@ describe('moveItemInOrder', () => {
     expect(moveItemInOrder(items, 0, 0)).toEqual(['a', 'b']);
     expect(moveItemInOrder(items, -1, 0)).toEqual(['a', 'b']);
     expect(moveItemInOrder(items, 0, 5)).toEqual(['a', 'b']);
+  });
+});
+
+describe('isMissingSortOrderColumnError', () => {
+  it('detects Postgres undefined_column for sort_order', () => {
+    expect(
+      isMissingSortOrderColumnError({
+        code: '42703',
+        message: 'column poker_session_rounds.sort_order does not exist',
+      })
+    ).toBe(true);
+  });
+
+  it('ignores unrelated errors', () => {
+    expect(isMissingSortOrderColumnError(null)).toBe(false);
+    expect(
+      isMissingSortOrderColumnError({
+        code: '42703',
+        message: 'column poker_session_rounds.other does not exist',
+      })
+    ).toBe(false);
+    expect(
+      isMissingSortOrderColumnError({
+        code: '23505',
+        message: 'duplicate key value',
+      })
+    ).toBe(false);
+  });
+});
+
+describe('omitSortOrder', () => {
+  it('removes sort_order and keeps other fields', () => {
+    expect(omitSortOrder({ round_number: 3, sort_order: 3, ticket_number: 'ABC-1' })).toEqual({
+      round_number: 3,
+      ticket_number: 'ABC-1',
+    });
   });
 });

--- a/src/lib/pokerRoundSortOrder.ts
+++ b/src/lib/pokerRoundSortOrder.ts
@@ -9,6 +9,22 @@ export function roundSortKey(round: RoundSortable): number {
   return typeof round.sort_order === 'number' ? round.sort_order : round.round_number;
 }
 
+/** True when Postgres/PostgREST rejects a query because sort_order is not on the table yet. */
+export function isMissingSortOrderColumnError(
+  error: { code?: string | null; message?: string | null } | null | undefined
+): boolean {
+  if (!error) return false;
+  const message = error.message ?? '';
+  if (!message.includes('sort_order')) return false;
+  return error.code === '42703' || message.includes('does not exist');
+}
+
+/** Drop sort_order so inserts/updates can proceed before the migration is applied. */
+export function omitSortOrder<T extends { sort_order?: unknown }>(row: T): Omit<T, 'sort_order'> {
+  const { sort_order: _ignored, ...rest } = row;
+  return rest;
+}
+
 export function compareRoundsBySortOrder(a: RoundSortable, b: RoundSortable): number {
   const bySort = roundSortKey(a) - roundSortKey(b);
   if (bySort !== 0) return bySort;

--- a/supabase/functions/slack-poke/index.ts
+++ b/supabase/functions/slack-poke/index.ts
@@ -266,21 +266,36 @@ export async function createNewRound(
     const effectiveTicket =
       (ticketNumber && ticketNumber.trim()) || `round:${newRoundNumber}`;
 
-    const { data: newRound, error } = await supabase
+    const roundRow = {
+      session_id: sessionId,
+      round_number: newRoundNumber,
+      sort_order: newRoundNumber,
+      ticket_number: effectiveTicket,
+      ticket_title: ticketTitle,
+      selections: {},
+      game_state: 'Selection',
+      is_active: true,
+      created_at: new Date().toISOString(),
+    };
+    let { data: newRound, error } = await supabase
       .from('poker_session_rounds')
-      .insert({
-        session_id: sessionId,
-        round_number: newRoundNumber,
-        sort_order: newRoundNumber,
-        ticket_number: effectiveTicket,
-        ticket_title: ticketTitle,
-        selections: {},
-        game_state: 'Selection',
-        is_active: true,
-        created_at: new Date().toISOString()
-      })
+      .insert(roundRow)
       .select()
       .single();
+
+    // Tolerate DBs that have not yet applied the sort_order migration.
+    const missingSortOrder =
+      !!error &&
+      (error.message?.includes('sort_order') ?? false) &&
+      (error.code === '42703' || (error.message?.includes('does not exist') ?? false));
+    if (missingSortOrder) {
+      const { sort_order: _ignored, ...withoutSortOrder } = roundRow;
+      ({ data: newRound, error } = await supabase
+        .from('poker_session_rounds')
+        .insert(withoutSortOrder)
+        .select()
+        .single());
+    }
 
     if (error) {
       throw error;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Resolves **DUN-61**: reloading an existing poker session failed because the client ordered `poker_session_rounds` by `sort_order`, which does not exist in production yet (Postgres `42703`).

Root cause: DUN-60 (#156) shipped frontend ordering/inserts that depend on `sort_order` before migration `20260806170000_poker_session_rounds_sort_order.sql` was applied.

## Changes
- Fetch round history ordered by `round_number` only; keep client-side `compareRoundsBySortOrder` (uses `sort_order` when present, otherwise `round_number`).
- Retry round inserts without `sort_order` when Postgres reports the column is missing.
- Clearer toast when ticket reorder fails because the column is absent.
- Same insert tolerance in the Slack poke edge function.

## Testing
- `npx vitest run src/lib/pokerRoundSortOrder.test.ts` (11 passed)
- `npx tsc --noEmit -p tsconfig.app.json`
- Verified against production API for session `74906104-1698-4af5-bce0-75fc992bbd6c`:
  - `order=sort_order.asc,round_number.asc` → `42703`
  - `order=round_number.asc` → returns rounds successfully

## Deploy note
Still apply `supabase/migrations/20260806170000_poker_session_rounds_sort_order.sql` on production so ticket reordering (DUN-60) can persist `sort_order`. This PR unblocks page reload either way.

Linear Issue: [DUN-61](https://linear.app/dungeon-dwellers/issue/DUN-61/fix-round-history-error)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-61](https://linear.app/dungeon-dwellers/issue/DUN-61/fix-round-history-error)

<div><a href="https://cursor.com/agents/bc-a0f887e3-266d-4642-b042-6454c864dbb8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0f887e3-266d-4642-b042-6454c864dbb8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

