### PR TITLE
fix(poker): detect PGRST204 when reordering rounds without sort_order (DUN-62)

### DIFF
--- a/src/lib/pokerRoundSortOrder.test.ts
+++ b/src/lib/pokerRoundSortOrder.test.ts
@@ -81,12 +81,27 @@ describe('isMissingSortOrderColumnError', () => {
     ).toBe(true);
   });
 
+  it('detects PostgREST schema-cache miss for sort_order (PGRST204)', () => {
+    expect(
+      isMissingSortOrderColumnError({
+        code: 'PGRST204',
+        message: "Could not find the 'sort_order' column of 'poker_session_rounds' in the schema cache",
+      })
+    ).toBe(true);
+  });
+
   it('ignores unrelated errors', () => {
     expect(isMissingSortOrderColumnError(null)).toBe(false);
     expect(
       isMissingSortOrderColumnError({
         code: '42703',
         message: 'column poker_session_rounds.other does not exist',
+      })
+    ).toBe(false);
+    expect(
+      isMissingSortOrderColumnError({
+        code: 'PGRST204',
+        message: "Could not find the 'other' column of 'poker_session_rounds' in the schema cache",
       })
     ).toBe(false);
     expect(

--- a/src/lib/pokerRoundSortOrder.ts
+++ b/src/lib/pokerRoundSortOrder.ts
@@ -16,7 +16,13 @@ export function isMissingSortOrderColumnError(
   if (!error) return false;
   const message = error.message ?? '';
   if (!message.includes('sort_order')) return false;
-  return error.code === '42703' || message.includes('does not exist');
+  // Postgres undefined_column, or PostgREST schema-cache miss on PATCH/POST (PGRST204).
+  return (
+    error.code === '42703' ||
+    error.code === 'PGRST204' ||
+    message.includes('does not exist') ||
+    message.includes('schema cache')
+  );
 }
 
 /** Drop sort_order so inserts/updates can proceed before the migration is applied. */

--- a/supabase/functions/slack-poke/index.ts
+++ b/supabase/functions/slack-poke/index.ts
@@ -287,7 +287,10 @@ export async function createNewRound(
     const missingSortOrder =
       !!error &&
       (error.message?.includes('sort_order') ?? false) &&
-      (error.code === '42703' || (error.message?.includes('does not exist') ?? false));
+      (error.code === '42703' ||
+        error.code === 'PGRST204' ||
+        (error.message?.includes('does not exist') ?? false) ||
+        (error.message?.includes('schema cache') ?? false));
     if (missingSortOrder) {
       const { sort_order: _ignored, ...withoutSortOrder } = roundRow;
       ({ data: newRound, error } = await supabase


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Resolves the client-side fallout for **DUN-62**: changing poker round/ticket order fails with PostgREST `PGRST204` because production does not have `poker_session_rounds.sort_order` yet.

Verified against production (`nwfwbjmzbwuyxehindpv`):
- `SELECT sort_order` → Postgres `42703` (column does not exist)
- `PATCH { sort_order }` → `PGRST204` (“Could not find the 'sort_order' column … in the schema cache”) — matches the issue report

## Root cause
DUN-60 (#156) added reordering + migration `20260806170000_poker_session_rounds_sort_order.sql`, but that migration has not been applied on production. DUN-61 (#157) handled the `42703` read/insert path; reorder `PATCH`es hit `PGRST204`, which the missing-column detector did not recognize.

## Changes
- Treat PostgREST `PGRST204` / “schema cache” messages about `sort_order` as a missing-column error (same toast: “Ticket reorder requires a database update”).
- Mirror the same check in the Slack poke edge function insert retry path.
- Unit coverage for the `PGRST204` shape from the issue.

## Deploy note (required to make reorder work)
This PR only improves the error handling. **Ticket reorder will keep failing until the migration is applied on production.**

Run `supabase/migrations/20260806170000_poker_session_rounds_sort_order.sql` in the Supabase SQL Editor for project `nwfwbjmzbwuyxehindpv`. If needed after DDL, reload the PostgREST schema cache.

## Testing
- `npx vitest run src/lib/pokerRoundSortOrder.test.ts` (12 passed)
- `npx tsc --noEmit -p tsconfig.app.json`
- Reproduced production `PATCH … sort_order` → `PGRST204`

Linear Issue: [DUN-62](https://linear.app/dungeon-dwellers/issue/DUN-62/error-changing-order-of-poker-rounds)

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-62](https://linear.app/dungeon-dwellers/issue/DUN-62/error-changing-order-of-poker-rounds)

<div><a href="https://cursor.com/agents/bc-6616d83f-8395-47fc-bed6-3b0569f91126?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6616d83f-8395-47fc-bed6-3b0569f91126&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

