### PR TITLE
fix(retro): assign action items created in the current board (DUN-64 / #90)

### DIFF
--- a/src/hooks/useRetroBoard.ts
+++ b/src/hooks/useRetroBoard.ts
@@ -655,7 +655,7 @@ export const useRetroBoard = (roomId: string) => {
     try {
       const targetColumn = columns.find(c => c.id === columnId);
       if (newItem && targetColumn?.is_action_items && board.team_id) {
-        await supabase
+        const { data: actionItem, error: actionError } = await supabase
           .from('team_action_items')
           .insert([{
             team_id: board.team_id,
@@ -663,7 +663,24 @@ export const useRetroBoard = (roomId: string) => {
             source_board_id: board.id,
             source_item_id: newItem.id,
             created_by: effectiveAuthorId
-          }]);
+          }])
+          .select('id')
+          .single();
+
+        if (actionError) {
+          console.error('Error creating team action item:', actionError);
+          toast({
+            title: 'Error creating action item',
+            description: 'The card was added, but assignment may not work until you refresh.',
+            variant: 'destructive',
+          });
+        } else if (actionItem) {
+          // Keep local status in sync so assign/done work immediately (don't wait on realtime)
+          setBoardActionStatus(prev => ({
+            ...prev,
+            [newItem.id]: { id: actionItem.id, done: false, assigned_to: null },
+          }));
+        }
       }
     } catch (e) {
       console.error('Error creating team action item:', e);
@@ -687,75 +704,158 @@ export const useRetroBoard = (roomId: string) => {
     }
   };
 
+  const resolveBoardActionLink = async (
+    sourceItemId: string
+  ): Promise<{ id: string; done: boolean; assigned_to?: string | null } | null> => {
+    const existingLink = boardActionStatus[sourceItemId];
+    if (existingLink) return existingLink;
+
+    const { data: existing, error: lookupError } = await supabase
+      .from('team_action_items')
+      .select('id, done, assigned_to')
+      .eq('source_item_id', sourceItemId)
+      .maybeSingle();
+
+    if (lookupError) {
+      console.error('Error looking up team action item:', lookupError);
+      return null;
+    }
+
+    if (existing) {
+      const link = { id: existing.id, done: !!existing.done, assigned_to: existing.assigned_to };
+      setBoardActionStatus(prev => ({ ...prev, [sourceItemId]: link }));
+      return link;
+    }
+
+    return null;
+  };
+
   const toggleBoardActionItemDone = async (sourceItemId: string, nextDone: boolean) => {
-    // Find linked action item id
-    const link = boardActionStatus[sourceItemId];
-    const actionId = link?.id;
-    if (!actionId && nextDone) {
+    let link = await resolveBoardActionLink(sourceItemId);
+
+    if (!link && nextDone) {
       // If no action record exists but toggling to done from board, create one linked to this item
       const targetItem = items.find(i => i.id === sourceItemId);
       if (board?.team_id && targetItem) {
         const { data, error } = await supabase
           .from('team_action_items')
-          .insert([{ team_id: board.team_id, text: targetItem.text, source_board_id: board.id, source_item_id: sourceItemId, created_by: profile?.id || null, done: true, done_at: new Date().toISOString(), done_by: profile?.id || null }])
+          .insert([{
+            team_id: board.team_id,
+            text: targetItem.text,
+            source_board_id: board.id,
+            source_item_id: sourceItemId,
+            created_by: profile?.id || null,
+            done: true,
+            done_at: new Date().toISOString(),
+            done_by: profile?.id || null,
+          }])
           .select('id')
           .single();
-        if (!error && data) {
-          setBoardActionStatus(prev => ({ ...prev, [sourceItemId]: { id: data.id, done: true } }));
+        if (error || !data) {
+          // Unique race: another client may have created it — look up and update instead
+          const raced = await resolveBoardActionLink(sourceItemId);
+          if (!raced) {
+            console.error('Error creating team action item:', error);
+            toast({ title: 'Error updating action item', variant: 'destructive' });
+            return;
+          }
+          link = raced;
+        } else {
+          link = { id: data.id, done: true, assigned_to: null };
+          setBoardActionStatus(prev => ({ ...prev, [sourceItemId]: link! }));
+          return;
         }
-        return;
       }
-      return;
     }
 
-    if (!actionId) return;
+    if (!link) return;
+
+    const actionId = link.id;
+    const previous = { ...link };
 
     // Optimistic update
-    setBoardActionStatus(prev => ({ ...prev, [sourceItemId]: { id: actionId, done: nextDone } }));
+    setBoardActionStatus(prev => ({
+      ...prev,
+      [sourceItemId]: { ...link!, done: nextDone },
+    }));
     const { error } = await supabase
       .from('team_action_items')
-      .update({ done: nextDone, done_at: nextDone ? new Date().toISOString() : null, done_by: nextDone ? (profile?.id || null) : null })
+      .update({
+        done: nextDone,
+        done_at: nextDone ? new Date().toISOString() : null,
+        done_by: nextDone ? (profile?.id || null) : null,
+      })
       .eq('id', actionId);
     if (error) {
-      // Revert
-      setBoardActionStatus(prev => ({ ...prev, [sourceItemId]: { id: actionId, done: !nextDone } }));
+      setBoardActionStatus(prev => ({ ...prev, [sourceItemId]: previous }));
       toast({ title: 'Error updating action item', variant: 'destructive' });
     }
   };
 
   const assignTeamActionItem = async (actionItemId: string, userId: string | null) => {
     // Optimistic update for Open Action Items list
+    const previous = teamActionItems;
     setTeamActionItems(prev => prev.map(a => a.id === actionItemId ? { ...a, assigned_to: userId } : a));
     const { error } = await supabase
       .from('team_action_items')
       .update({ assigned_to: userId })
       .eq('id', actionItemId);
     if (error) {
+      setTeamActionItems(previous);
       toast({ title: 'Error assigning action item', variant: 'destructive' });
     }
   };
 
   const assignBoardActionItem = async (sourceItemId: string, userId: string | null) => {
-    const link = boardActionStatus[sourceItemId];
+    let link = await resolveBoardActionLink(sourceItemId);
+
     if (!link) {
       const targetItem = items.find(i => i.id === sourceItemId);
-      if (board?.team_id && targetItem) {
-        const { data, error } = await supabase
-          .from('team_action_items')
-          .insert([{ team_id: board.team_id, text: targetItem.text, source_board_id: board.id, source_item_id: sourceItemId, created_by: profile?.id || null, assigned_to: userId ?? null }])
-          .select('id')
-          .single();
-        if (!error && data) {
-          setBoardActionStatus(prev => ({ ...prev, [sourceItemId]: { id: data.id, done: false, assigned_to: userId ?? null } }));
-        }
+      if (!board?.team_id || !targetItem) return;
+
+      const { data, error } = await supabase
+        .from('team_action_items')
+        .insert([{
+          team_id: board.team_id,
+          text: targetItem.text,
+          source_board_id: board.id,
+          source_item_id: sourceItemId,
+          created_by: profile?.id || null,
+          assigned_to: userId ?? null,
+        }])
+        .select('id')
+        .single();
+
+      if (!error && data) {
+        setBoardActionStatus(prev => ({
+          ...prev,
+          [sourceItemId]: { id: data.id, done: false, assigned_to: userId ?? null },
+        }));
+        return;
       }
-      return;
+
+      // Unique constraint race: row already exists — look up and update instead
+      link = await resolveBoardActionLink(sourceItemId);
+      if (!link) {
+        console.error('Error assigning action item:', error);
+        toast({ title: 'Error assigning action item', variant: 'destructive' });
+        return;
+      }
     }
-    setBoardActionStatus(prev => ({ ...prev, [sourceItemId]: { ...prev[sourceItemId], assigned_to: userId ?? null } }));
-    await supabase
+
+    const previous = { ...link };
+    setBoardActionStatus(prev => ({
+      ...prev,
+      [sourceItemId]: { ...link!, assigned_to: userId ?? null },
+    }));
+    const { error } = await supabase
       .from('team_action_items')
       .update({ assigned_to: userId ?? null })
       .eq('id', link.id);
+    if (error) {
+      setBoardActionStatus(prev => ({ ...prev, [sourceItemId]: previous }));
+      toast({ title: 'Error assigning action item', variant: 'destructive' });
+    }
   };
 
   const addColumn = async (title: string) => {

--- a/supabase/migrations/20260807034400_team_action_items_member_update_policy.sql
+++ b/supabase/migrations/20260807034400_team_action_items_member_update_policy.sql
@@ -1,0 +1,28 @@
+-- Allow any team member to update action items on their team.
+-- Previous policy only allowed the current assignee, team admins/owners, or global admins,
+-- which blocked assigning unassigned items (assigned_to IS NULL) for normal members.
+
+DROP POLICY IF EXISTS "Users can update action items assigned to them or team admins can update all"
+  ON public.team_action_items;
+
+CREATE POLICY "Team members can update team action items"
+ON public.team_action_items
+FOR UPDATE
+USING (
+  is_team_member(team_id, auth.uid())
+  OR EXISTS (
+    SELECT 1
+    FROM public.profiles p
+    WHERE p.id = auth.uid()
+      AND p.role = 'admin'
+  )
+)
+WITH CHECK (
+  is_team_member(team_id, auth.uid())
+  OR EXISTS (
+    SELECT 1
+    FROM public.profiles p
+    WHERE p.id = auth.uid()
+      AND p.role = 'admin'
+  )
+);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes [GitHub #90](https://github.com/justinloveless/retro-vote-sorter-board/issues/90) / Linear **DUN-64**: action items created in the current retro could not be assigned.

### Root cause
- Creating an action-item card inserted into `team_action_items` but never updated local `boardActionStatus`.
- Assign then fell back to another insert, hit the unique index on `source_item_id`, and failed with no toast — UI stayed on “Nobody”.
- Previous-retro items use `assignTeamActionItem` by id, so they still worked.

### Changes
1. **`useRetroBoard.ts`**
   - On create, `.select('id')` and populate `boardActionStatus` immediately.
   - Resolve missing links via select-by-`source_item_id` before insert; on unique races, look up and update.
   - Toast + optimistic revert on assign/done failures.
2. **RLS migration** — allow any team member to `UPDATE` their team’s action items (unassigned items were previously blocked for non-admins).

### Verification
- Reproduced on production (`ECXCYG`): new current-board action item assign reverted to Nobody; previous open items assigned fine.
- Code-level fix committed; production verification needs deploy + migration apply.

## Test plan
- [ ] Create a new action item in the current retro’s Action Items column
- [ ] Assign it to a teammate immediately — assignee should persist (not revert to Nobody)
- [ ] Mark it done / undo done
- [ ] Confirm previous-retro Open Action Items assign still works
- [ ] As a non-admin team member, assign an unassigned item (requires migration applied)
- [ ] Apply migration `20260807034400_team_action_items_member_update_policy.sql` to the target Supabase project

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-64](https://linear.app/dungeon-dwellers/issue/DUN-64/find-and-fix-one-issue)

<div><a href="https://cursor.com/agents/bc-455b8f09-c531-4612-8669-ff5d21e5dd35?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-455b8f09-c531-4612-8669-ff5d21e5dd35&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

