### PR TITLE
fix(poker): enlarge round reorder drag-handle hit area (DUN-67)

### DIFF
--- a/src/components/Neotro/RoundSelector.tsx
+++ b/src/components/Neotro/RoundSelector.tsx
@@ -708,11 +708,15 @@ export const RoundSelector: React.FC<RoundSelectorProps> = ({
                               moveStripItem(index, 1);
                             }
                           }}
-                          className="relative z-[1] inline-flex cursor-grab items-center px-1 active:cursor-grabbing touch-none text-muted-foreground hover:text-foreground"
+                          className="relative z-[2] inline-flex shrink-0 self-stretch cursor-grab items-center justify-center px-2.5 active:cursor-grabbing touch-none select-none text-muted-foreground hover:text-foreground"
                           aria-label={`Drag to reorder ${item.ticketKey}`}
                           title="Drag to reorder"
                         >
-                          <GripVertical className="h-3.5 w-3.5 pointer-events-none" />
+                          <span
+                            aria-hidden="true"
+                            className="absolute -inset-y-1 -left-1.5 -right-2.5"
+                          />
+                          <GripVertical className="relative h-3.5 w-3.5 pointer-events-none" />
                         </span>
                       )}
                       <button


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Enlarges the round-selector grip handle hit target so drag-to-reorder does not require clicking precisely on the grip dots.
- Handle now stretches to full chip height, uses wider padding, and includes an invisible absolute region around the icon (including a little overlap toward the ticket label).

## Test plan
- [x] Open a poker session as a participant who can reorder rounds
- [x] Confirm the grip handle still appears on each reorderable chip
- [x] Click/drag starting slightly around the grip (not only on the dots) and verify reorder begins
- [x] Confirm clicking the ticket key still selects the round (not stolen by the handle except at the immediate edge)
- [ ] Confirm carousel horizontal swipe still works when not grabbing the handle

## Manual QA
Verified on a multi-round poker session with QA login. Grip hover shows grab cursor / “Drag to reorder” in a wider region (~50×36px hit box); drag starts from near the dots (not only on painted pixels); ticket-key click still selects the round.

![Grip handle with drag tooltip](https://cursor.com/artifacts/c/art-87639f58-c732-4ca1-9a3e-f2cbac530041)
![DevTools hit area for expanded grip handle](https://cursor.com/artifacts/c/art-3eb59fab-95e5-4a25-8443-d6db7e75a5aa)
![Round selector grip handles](https://cursor.com/artifacts/c/art-dd53d929-a4de-4bb8-85d6-4897fc7ab566)

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-67](https://linear.app/dungeon-dwellers/issue/DUN-67/drag-to-reorder-handles)

<div><a href="https://cursor.com/agents/bc-27de5a6f-ac8a-421d-bf33-73599e9164f7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27de5a6f-ac8a-421d-bf33-73599e9164f7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

