### PR TITLE
docs: Linear GitHub issue sync for Retroscope (DUN-68)

### DIFF
--- a/.github/workflows/sync-github-issue-to-linear.yml
+++ b/.github/workflows/sync-github-issue-to-linear.yml
@@ -1,0 +1,106 @@
+# Optional alternative to Linear's native GitHub Issues Sync.
+# Creates a Linear issue on the Retroscope project when a GitHub issue is opened.
+#
+# Prefer native sync when possible (see documentation/plans/linear-github-issue-sync.md).
+# Do not enable this workflow AND native Issues Sync for the same repo (duplicates).
+#
+# Required secret: LINEAR_API_KEY
+# Optional vars:   LINEAR_TEAM_KEY (default DUN), LINEAR_PROJECT_NAME (default Retroscope)
+
+name: Sync GitHub issue to Linear
+
+on:
+  issues:
+    types: [opened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: GitHub issue number to sync
+        required: true
+        type: string
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  create-linear-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Ensure LINEAR_API_KEY is configured
+        env:
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+        run: |
+          if [ -z "${LINEAR_API_KEY}" ]; then
+            echo "::error::LINEAR_API_KEY secret is not set. Add it under repo Settings → Secrets, or use Linear's native GitHub Issues Sync instead (see documentation/plans/linear-github-issue-sync.md)."
+            exit 1
+          fi
+
+      - name: Resolve issue payload
+        id: issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const number = context.eventName === 'workflow_dispatch'
+              ? Number('${{ inputs.issue_number }}')
+              : context.payload.issue.number;
+            const { data: issue } = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+            });
+            if (issue.pull_request) {
+              core.setFailed('Refusing to sync pull requests as issues');
+              return;
+            }
+            core.setOutput('number', String(issue.number));
+            core.setOutput('title', issue.title);
+            // Multilines must be escaped for GITHUB_OUTPUT consumers
+            core.setOutput('body', issue.body || '');
+            core.setOutput('url', issue.html_url);
+
+      - name: Create Linear issue
+        id: linear
+        env:
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+          LINEAR_TEAM_KEY: ${{ vars.LINEAR_TEAM_KEY }}
+          LINEAR_PROJECT_NAME: ${{ vars.LINEAR_PROJECT_NAME }}
+          GITHUB_ISSUE_TITLE: ${{ steps.issue.outputs.title }}
+          GITHUB_ISSUE_BODY: ${{ steps.issue.outputs.body }}
+          GITHUB_ISSUE_URL: ${{ steps.issue.outputs.url }}
+          GITHUB_ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Script defaults team/project when vars are empty
+          OUTPUT=$(node scripts/create-linear-issue-from-github.mjs)
+          echo "$OUTPUT"
+          IDENTIFIER=$(printf '%s' "$OUTPUT" | node -e "let s='';process.stdin.on('data',d=>s+=d);process.stdin.on('end',()=>{const j=JSON.parse(s);process.stdout.write(j.issue.identifier)})")
+          URL=$(printf '%s' "$OUTPUT" | node -e "let s='';process.stdin.on('data',d=>s+=d);process.stdin.on('end',()=>{const j=JSON.parse(s);process.stdout.write(j.issue.url)})")
+          {
+            echo "identifier=$IDENTIFIER"
+            echo "url=$URL"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Comment Linear link on GitHub issue
+        if: steps.linear.outputs.identifier != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const number = Number('${{ steps.issue.outputs.number }}');
+            const identifier = '${{ steps.linear.outputs.identifier }}';
+            const url = '${{ steps.linear.outputs.url }}';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+              body: `Tracked in Linear as [${identifier}](${url}).`,
+            });

--- a/documentation/plans/linear-github-issue-sync.md
+++ b/documentation/plans/linear-github-issue-sync.md
@@ -1,0 +1,114 @@
+# Linear ← GitHub issue creation (DUN-68)
+
+## Goal
+
+Whenever a GitHub issue is created on `justinloveless/retro-vote-sorter-board`, automatically create a corresponding Linear issue on the **Retroscope** project (DUN team).
+
+## Verdict
+
+**Yes — this is supported natively by Linear**, with no repo code required for the core flow.
+
+Linear’s **GitHub Issues Sync** maps a GitHub repository to a Linear **team**. New GitHub issues create synced Linear issues going forward (historical issues need a separate import).
+
+Native sync targets a **team**, not a **project**. Retroscope is a Linear project, so after sync is enabled you either:
+
+1. Manually (or via Triage) put synced issues on Retroscope, or
+2. Use a Triage rule / custom GitHub Action to set `project = Retroscope` automatically.
+
+## Recommended approach: Linear GitHub Issues Sync (one-way)
+
+Prefer this unless you need project assignment without a Business/Enterprise Triage plan.
+
+### Why this approach
+
+- Official, maintained by Linear
+- Bi-directional comments/status/labels/assignee on the synced issue thread
+- No API keys or workflow maintenance in this repo
+- Available on all Linear plans for the sync itself
+
+### Setup (Linear admin + GitHub admin)
+
+1. Open [Linear → Settings → Integrations → GitHub](https://linear.app/settings/integrations/github).
+2. Enable/install the Linear GitHub app if it is not already installed.
+3. Grant the app access to `justinloveless/retro-vote-sorter-board` (repo admin or org owner).
+4. Under **GitHub Issues**, click **+**.
+5. Select:
+   - **Repository:** `justinloveless/retro-vote-sorter-board`
+   - **Linear team:** DUN (Dungeon Dwellers)
+   - **Direction:** **One-way** (GitHub → Linear)
+6. Save.
+
+Docs: [Configure GitHub Issues Sync](https://linear.app/docs/github#configure-github-issues-sync)
+
+### Put synced issues on the Retroscope project
+
+Native sync does **not** let you pick a Linear project in the mapping UI. Options:
+
+| Method | Notes |
+| --- | --- |
+| **Triage rule** | Team Settings → Triage → Rules. When issues enter Triage from the GitHub sync, set **Project = Retroscope**. Requires Business/Enterprise. |
+| **Triage Intelligence** | Can suggest/auto-apply project. Business/Enterprise. |
+| **Manual accept** | Accept from Triage and set project Retroscope. Works on all plans. |
+| **Custom Action (this PR)** | Creates Linear issues with `projectId` set to Retroscope via the Linear API. Use only if you are **not** using native sync (to avoid duplicates). |
+
+### Important limitations
+
+- Sync applies to **newly created** GitHub issues only. Import existing ones via [GitHub Issues Importer](https://linear.app/docs/github-to-linear) if needed.
+- One-way: multiple GitHub repos can feed one Linear team.
+- Two-way: a Linear team can sync with only **one** GitHub repo at a time. Prefer one-way unless you need Linear→GitHub creation.
+- Only one Linear workspace can be connected to a given GitHub organization (GitHub App install limit).
+- Custom GitHub Project statuses do not map into Linear workflow states.
+
+### Properties that sync
+
+Title, description, status (open/closed), assignee (when personal GitHub accounts are linked), labels, sub-issues, and comments in the synced thread.
+
+## Alternative: GitHub Action → Linear API
+
+Use this when you need issues created **directly on the Retroscope project** and do not want native sync (or Triage rules are unavailable).
+
+Workflow: `.github/workflows/sync-github-issue-to-linear.yml`  
+Script: `scripts/create-linear-issue-from-github.mjs`
+
+### Required GitHub secrets / vars
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `LINEAR_API_KEY` | Secret | Personal API key from Linear → Settings → Account → Security & access → Personal API keys |
+| `LINEAR_TEAM_KEY` | Variable (optional) | Defaults to `DUN` |
+| `LINEAR_PROJECT_NAME` | Variable (optional) | Defaults to `Retroscope` |
+
+Do **not** enable this workflow while native GitHub Issues Sync is also creating Linear issues for the same repo, or you will get duplicates.
+
+### Behavior
+
+On `issues: opened`:
+
+1. Resolve team by key (`DUN`) and project by name (`Retroscope`).
+2. Create a Linear issue with title/body from the GitHub issue, including a link back to GitHub.
+3. Comment on the GitHub issue with the new Linear identifier/URL (best-effort).
+
+This path creates a Linear issue; it does **not** establish Linear’s native synced-comment attachment unless you later link them manually.
+
+## Recommendation for Retroscope
+
+1. Enable **one-way** GitHub Issues Sync for `retro-vote-sorter-board` → DUN.
+2. If the workspace has Triage rules: auto-set **Project = Retroscope**.
+3. If not: either accept into Retroscope manually, or enable the Action in this PR and leave native Issues Sync **off** for this repo.
+
+## Verification checklist
+
+After enabling native sync (or the Action):
+
+1. Open a throwaway GitHub issue on `retro-vote-sorter-board`.
+2. Confirm a Linear issue appears on team DUN within a minute or two.
+3. Confirm it is (or gets) on project **Retroscope**.
+4. Close the GitHub issue and confirm Linear status updates (native sync only).
+5. Delete/cancel the throwaway issues.
+
+## References
+
+- [Linear GitHub docs](https://linear.app/docs/github)
+- [GitHub Issues Sync overview](https://linear.app/integrations/github)
+- [Import / sync options](https://linear.app/docs/github-to-linear)
+- [Triage rules](https://linear.app/docs/triage#triage-rules)

--- a/scripts/create-linear-issue-from-github.mjs
+++ b/scripts/create-linear-issue-from-github.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+/**
+ * Create a Linear issue (Retroscope project by default) from a GitHub issue payload.
+ *
+ * Env:
+ *   LINEAR_API_KEY          (required)
+ *   LINEAR_TEAM_KEY         (default: DUN)
+ *   LINEAR_PROJECT_NAME     (default: Retroscope)
+ *   GITHUB_ISSUE_TITLE      (required unless --dry-run with fixtures)
+ *   GITHUB_ISSUE_BODY
+ *   GITHUB_ISSUE_URL
+ *   GITHUB_ISSUE_NUMBER
+ *   GITHUB_REPOSITORY
+ *
+ * CLI:
+ *   --dry-run   Resolve IDs / print mutation input without creating
+ */
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const LINEAR_API = "https://api.linear.app/graphql";
+
+function env(name, fallback) {
+  const value = process.env[name];
+  if (value == null || value === "") return fallback;
+  return value;
+}
+
+async function linearGraphQL(apiKey, query, variables = {}) {
+  const res = await fetch(LINEAR_API, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: apiKey,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error(`Linear HTTP ${res.status}: ${JSON.stringify(json)}`);
+  }
+  if (json.errors?.length) {
+    throw new Error(`Linear GraphQL errors: ${JSON.stringify(json.errors)}`);
+  }
+  return json.data;
+}
+
+export function buildIssueDescription({ body, issueUrl, issueNumber, repository }) {
+  const parts = [];
+  if (body?.trim()) parts.push(body.trim());
+  parts.push("---");
+  parts.push(`Synced from GitHub issue [#${issueNumber}](${issueUrl}) in \`${repository}\`.`);
+  return parts.join("\n\n");
+}
+
+export async function resolveTeamAndProject(apiKey, { teamKey, projectName }) {
+  const data = await linearGraphQL(
+    apiKey,
+    `
+    query ResolveTeamProject($teamKey: String!) {
+      teams(filter: { key: { eq: $teamKey } }) {
+        nodes {
+          id
+          key
+          name
+          projects {
+            nodes {
+              id
+              name
+            }
+          }
+        }
+      }
+    }
+    `,
+    { teamKey }
+  );
+
+  const team = data.teams?.nodes?.[0];
+  if (!team) {
+    throw new Error(`No Linear team found with key "${teamKey}"`);
+  }
+
+  const project = (team.projects?.nodes || []).find(
+    (p) => p.name.toLowerCase() === projectName.toLowerCase()
+  );
+  if (!project) {
+    const available = (team.projects?.nodes || []).map((p) => p.name).join(", ") || "(none)";
+    throw new Error(
+      `No project named "${projectName}" on team ${team.key}. Available: ${available}`
+    );
+  }
+
+  return { team, project };
+}
+
+export async function createLinearIssue(apiKey, input) {
+  const data = await linearGraphQL(
+    apiKey,
+    `
+    mutation IssueCreate($input: IssueCreateInput!) {
+      issueCreate(input: $input) {
+        success
+        issue {
+          id
+          identifier
+          url
+          title
+        }
+      }
+    }
+    `,
+    { input }
+  );
+
+  if (!data.issueCreate?.success || !data.issueCreate.issue) {
+    throw new Error(`issueCreate failed: ${JSON.stringify(data)}`);
+  }
+  return data.issueCreate.issue;
+}
+
+async function main() {
+  const dryRun = process.argv.includes("--dry-run");
+  const apiKey = env("LINEAR_API_KEY");
+  const teamKey = env("LINEAR_TEAM_KEY", "DUN");
+  const projectName = env("LINEAR_PROJECT_NAME", "Retroscope");
+  const title = env("GITHUB_ISSUE_TITLE");
+  const body = env("GITHUB_ISSUE_BODY", "");
+  const issueUrl = env("GITHUB_ISSUE_URL", "");
+  const issueNumber = env("GITHUB_ISSUE_NUMBER", "");
+  const repository = env("GITHUB_REPOSITORY", "justinloveless/retro-vote-sorter-board");
+
+  if (!apiKey) {
+    console.error("LINEAR_API_KEY is required");
+    process.exit(1);
+  }
+  if (!title) {
+    console.error("GITHUB_ISSUE_TITLE is required");
+    process.exit(1);
+  }
+
+  const { team, project } = await resolveTeamAndProject(apiKey, { teamKey, projectName });
+  const input = {
+    teamId: team.id,
+    projectId: project.id,
+    title,
+    description: buildIssueDescription({ body, issueUrl, issueNumber, repository }),
+  };
+
+  if (dryRun) {
+    console.log(
+      JSON.stringify(
+        {
+          dryRun: true,
+          team: { id: team.id, key: team.key, name: team.name },
+          project: { id: project.id, name: project.name },
+          input,
+        },
+        null,
+        2
+      )
+    );
+    return;
+  }
+
+  const issue = await createLinearIssue(apiKey, input);
+  console.log(JSON.stringify({ success: true, issue }, null, 2));
+}
+
+const isDirectRun =
+  !!process.argv[1] &&
+  path.resolve(fileURLToPath(import.meta.url)) === path.resolve(process.argv[1]);
+
+if (isDirectRun) {
+  main().catch((err) => {
+    console.error(err.message || err);
+    process.exit(1);
+  });
+}

--- a/scripts/create-linear-issue-from-github.test.mjs
+++ b/scripts/create-linear-issue-from-github.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { buildIssueDescription } from "./create-linear-issue-from-github.mjs";
+
+const withBody = buildIssueDescription({
+  body: "Something broke in poker.",
+  issueUrl: "https://github.com/justinloveless/retro-vote-sorter-board/issues/999",
+  issueNumber: "999",
+  repository: "justinloveless/retro-vote-sorter-board",
+});
+
+assert.match(withBody, /Something broke in poker/);
+assert.match(
+  withBody,
+  /\[#999\]\(https:\/\/github\.com\/justinloveless\/retro-vote-sorter-board\/issues\/999\)/
+);
+assert.match(withBody, /justinloveless\/retro-vote-sorter-board/);
+
+const emptyBody = buildIssueDescription({
+  body: "   ",
+  issueUrl: "https://example.com/issues/1",
+  issueNumber: "1",
+  repository: "org/repo",
+});
+assert.equal(
+  emptyBody,
+  "---\n\nSynced from GitHub issue [#1](https://example.com/issues/1) in `org/repo`."
+);
+
+console.log("create-linear-issue-from-github.test.mjs: ok");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Investigates DUN-68: automatically create a Linear issue on the **Retroscope** project when a GitHub issue is opened on `justinloveless/retro-vote-sorter-board`.

**Verdict: yes — use Linear’s native GitHub Issues Sync (one-way).**

Native sync maps a GitHub repo → Linear **team** (DUN). It does not select a Linear **project** in the mapping UI, so Retroscope assignment is a follow-up via Triage rules or the optional Action in this PR.

## What’s in this PR

- `documentation/plans/linear-github-issue-sync.md` — findings, setup steps, limitations, verification checklist
- Optional GitHub Action + script if you need `projectId = Retroscope` without Triage rules:
  - `.github/workflows/sync-github-issue-to-linear.yml`
  - `scripts/create-linear-issue-from-github.mjs`
- Unit test for description formatting

## Recommended next step (admin UI)

1. Linear → Settings → Integrations → GitHub
2. Ensure app access to `retro-vote-sorter-board`
3. GitHub Issues → `+` → repo → **DUN** → **One-way**
4. Optional: Triage rule → set Project = Retroscope

Do **not** enable both native Issues Sync and the Action for the same repo (duplicates).

## Test plan

- [x] `node scripts/create-linear-issue-from-github.test.mjs`
- [ ] Admin enables native sync (or adds `LINEAR_API_KEY` for the Action)
- [ ] Open a throwaway GitHub issue and confirm a DUN/Retroscope Linear issue appears
- [ ] Clean up throwaway issues

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-68](https://linear.app/dungeon-dwellers/issue/DUN-68/linear-integration-with-github-issue-creation)

<div><a href="https://cursor.com/agents/bc-dc7cf3e5-262e-4b36-89c3-48a72a058fd6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc7cf3e5-262e-4b36-89c3-48a72a058fd6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

