### PR TITLE
feat(retro): show who voted on each retro item (DUN-69)

### DIFF
--- a/src/components/RetroBoard.tsx
+++ b/src/components/RetroBoard.tsx
@@ -63,6 +63,7 @@ export const RetroBoard: React.FC<RetroBoardProps> = ({
     sessionId,
     presenceChannel,
     userVotes,
+    votersByItemId,
     teamActionItems,
     boardActionStatus,
     audioSummaryState,
@@ -318,6 +319,7 @@ export const RetroBoard: React.FC<RetroBoardProps> = ({
               columnColor={focusedColumn.color}
               voteCount={focusedItem.votes}
               voteEmoji={boardConfig?.vote_emoji}
+              voters={votersByItemId[focusedItem.id] || []}
               comments={getCommentsForItem(focusedItem.id)}
               userName={userName}
               currentUserId={user?.id}
@@ -377,6 +379,7 @@ export const RetroBoard: React.FC<RetroBoardProps> = ({
                 isArchived={isArchived}
                 sessionId={sessionId}
                 userVotes={userVotes}
+                votersByItemId={votersByItemId}
                 audioSummaryState={audioSummaryState}
                 updateAudioSummaryState={updateAudioSummaryState}
                 teamMembers={teamMembers}

--- a/src/components/retro/FocusedCardBanner.tsx
+++ b/src/components/retro/FocusedCardBanner.tsx
@@ -6,7 +6,7 @@ import { RetroItemComments } from '../RetroItemComments';
 import { RICH_TEXT_DISPLAY_CLASS } from '@/lib/richTextDisplay';
 import { cn } from '@/lib/utils';
 import type { ItemVoter } from '@/hooks/useRetroBoard';
-import { VoterAvatarStack } from './VoterAvatarStack';
+import { VotersTooltip } from './VoterAvatarStack';
 
 interface RetroComment {
   id: string;
@@ -164,12 +164,11 @@ export const FocusedCardBanner: React.FC<FocusedCardBannerProps> = ({
               <span className="text-xs text-muted-foreground">
                 by {itemAuthor}
               </span>
-              <span className="text-xs text-muted-foreground flex items-center gap-1">
-                {voteEmoji || '👍'} {voteCount}
-              </span>
-              {voters.length > 0 && (
-                <VoterAvatarStack voters={voters} maxVisible={6} sizeClassName="h-5 w-5" />
-              )}
+              <VotersTooltip voters={voters}>
+                <span className="text-xs text-muted-foreground flex items-center gap-1 cursor-default">
+                  {voteEmoji || '👍'} {voteCount}
+                </span>
+              </VotersTooltip>
             </div>
             <div
               className={cn('text-sm text-foreground prose dark:prose-invert max-w-none', RICH_TEXT_DISPLAY_CLASS)}

--- a/src/components/retro/FocusedCardBanner.tsx
+++ b/src/components/retro/FocusedCardBanner.tsx
@@ -5,6 +5,8 @@ import { processRichTextForDisplay } from '../shared/TiptapEditorWithMentions';
 import { RetroItemComments } from '../RetroItemComments';
 import { RICH_TEXT_DISPLAY_CLASS } from '@/lib/richTextDisplay';
 import { cn } from '@/lib/utils';
+import type { ItemVoter } from '@/hooks/useRetroBoard';
+import { VoterAvatarStack } from './VoterAvatarStack';
 
 interface RetroComment {
   id: string;
@@ -95,6 +97,7 @@ interface FocusedCardBannerProps {
   columnColor: string;
   voteCount: number;
   voteEmoji?: string | null;
+  voters?: ItemVoter[];
   comments: RetroComment[];
   userName: string;
   currentUserId?: string;
@@ -120,6 +123,7 @@ export const FocusedCardBanner: React.FC<FocusedCardBannerProps> = ({
   columnColor,
   voteCount,
   voteEmoji,
+  voters = [],
   comments,
   userName,
   currentUserId,
@@ -163,6 +167,9 @@ export const FocusedCardBanner: React.FC<FocusedCardBannerProps> = ({
               <span className="text-xs text-muted-foreground flex items-center gap-1">
                 {voteEmoji || '👍'} {voteCount}
               </span>
+              {voters.length > 0 && (
+                <VoterAvatarStack voters={voters} maxVisible={6} sizeClassName="h-5 w-5" />
+              )}
             </div>
             <div
               className={cn('text-sm text-foreground prose dark:prose-invert max-w-none', RICH_TEXT_DISPLAY_CLASS)}

--- a/src/components/retro/RetroColumn.tsx
+++ b/src/components/retro/RetroColumn.tsx
@@ -12,8 +12,9 @@ import { UserAvatar } from '../ui/UserAvatar';
 import { useFeatureFlags } from '@/contexts/FeatureFlagContext';
 
 
-import { AudioSummaryState, RetroStage } from '@/hooks/useRetroBoard';
+import { AudioSummaryState, ItemVoter, RetroStage } from '@/hooks/useRetroBoard';
 import { SummaryButton } from './SummaryButton';
+import { VoterAvatarStack } from './VoterAvatarStack';
 import { TiptapEditorWithMentions, processRichTextForDisplay } from '../shared/TiptapEditorWithMentions';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { RICH_TEXT_DISPLAY_CLASS } from '@/lib/richTextDisplay';
@@ -78,6 +79,7 @@ interface RetroColumnProps {
   isArchived: boolean;
   sessionId?: string | null;
   userVotes: string[];
+  votersByItemId?: Record<string, ItemVoter[]>;
   teamMembers?: TeamMember[];
   previousActionItems?: { id: string; text: string }[];
   onMarkActionItemDone?: (id: string) => void;
@@ -233,6 +235,18 @@ const canFocusItem = (stage: RetroStage | null, boardConfig: any): boolean => {
   return stage === 'discussing';
 };
 
+/** Show voter identities after voting (or when stages are off / board archived). */
+const canShowVoters = (
+  stage: RetroStage | null,
+  boardConfig: any,
+  isArchived: boolean
+): boolean => {
+  if (isArchived) return true;
+  if (!isRetroStagesEnabled(boardConfig)) return true;
+  if (!stage) return true;
+  return stage === 'discussing' || stage === 'closed';
+};
+
 export const RetroColumn: React.FC<RetroColumnProps> = ({
   board,
   column,
@@ -249,6 +263,7 @@ export const RetroColumn: React.FC<RetroColumnProps> = ({
   isArchived,
   sessionId,
   userVotes,
+  votersByItemId = {},
   teamMembers,
   onAddItem,
   onUpdateColumn,
@@ -481,6 +496,9 @@ export const RetroColumn: React.FC<RetroColumnProps> = ({
                             )}
                             {item.votes}
                           </div>
+                        )}
+                        {canShowVoters(board?.retro_stage, boardConfig, isArchived) && (
+                          <VoterAvatarStack voters={votersByItemId[item.id] || []} />
                         )}
                       </div>
 

--- a/src/components/retro/RetroColumn.tsx
+++ b/src/components/retro/RetroColumn.tsx
@@ -14,7 +14,7 @@ import { useFeatureFlags } from '@/contexts/FeatureFlagContext';
 
 import { AudioSummaryState, ItemVoter, RetroStage } from '@/hooks/useRetroBoard';
 import { SummaryButton } from './SummaryButton';
-import { VoterAvatarStack } from './VoterAvatarStack';
+import { VotersTooltip } from './VoterAvatarStack';
 import { TiptapEditorWithMentions, processRichTextForDisplay } from '../shared/TiptapEditorWithMentions';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { RICH_TEXT_DISPLAY_CLASS } from '@/lib/richTextDisplay';
@@ -472,34 +472,37 @@ export const RetroColumn: React.FC<RetroColumnProps> = ({
                             className="h-6 w-6"
                           />
                         )}
-                        {/* Always show vote count, but only make clickable when voting is allowed */}
-                        {canVoteOnItem(board?.retro_stage, boardConfig, item, user, isAnonymousUser, sessionId) ? (
-                          <Button
-                            variant={userVotes.includes(item.id) ? 'default' : 'outline'}
-                            size="sm"
-                            onClick={() => onUpvoteItem(item.id)}
-                            className="flex items-center gap-1 h-auto px-2.5 py-0.5 rounded-full text-xs font-semibold"
-                          >
-                            {boardConfig?.vote_emoji ? (
-                              <span className="h-3 w-3 inline-flex items-center justify-center">{boardConfig.vote_emoji}</span>
-                            ) : (
-                              <ThumbsUp className="h-3 w-3" />
-                            )}
-                            {item.votes}
-                          </Button>
-                        ) : (
-                          <div className="flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-semibold bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400">
-                            {boardConfig?.vote_emoji ? (
-                              <span className="h-3 w-3 inline-flex items-center justify-center">{boardConfig.vote_emoji}</span>
-                            ) : (
-                              <ThumbsUp className="h-3 w-3" />
-                            )}
-                            {item.votes}
-                          </div>
-                        )}
-                        {canShowVoters(board?.retro_stage, boardConfig, isArchived) && (
-                          <VoterAvatarStack voters={votersByItemId[item.id] || []} />
-                        )}
+                        {/* Always show vote count, but only make clickable when voting is allowed.
+                            Voter names appear on hover when visibility is allowed for the stage. */}
+                        <VotersTooltip
+                          voters={votersByItemId[item.id] || []}
+                          enabled={canShowVoters(board?.retro_stage, boardConfig, isArchived)}
+                        >
+                          {canVoteOnItem(board?.retro_stage, boardConfig, item, user, isAnonymousUser, sessionId) ? (
+                            <Button
+                              variant={userVotes.includes(item.id) ? 'default' : 'outline'}
+                              size="sm"
+                              onClick={() => onUpvoteItem(item.id)}
+                              className="flex items-center gap-1 h-auto px-2.5 py-0.5 rounded-full text-xs font-semibold"
+                            >
+                              {boardConfig?.vote_emoji ? (
+                                <span className="h-3 w-3 inline-flex items-center justify-center">{boardConfig.vote_emoji}</span>
+                              ) : (
+                                <ThumbsUp className="h-3 w-3" />
+                              )}
+                              {item.votes}
+                            </Button>
+                          ) : (
+                            <div className="flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-semibold bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400 cursor-default">
+                              {boardConfig?.vote_emoji ? (
+                                <span className="h-3 w-3 inline-flex items-center justify-center">{boardConfig.vote_emoji}</span>
+                              ) : (
+                                <ThumbsUp className="h-3 w-3" />
+                              )}
+                              {item.votes}
+                            </div>
+                          )}
+                        </VotersTooltip>
                       </div>
 
                       {/* Row 2: Buttons */}

--- a/src/components/retro/VoterAvatarStack.tsx
+++ b/src/components/retro/VoterAvatarStack.tsx
@@ -1,54 +1,65 @@
 import React from 'react';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { UserAvatar } from '@/components/ui/UserAvatar';
 import type { ItemVoter } from '@/hooks/useRetroBoard';
 
-interface VoterAvatarStackProps {
+interface VotersTooltipProps {
   voters: ItemVoter[];
-  maxVisible?: number;
-  sizeClassName?: string;
+  /** When false, renders children without a voters tooltip. */
+  enabled?: boolean;
+  children: React.ReactNode;
 }
 
-export const VoterAvatarStack: React.FC<VoterAvatarStackProps> = ({
-  voters,
-  maxVisible = 5,
-  sizeClassName = 'h-6 w-6',
-}) => {
-  if (!voters.length) return null;
+const getInitials = (name: string) => {
+  if (!name) return 'A';
+  return name
+    .split(' ')
+    .map(n => n[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2);
+};
 
-  const visible = voters.slice(0, maxVisible);
-  const overflow = voters.slice(maxVisible);
+/**
+ * Wraps the vote counter and reveals who voted on hover.
+ */
+export const VotersTooltip: React.FC<VotersTooltipProps> = ({
+  voters,
+  enabled = true,
+  children,
+}) => {
+  if (!enabled || voters.length === 0) {
+    return <>{children}</>;
+  }
 
   return (
-    <TooltipProvider delayDuration={300}>
-      <div className="flex items-center -space-x-2" aria-label={`Voted by ${voters.map(v => v.name).join(', ')}`}>
-        {visible.map((voter) => (
-          <UserAvatar
-            key={voter.key}
-            name={voter.name}
-            avatarUrl={voter.avatarUrl}
-            className={`${sizeClassName} border-2 border-white dark:border-gray-800`}
-          />
-        ))}
-        {overflow.length > 0 && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <div
-                className={`flex items-center justify-center ${sizeClassName} rounded-full bg-gray-100 dark:bg-gray-700 border-2 border-white dark:border-gray-800 text-[10px] font-medium text-gray-600 dark:text-gray-300`}
-              >
-                +{overflow.length}
-              </div>
-            </TooltipTrigger>
-            <TooltipContent>
-              <div className="space-y-0.5">
-                {overflow.map((voter) => (
-                  <p key={voter.key}>{voter.name}</p>
-                ))}
-              </div>
-            </TooltipContent>
-          </Tooltip>
-        )}
-      </div>
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="inline-flex">{children}</span>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="max-w-xs p-2">
+          <p className="mb-1.5 text-xs font-medium text-muted-foreground">
+            Voted by
+          </p>
+          <ul className="space-y-1">
+            {voters.map((voter) => (
+              <li key={voter.key} className="flex items-center gap-2">
+                <Avatar className="h-5 w-5">
+                  <AvatarImage src={voter.avatarUrl ?? undefined} alt={voter.name} />
+                  <AvatarFallback className="text-[9px] bg-indigo-100 text-indigo-700 dark:bg-indigo-900 dark:text-indigo-300">
+                    {getInitials(voter.name)}
+                  </AvatarFallback>
+                </Avatar>
+                <span className="text-xs">{voter.name}</span>
+              </li>
+            ))}
+          </ul>
+        </TooltipContent>
+      </Tooltip>
     </TooltipProvider>
   );
 };
+
+/** @deprecated Prefer VotersTooltip; kept for any lingering imports. */
+export const VoterAvatarStack = VotersTooltip;

--- a/src/components/retro/VoterAvatarStack.tsx
+++ b/src/components/retro/VoterAvatarStack.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { UserAvatar } from '@/components/ui/UserAvatar';
+import type { ItemVoter } from '@/hooks/useRetroBoard';
+
+interface VoterAvatarStackProps {
+  voters: ItemVoter[];
+  maxVisible?: number;
+  sizeClassName?: string;
+}
+
+export const VoterAvatarStack: React.FC<VoterAvatarStackProps> = ({
+  voters,
+  maxVisible = 5,
+  sizeClassName = 'h-6 w-6',
+}) => {
+  if (!voters.length) return null;
+
+  const visible = voters.slice(0, maxVisible);
+  const overflow = voters.slice(maxVisible);
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <div className="flex items-center -space-x-2" aria-label={`Voted by ${voters.map(v => v.name).join(', ')}`}>
+        {visible.map((voter) => (
+          <UserAvatar
+            key={voter.key}
+            name={voter.name}
+            avatarUrl={voter.avatarUrl}
+            className={`${sizeClassName} border-2 border-white dark:border-gray-800`}
+          />
+        ))}
+        {overflow.length > 0 && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div
+                className={`flex items-center justify-center ${sizeClassName} rounded-full bg-gray-100 dark:bg-gray-700 border-2 border-white dark:border-gray-800 text-[10px] font-medium text-gray-600 dark:text-gray-300`}
+              >
+                +{overflow.length}
+              </div>
+            </TooltipTrigger>
+            <TooltipContent>
+              <div className="space-y-0.5">
+                {overflow.map((voter) => (
+                  <p key={voter.key}>{voter.name}</p>
+                ))}
+              </div>
+            </TooltipContent>
+          </Tooltip>
+        )}
+      </div>
+    </TooltipProvider>
+  );
+};

--- a/src/hooks/useRetroBoard.ts
+++ b/src/hooks/useRetroBoard.ts
@@ -84,9 +84,23 @@ interface RetroBoardConfig {
 
 interface ActiveUser {
   id: string;
+  user_id?: string;
   user_name: string;
   last_seen: string;
   avatar_url?: string;
+}
+
+export interface RetroVote {
+  id: string;
+  item_id: string;
+  user_id: string | null;
+  session_id: string | null;
+}
+
+export interface ItemVoter {
+  key: string;
+  name: string;
+  avatarUrl?: string | null;
 }
 
 export type AudioSummaryStatus = 'generating' | 'ready' | 'playing' | 'paused';
@@ -104,7 +118,7 @@ export const useRetroBoard = (roomId: string) => {
   const [comments, setComments] = useState<RetroComment[]>([]);
   const [boardConfig, setBoardConfig] = useState<RetroBoardConfig | null>(null);
   const [activeUsers, setActiveUsers] = useState<ActiveUser[]>([]);
-  const [userVotes, setUserVotes] = useState<string[]>([]);
+  const [votes, setVotes] = useState<RetroVote[]>([]);
   const [teamActionItems, setTeamActionItems] = useState<TeamActionItem[]>([]);
   const [boardActionStatus, setBoardActionStatus] = useState<Record<string, { id: string; done: boolean; assigned_to?: string | null }>>({});
   const [loading, setLoading] = useState(true);
@@ -330,19 +344,45 @@ export const useRetroBoard = (roomId: string) => {
           setBoardActionStatus({});
         }
 
-        // Load user's votes
-        const currentUserId = profile?.id || null;
-        const voteQuery = supabase.from('retro_votes').select('item_id').eq('board_id', boardData.id);
-        if (currentUserId) {
-          voteQuery.eq('user_id', currentUserId);
+        // Load all votes for items on this board (includes legacy rows with null board_id)
+        const itemIds = (itemsData || []).map(item => item.id);
+        if (itemIds.length > 0) {
+          const { data: votesData, error: votesError } = await supabase
+            .from('retro_votes')
+            .select('id, item_id, user_id, session_id')
+            .in('item_id', itemIds);
+
+          if (votesError) throw votesError;
+
+          const loadedVotes = (votesData || []).filter(
+            (vote): vote is RetroVote => !!vote.item_id
+          ) as RetroVote[];
+          setVotes(loadedVotes);
+
+          // Batch-fetch profiles for voters not already cached from items/comments
+          const voterIds = [...new Set(
+            loadedVotes
+              .map(vote => vote.user_id)
+              .filter((id): id is string => !!id && !itemProfiles[id] && !commentProfiles[id])
+          )];
+
+          if (voterIds.length > 0) {
+            const { data: voterProfiles } = await supabase
+              .from('profiles')
+              .select('id, avatar_url, full_name')
+              .in('id', voterIds);
+
+            if (voterProfiles?.length) {
+              const voterProfileMap: Record<string, { avatar_url: string; full_name: string }> = {};
+              voterProfiles.forEach(p => {
+                voterProfileMap[p.id] = { avatar_url: p.avatar_url, full_name: p.full_name };
+              });
+              setProfileCache(prev => ({ ...prev, ...voterProfileMap }));
+            }
+          }
         } else {
-          voteQuery.eq('session_id', sessionId);
+          setVotes([]);
         }
-
-        const { data: userVotesData, error: userVotesError } = await voteQuery;
-
-        if (userVotesError) throw userVotesError;
-        setUserVotes((userVotesData || []).map(v => v.item_id));
 
       } catch (error) {
         console.error('Error loading board data:', error);
@@ -453,6 +493,52 @@ export const useRetroBoard = (roomId: string) => {
       .on('postgres_changes', { event: 'DELETE', schema: 'public', table: 'retro_comments' }, (payload) => {
         const deletedComment = payload.old as RetroComment;
         setComments(currentComments => currentComments.filter(comment => comment.id !== deletedComment.id));
+      })
+      .on('postgres_changes', {
+        event: 'INSERT',
+        schema: 'public',
+        table: 'retro_votes',
+        filter: `board_id=eq.${board.id}`,
+      }, async (payload) => {
+        const newVote = payload.new as RetroVote;
+        if (!newVote?.item_id) return;
+
+        setVotes(current => {
+          if (current.some(vote => vote.id === newVote.id)) return current;
+          // Drop optimistic temp vote for the same voter/item if present
+          const withoutTemp = current.filter(vote => {
+            if (!vote.id.startsWith('temp-')) return true;
+            const sameItem = vote.item_id === newVote.item_id;
+            const sameUser = !!newVote.user_id && vote.user_id === newVote.user_id;
+            const sameSession = !!newVote.session_id && vote.session_id === newVote.session_id;
+            return !(sameItem && (sameUser || sameSession));
+          });
+          return [...withoutTemp, newVote];
+        });
+
+        if (newVote.user_id) {
+          await fetchProfileData(newVote.user_id);
+        }
+      })
+      .on('postgres_changes', {
+        event: 'DELETE',
+        schema: 'public',
+        table: 'retro_votes',
+        filter: `board_id=eq.${board.id}`,
+      }, (payload) => {
+        const deletedVote = payload.old as Partial<RetroVote>;
+        setVotes(current => {
+          if (deletedVote.id) {
+            return current.filter(vote => vote.id !== deletedVote.id);
+          }
+          // Fallback match when DELETE payload lacks full row (replica identity default)
+          return current.filter(vote => {
+            const sameItem = vote.item_id === deletedVote.item_id;
+            const sameUser = deletedVote.user_id != null && vote.user_id === deletedVote.user_id;
+            const sameSession = deletedVote.session_id != null && vote.session_id === deletedVote.session_id;
+            return !(sameItem && (sameUser || sameSession));
+          });
+        });
       })
       // Team action items realtime for this team
       .on('postgres_changes', {
@@ -575,7 +661,7 @@ export const useRetroBoard = (roomId: string) => {
     return () => {
       supabase.removeChannel(channel);
     };
-  }, [board, sessionId, handleNewItem, handleNewComment]);
+  }, [board, sessionId, handleNewItem, handleNewComment, fetchProfileData]);
 
   const updateBoardTitle = async (title: string) => {
     if (!board) return;
@@ -989,10 +1075,13 @@ export const useRetroBoard = (roomId: string) => {
   const upvoteItem = async (itemId: string) => {
     if (!board || !boardConfig) return;
 
-    const userId = profile?.id;
-    const voteSessionId = !userId ? sessionId : undefined;
-
-    const hasVoted = userVotes.includes(itemId);
+    const userId = profile?.id ?? null;
+    const voteSessionId = !userId ? sessionId : null;
+    const existingVote = votes.find(vote =>
+      vote.item_id === itemId &&
+      (userId ? vote.user_id === userId : vote.session_id === sessionId)
+    );
+    const hasVoted = !!existingVote;
 
     // Prevent self-votes when disallowed
     if (!hasVoted && boardConfig.allow_self_votes === false) {
@@ -1008,7 +1097,10 @@ export const useRetroBoard = (roomId: string) => {
     }
 
     // Prevent adding a new vote if the limit is reached
-    if (!hasVoted && boardConfig.max_votes_per_user && userVotes.length >= boardConfig.max_votes_per_user) {
+    const currentUserVoteCount = votes.filter(vote =>
+      userId ? vote.user_id === userId : vote.session_id === sessionId
+    ).length;
+    if (!hasVoted && boardConfig.max_votes_per_user && currentUserVoteCount >= boardConfig.max_votes_per_user) {
       toast({
         title: 'Vote limit reached',
         description: `You can only vote ${boardConfig.max_votes_per_user} times.`,
@@ -1017,8 +1109,22 @@ export const useRetroBoard = (roomId: string) => {
       return;
     }
 
+    const tempVoteId = `temp-${Date.now()}-${itemId}`;
+
     // Optimistic UI updates
-    setUserVotes(prev => (hasVoted ? prev.filter(id => id !== itemId) : [...prev, itemId]));
+    if (hasVoted && existingVote) {
+      setVotes(prev => prev.filter(vote => vote.id !== existingVote.id));
+    } else {
+      setVotes(prev => [
+        ...prev,
+        {
+          id: tempVoteId,
+          item_id: itemId,
+          user_id: userId,
+          session_id: voteSessionId,
+        },
+      ]);
+    }
     setItems(prevItems =>
       prevItems.map(item =>
         item.id === itemId
@@ -1029,15 +1135,24 @@ export const useRetroBoard = (roomId: string) => {
 
     if (hasVoted) {
       // Remove vote from server
-      const { error } = await supabase
+      let deleteQuery = supabase
         .from('retro_votes')
         .delete()
-        .match({ item_id: itemId, board_id: board.id, user_id: userId, session_id: voteSessionId });
+        .eq('item_id', itemId)
+        .eq('board_id', board.id);
+
+      if (userId) {
+        deleteQuery = deleteQuery.eq('user_id', userId);
+      } else {
+        deleteQuery = deleteQuery.eq('session_id', sessionId);
+      }
+
+      const { error } = await deleteQuery;
 
       if (error) {
         toast({ title: 'Error removing vote', variant: 'destructive' });
         // Revert UI changes on error
-        setUserVotes(prev => [...prev, itemId]);
+        setVotes(prev => [...prev, existingVote]);
         setItems(prevItems =>
           prevItems.map(item =>
             item.id === itemId ? { ...item, votes: item.votes + 1 } : item
@@ -1046,22 +1161,32 @@ export const useRetroBoard = (roomId: string) => {
       }
     } else {
       // Add vote to server
-      const { error } = await supabase.from('retro_votes').insert({
-        item_id: itemId,
-        board_id: board.id,
-        user_id: userId,
-        session_id: voteSessionId,
-      });
+      const { data: insertedVote, error } = await supabase
+        .from('retro_votes')
+        .insert({
+          item_id: itemId,
+          board_id: board.id,
+          user_id: userId,
+          session_id: voteSessionId,
+        })
+        .select('id, item_id, user_id, session_id')
+        .single();
 
       if (error) {
         toast({ title: 'Error adding vote', variant: 'destructive' });
         // Revert UI changes on error
-        setUserVotes(prev => prev.filter(id => id !== itemId));
+        setVotes(prev => prev.filter(vote => vote.id !== tempVoteId));
         setItems(prevItems =>
           prevItems.map(item =>
             item.id === itemId ? { ...item, votes: item.votes - 1 } : item
           )
         );
+      } else if (insertedVote?.item_id) {
+        setVotes(prev => {
+          const withoutTemp = prev.filter(vote => vote.id !== tempVoteId);
+          if (withoutTemp.some(vote => vote.id === insertedVote.id)) return withoutTemp;
+          return [...withoutTemp, insertedVote as RetroVote];
+        });
       }
     }
   };
@@ -1244,6 +1369,60 @@ export const useRetroBoard = (roomId: string) => {
     }
   };
 
+  const userVotes = useMemo(() => {
+    const currentUserId = profile?.id || null;
+    return votes
+      .filter(vote =>
+        currentUserId ? vote.user_id === currentUserId : vote.session_id === sessionId
+      )
+      .map(vote => vote.item_id);
+  }, [votes, profile?.id, sessionId]);
+
+  const votersByItemId = useMemo(() => {
+    const map: Record<string, ItemVoter[]> = {};
+
+    const resolvePresence = (identity: string) =>
+      activeUsers.find(user => user.user_id === identity || user.id === identity);
+
+    for (const vote of votes) {
+      if (!vote.item_id) continue;
+      const key = vote.user_id || vote.session_id;
+      if (!key) continue;
+
+      let name = 'Anonymous';
+      let avatarUrl: string | null | undefined;
+
+      if (vote.user_id) {
+        const cached = profileCache[vote.user_id];
+        if (cached) {
+          name = cached.full_name || 'Anonymous';
+          avatarUrl = cached.avatar_url;
+        } else {
+          const presence = resolvePresence(vote.user_id);
+          if (presence) {
+            name = presence.user_name || 'Anonymous';
+            avatarUrl = presence.avatar_url;
+          }
+        }
+      } else if (vote.session_id) {
+        const presence = resolvePresence(vote.session_id);
+        if (presence) {
+          name = presence.user_name || 'Anonymous';
+          avatarUrl = presence.avatar_url;
+        }
+      }
+
+      if (!map[vote.item_id]) {
+        map[vote.item_id] = [];
+      }
+      if (!map[vote.item_id].some(voter => voter.key === key)) {
+        map[vote.item_id].push({ key, name, avatarUrl });
+      }
+    }
+
+    return map;
+  }, [votes, profileCache, activeUsers]);
+
   return {
     board,
     columns,
@@ -1252,6 +1431,7 @@ export const useRetroBoard = (roomId: string) => {
     boardConfig,
     activeUsers,
     userVotes,
+    votersByItemId,
     teamActionItems,
     boardActionStatus,
     loading,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Loads all votes for a retro board and resolves voter names/avatars from profiles and presence.
- Hovering a vote counter reveals who voted (avatar + name list in a tooltip). Voters are not shown permanently on the card.
- Keeps ballots private during the voting stage when structured stages are enabled; hover reveal works in discussing/closed, when stages are off, or on archived boards.
- Same hover behavior on the focused discussion banner vote count.

## Test plan
- [x] Open archived board `/retro/X4J6FZ` — vote counters show count only (no permanent avatar stack)
- [x] Hover a vote counter — tooltip lists voters with names/avatars
- [ ] Confirm voters stay hidden during the voting stage when stages are enabled
- [ ] Cast/remove a vote and confirm the hover list updates for other clients
- [ ] Focus a card and confirm hover on the banner vote count shows voters

## Screenshots
![Vote counters without permanent voter avatars](https://cursor.com/artifacts/c/art-bab1e85c-1976-4b43-af13-53057efb9c33)
![Hover tooltip listing who voted](https://cursor.com/artifacts/c/art-d8b02e8b-268e-491f-8b10-37a69b600abe)

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-69](https://linear.app/dungeon-dwellers/issue/DUN-69/feature-enable-showing-who-voted-for-what-retro-item)

<div><a href="https://cursor.com/agents/bc-fec01b10-b2a8-4a4e-9438-0724ce10db81?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fec01b10-b2a8-4a4e-9438-0724ce10db81&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

