### PR TITLE
fix(poker): start each round as Abstained instead of 1 point (#44)

### DIFF
--- a/src/components/Neotro/PokerTableComponent/context.tsx
+++ b/src/components/Neotro/PokerTableComponent/context.tsx
@@ -3,8 +3,10 @@ import {
   PlayerSelection,
   PokerSession,
   PokerSessionState,
+  createDefaultPlayerSelection,
   getPointsWithMostVotes,
   getWinningVoteFromSelections,
+  shouldAutoRevealSelections,
   winningVoteToStoredAveragePoints,
   type WinningPoints,
 } from '@/hooks/usePokerSession';
@@ -1008,11 +1010,7 @@ export const PokerTableProvider: React.FC<PokerTableProviderProps> = ({ children
         (fromSession?.name && String(fromSession.name).trim()) ||
         activeUserDisplayName?.trim() ||
         'Player';
-      const synthetic: PlayerSelection = {
-        points: 0,
-        locked: false,
-        name,
-      };
+      const synthetic = createDefaultPlayerSelection(name);
       return {
         next: { ...selections, [activeUserId!]: synthetic },
         user: synthetic,
@@ -1285,17 +1283,10 @@ export const PokerTableProvider: React.FC<PokerTableProviderProps> = ({ children
     if (effectiveCurrentRound.auto_reveal_enabled === false) return;
 
     const selections = effectiveCurrentRound.selections || {};
-    const entries = Object.entries(selections);
-    // Need at least 1 player to auto-reveal
-    if (entries.length === 0) return;
-
-    const allReady = entries.every(([, sel]) => {
-      const s = sel as PlayerSelection;
-      return s.locked || s.points === -1;
-    });
-
-    // Not everyone ready (e.g. someone unlocked): allow a future auto-reveal for this round.
-    if (!allReady) {
+    const selectionList = Object.values(selections) as PlayerSelection[];
+    // Need at least 1 player, everyone ready, and at least one non-abstain lock-in
+    // (new rounds start everyone abstained — do not auto-reveal that default state).
+    if (!shouldAutoRevealSelections(selectionList)) {
       autoRevealTriggeredRef.current = null;
       return;
     }

--- a/src/hooks/usePokerSession.ts
+++ b/src/hooks/usePokerSession.ts
@@ -17,6 +17,9 @@ import {
   isMissingSortOrderColumnError,
   omitSortOrder,
 } from '@/lib/pokerRoundSortOrder';
+import { createDefaultPlayerSelection } from '@/lib/pokerPlayerSelection';
+
+export { createDefaultPlayerSelection, shouldAutoRevealSelections } from '@/lib/pokerPlayerSelection';
 
 function emitSpotlightServerAligned(sessionId: string, roundNumber: number) {
   window.dispatchEvent(
@@ -159,11 +162,7 @@ export const usePokerSession = (
     const selections: Selections = {};
     for (const uid of userIds) {
       const existing = existingSelections?.[uid];
-      selections[uid] = existing ?? {
-        points: 1,
-        locked: false,
-        name: profileMap.get(uid) || 'Player',
-      };
+      selections[uid] = existing ?? createDefaultPlayerSelection(profileMap.get(uid) || 'Player');
     }
     return selections;
   }, []);
@@ -270,11 +269,11 @@ export const usePokerSession = (
       if (effectiveTeamId) {
         initialSelections = await fetchTeamSelections(effectiveTeamId, undefined, observerIds) ?? {};
         if (!isCurrentUserObserver && Object.keys(initialSelections).length === 0) {
-          initialSelections = { [currentUserId]: { points: 1, locked: false, name: currentUserDisplayName } };
+          initialSelections = { [currentUserId]: createDefaultPlayerSelection(currentUserDisplayName) };
         }
       } else {
         initialSelections = isCurrentUserObserver ? {} : {
-          [currentUserId]: { points: 1, locked: false, name: currentUserDisplayName },
+          [currentUserId]: createDefaultPlayerSelection(currentUserDisplayName),
         };
       }
 
@@ -330,11 +329,7 @@ export const usePokerSession = (
       }
     } else if (roundData && !roundData.selections[currentUserId] && !observerIds.includes(currentUserId)) {
       // Non-team session: add the current user if they aren't already in selections and aren't an observer
-      roundData.selections[currentUserId] = {
-        points: 1,
-        locked: false,
-        name: currentUserDisplayName,
-      };
+      roundData.selections[currentUserId] = createDefaultPlayerSelection(currentUserDisplayName);
       const { data: updatedRound, error: updateRoundError } = await supabase
         .from('poker_session_rounds')
         .update({ selections: roundData.selections })
@@ -648,7 +643,8 @@ export const usePokerSession = (
           const { data: profiles } = await supabase.from('profiles').select('id, full_name, nickname').in('id', toAddBack);
           const profileMap = new Map((profiles || []).map(p => [p.id, p.nickname || p.full_name || 'Player']));
           toAddBack.forEach(uid => {
-            newSelections[uid] = session.selections[uid] ?? { points: 1, locked: false, name: profileMap.get(uid) || 'Player' };
+            newSelections[uid] =
+              session.selections[uid] ?? createDefaultPlayerSelection(profileMap.get(uid) || 'Player');
           });
         }
       }
@@ -745,7 +741,7 @@ export const usePokerSession = (
       Object.entries(session.selections).forEach(([key, sel]) => {
         if (!observerSet.has(key)) {
           const { betweenHighPoints: _bn, ...selBase } = sel as PlayerSelection;
-          resetSelections[key] = { ...selBase, points: 1, locked: false };
+          resetSelections[key] = { ...selBase, points: -1, locked: true };
         }
       });
     }
@@ -831,7 +827,7 @@ export const usePokerSession = (
       Object.entries(session.selections).forEach(([key, sel]) => {
         if (!observerSet.has(key)) {
           const { betweenHighPoints: _bn, ...selBase } = sel as PlayerSelection;
-          resetSelections[key] = { ...selBase, points: 1, locked: false };
+          resetSelections[key] = { ...selBase, points: -1, locked: true };
         }
       });
     }
@@ -925,7 +921,7 @@ export const usePokerSession = (
       Object.entries(session.selections).forEach(([key, sel]) => {
         if (!observerSet.has(key)) {
           const { betweenHighPoints: _bn, ...selBase } = sel as PlayerSelection;
-          resetSelections[key] = { ...selBase, points: 1, locked: false };
+          resetSelections[key] = { ...selBase, points: -1, locked: true };
         }
       });
     }

--- a/src/lib/pokerPlayerSelection.test.ts
+++ b/src/lib/pokerPlayerSelection.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createDefaultPlayerSelection,
+  shouldAutoRevealSelections,
+  type PlayerSelectionLike,
+} from './pokerPlayerSelection';
+
+describe('createDefaultPlayerSelection', () => {
+  it('starts players abstained and locked', () => {
+    expect(createDefaultPlayerSelection('Alex')).toEqual({
+      points: -1,
+      locked: true,
+      name: 'Alex',
+    });
+  });
+});
+
+describe('shouldAutoRevealSelections', () => {
+  it('does not auto-reveal when everyone is still at the default abstained state', () => {
+    const selections: PlayerSelectionLike[] = [
+      { points: -1, locked: true, name: 'A' },
+      { points: -1, locked: true, name: 'B' },
+    ];
+    expect(shouldAutoRevealSelections(selections)).toBe(false);
+  });
+
+  it('auto-reveals when everyone is ready and at least one non-abstain vote is locked', () => {
+    const selections: PlayerSelectionLike[] = [
+      { points: 5, locked: true, name: 'A' },
+      { points: -1, locked: true, name: 'B' },
+    ];
+    expect(shouldAutoRevealSelections(selections)).toBe(true);
+  });
+
+  it('does not auto-reveal while someone is still unlocked on a point value', () => {
+    const selections: PlayerSelectionLike[] = [
+      { points: 5, locked: true, name: 'A' },
+      { points: 3, locked: false, name: 'B' },
+    ];
+    expect(shouldAutoRevealSelections(selections)).toBe(false);
+  });
+
+  it('returns false for an empty table', () => {
+    expect(shouldAutoRevealSelections([])).toBe(false);
+  });
+});

--- a/src/lib/pokerPlayerSelection.ts
+++ b/src/lib/pokerPlayerSelection.ts
@@ -1,0 +1,25 @@
+export interface PlayerSelectionLike {
+  points: number;
+  locked: boolean;
+  name: string;
+  betweenHighPoints?: number;
+}
+
+/**
+ * Default for a player on a new or reset round: abstained until they pick a value (#44).
+ * Matches toggle-abstain semantics (`points: -1`, `locked: true`).
+ */
+export function createDefaultPlayerSelection(name: string): PlayerSelectionLike {
+  return { points: -1, locked: true, name };
+}
+
+/**
+ * Auto-reveal when every participant is ready, but not when the table is still
+ * entirely at the default abstained state (otherwise a new round would reveal immediately).
+ */
+export function shouldAutoRevealSelections(selections: PlayerSelectionLike[]): boolean {
+  if (selections.length === 0) return false;
+  const allReady = selections.every((s) => s.locked || s.points === -1);
+  if (!allReady) return false;
+  return selections.some((s) => s.locked && s.points !== -1);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes GitHub [#44](https://github.com/justinloveless/retro-vote-sorter-board/issues/44) for Linear **DUN-70**.

Among open issues, this was the highest-priority clear bug still broken in code that needs no design/architecture decision: new poker rounds (and newly added players) defaulted to **1 point unlocked** instead of **Abstained**.

### Why this issue
- [#113](https://github.com/justinloveless/retro-vote-sorter-board/issues/113) already has a `round_number === 1` guard on main (from #114)
- [#86](https://github.com/justinloveless/retro-vote-sorter-board/issues/86) was fixed in #161
- [#44](https://github.com/justinloveless/retro-vote-sorter-board/issues/44) is still wrong in code and states the expected default explicitly

### Changes
- Default new/reset player selections to abstained (`points: -1`, `locked: true`) across session create, join, next round, start new round, and batch ticket rounds
- Tighten auto-reveal so an all-default-abstained table does **not** reveal immediately; require at least one non-abstain lock-in
- Add unit tests for the selection helpers

## Manual QA
Verified on local Vite (`localhost:8081`) with the project QA account:

![Round 1 starts abstained (Unabstain button)](https://cursor.com/artifacts/c/art-b5d3b6ba-1a20-4cb9-bf26-149ab643d008)
![Round 2 / Next Round also starts abstained](https://cursor.com/artifacts/c/art-f7672de9-25c1-4e9f-9ea9-e7c0b681c65b)

## Test plan
- [x] Unit tests for `createDefaultPlayerSelection` / `shouldAutoRevealSelections`
- [x] Start a poker session → players appear Abstained (not on 1)
- [x] Click Next Round → players reset to Abstained
- [ ] Un-abstain and lock a value; with others abstained, auto-reveal still works after everyone is ready
- [x] Fresh round with everyone still abstained does not auto-reveal
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-70](https://linear.app/dungeon-dwellers/issue/DUN-70/find-and-fix-one-issue)

<div><a href="https://cursor.com/agents/bc-c8c1e1ea-869d-45cb-ac20-e047dfcfc344?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8c1e1ea-869d-45cb-ac20-e047dfcfc344&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

