### PR TITLE
fix(retro): keep page header visible while scrolling (#89)

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -357,7 +357,7 @@ export const AppHeader = ({ variant = 'default', backTo, children, handleSignIn 
 
     return (
         <>
-            <header className={`flex justify-between items-center px-4 py-2 md:px-6 md:py-3 ${isMobile ? 'fixed top-0 left-0 right-0 z-50 bg-background/40 backdrop-blur-sm' : ''}`}>
+            <header className={`flex justify-between items-center px-4 py-2 md:px-6 md:py-3 ${isMobile ? 'fixed top-0 left-0 right-0 z-50 bg-background/40 backdrop-blur-sm' : 'sticky top-0 z-50 bg-background/80 backdrop-blur-sm'}`}>
                 <div className="flex items-center space-x-4">
                     {!isMobile && renderOrgSelector()}
                     {renderLeftContent()}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes GitHub [#89](https://github.com/justinloveless/retro-vote-sorter-board/issues/89) for Linear **DUN-71**.

Among open issues, this was the highest-priority clear bug still broken in code that needs no design/architecture decision: on desktop, the retro page `AppHeader` (including the board title) scrolled away with the page.

### Why this issue
- [#113](https://github.com/justinloveless/retro-vote-sorter-board/issues/113) already has a `round_number === 1` guard on main (from #114)
- [#92](https://github.com/justinloveless/retro-vote-sorter-board/issues/92) was fixed by the `'shared'` → null-UUID tenant migration
- [#86](https://github.com/justinloveless/retro-vote-sorter-board/issues/86) was fixed in #161
- [#44](https://github.com/justinloveless/retro-vote-sorter-board/issues/44) already has open draft PR #168
- [#89](https://github.com/justinloveless/retro-vote-sorter-board/issues/89) is still wrong: desktop header is not pinned

### Changes
- Make `AppHeader` sticky on desktop with a translucent backdrop (mobile remains `fixed`, unchanged)
- Sticky keeps the header in document flow, so existing `pt-24 md:pt-0` padding patterns stay valid

## Manual QA
Verified on local Vite (`localhost:8081`) with the project QA account on board `/retro/ECXCYG`:

![Retro header before scroll](https://cursor.com/artifacts/c/art-45999a36-9c6d-4ac0-8cf2-af05d402f8a9)
![Retro header remains sticky after scroll](https://cursor.com/artifacts/c/art-acc8e704-6558-45f0-a900-8cc75e2e1aba)

## Test plan
- [x] Open a retro board on desktop width (≥768px)
- [x] Scroll the board columns/content down
- [x] Confirm AppHeader (back control + board title) stays pinned at the top
- [ ] Confirm mobile (<768px) header still behaves as fixed with existing top padding
- [ ] Spot-check a non-retro page (e.g. Dashboard) still looks correct with sticky header

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-71](https://linear.app/dungeon-dwellers/issue/DUN-71/find-and-fix-one-issue)

<div><a href="https://cursor.com/agents/bc-cb955681-455f-4009-9373-0b93c0b4ea62?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb955681-455f-4009-9373-0b93c0b4ea62&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

