### PR TITLE
fix(retro): correct @mention team member matching (#87)

### DIFF
--- a/src/components/shared/MentionSuggestions.tsx
+++ b/src/components/shared/MentionSuggestions.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useEffect, useImperativeHandle, forwardRef } from 'react';
+import React, { useState, useEffect, useImperativeHandle, forwardRef, useMemo } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { UserAvatar } from '@/components/ui/UserAvatar';
+import { dedupeTeamMembersByUserId, memberMatchesMentionQuery } from '@/lib/mentionMatching';
 
 interface TeamMember {
     id: string;
@@ -8,6 +9,7 @@ interface TeamMember {
     profiles?: {
         full_name: string | null;
         nickname?: string | null;
+        avatar_url?: string | null;
     } | null;
 }
 
@@ -21,21 +23,45 @@ export interface MentionSuggestionsRef {
     onKeyDown: (event: KeyboardEvent) => boolean;
 }
 
+const displayNameFor = (member: TeamMember): string => {
+    return member.profiles?.full_name?.trim() || member.profiles?.nickname?.trim() || 'Unknown User';
+};
+
+/** When multiple people share a full name, surface nickname (or a short id) to tell them apart. */
+const disambiguationLabel = (member: TeamMember, duplicateNames: Set<string>): string | null => {
+    const fullName = member.profiles?.full_name?.trim() || '';
+    const nickname = member.profiles?.nickname?.trim() || '';
+    if (nickname) return nickname;
+    if (fullName && duplicateNames.has(fullName.toLowerCase())) {
+        return member.user_id.slice(0, 8);
+    }
+    return null;
+};
+
 export const MentionSuggestions = forwardRef<MentionSuggestionsRef, MentionSuggestionsProps>(
     ({ query, teamMembers, onSelect }, ref) => {
         const [selectedIndex, setSelectedIndex] = useState(0);
-        const [filteredMembers, setFilteredMembers] = useState<TeamMember[]>([]);
+
+        const filteredMembers = useMemo(() => {
+            const unique = dedupeTeamMembersByUserId(teamMembers);
+            return unique
+                .filter(member => memberMatchesMentionQuery(member, query))
+                .sort((a, b) => displayNameFor(a).localeCompare(displayNameFor(b)));
+        }, [query, teamMembers]);
+
+        const duplicateNames = useMemo(() => {
+            const counts = new Map<string, number>();
+            for (const member of filteredMembers) {
+                const key = (member.profiles?.full_name || '').trim().toLowerCase();
+                if (!key) continue;
+                counts.set(key, (counts.get(key) || 0) + 1);
+            }
+            return new Set([...counts.entries()].filter(([, n]) => n > 1).map(([name]) => name));
+        }, [filteredMembers]);
 
         useEffect(() => {
-            const filtered = teamMembers.filter(member => {
-                const name = member.profiles?.full_name || 'Unknown User';
-                const nickname = member.profiles?.nickname || '';
-                const q = query.toLowerCase();
-                return name.toLowerCase().includes(q) || nickname.toLowerCase().includes(q);
-            });
-            setFilteredMembers(filtered);
             setSelectedIndex(0);
-        }, [query, teamMembers]);
+        }, [filteredMembers]);
 
         useImperativeHandle(ref, () => ({
             onKeyDown: (event: KeyboardEvent) => {
@@ -67,7 +93,7 @@ export const MentionSuggestions = forwardRef<MentionSuggestionsRef, MentionSugge
                         return false;
                 }
             }
-        }));
+        }), [filteredMembers, selectedIndex, onSelect]);
 
         if (filteredMembers.length === 0) {
             return null;
@@ -76,31 +102,36 @@ export const MentionSuggestions = forwardRef<MentionSuggestionsRef, MentionSugge
         return (
             <Card className="absolute z-[9999] mt-1 max-h-60 w-64 overflow-y-auto bg-white dark:bg-gray-800 shadow-lg border border-gray-200 dark:border-gray-600">
                 <CardContent className="p-2">
-                    {filteredMembers.map((member, index) => (
-                        <div
-                            key={member.user_id}
-                            className={`flex items-center gap-2 p-2 rounded cursor-pointer transition-colors ${index === selectedIndex
-                                ? 'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300'
-                                : 'hover:bg-gray-50 dark:hover:bg-gray-700'
-                                }`}
-                            onClick={() => onSelect(member)}
-                        >
-                            <UserAvatar
-                                name={member.profiles?.full_name || 'Unknown User'}
-                                className="w-6 h-6"
-                            />
-                            <span className="text-sm font-medium">
-                                {member.profiles?.full_name || 'Unknown User'}
-                                {member.profiles?.nickname && (
-                                    <span className="text-muted-foreground ml-1">({member.profiles.nickname})</span>
-                                )}
-                            </span>
-                        </div>
-                    ))}
+                    {filteredMembers.map((member, index) => {
+                        const name = displayNameFor(member);
+                        const secondary = disambiguationLabel(member, duplicateNames);
+                        return (
+                            <div
+                                key={member.user_id}
+                                className={`flex items-center gap-2 p-2 rounded cursor-pointer transition-colors ${index === selectedIndex
+                                    ? 'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300'
+                                    : 'hover:bg-gray-50 dark:hover:bg-gray-700'
+                                    }`}
+                                onClick={() => onSelect(member)}
+                            >
+                                <UserAvatar
+                                    name={name}
+                                    avatarUrl={member.profiles?.avatar_url || undefined}
+                                    className="w-6 h-6"
+                                />
+                                <span className="text-sm font-medium truncate">
+                                    {name}
+                                    {secondary && secondary !== name && (
+                                        <span className="text-muted-foreground ml-1 font-normal">({secondary})</span>
+                                    )}
+                                </span>
+                            </div>
+                        );
+                    })}
                 </CardContent>
             </Card>
         );
     }
 );
 
-MentionSuggestions.displayName = 'MentionSuggestions'; 
+MentionSuggestions.displayName = 'MentionSuggestions';

--- a/src/components/shared/TiptapEditorWithMentions.tsx
+++ b/src/components/shared/TiptapEditorWithMentions.tsx
@@ -9,6 +9,7 @@ import { MentionSuggestions, MentionSuggestionsRef } from './MentionSuggestions'
 import type { UploadImageFn } from '@/hooks/usePokerSessionChat';
 import { convertMarkdownLinksToHtml, RICH_TEXT_EDITOR_CLASS } from '@/lib/richTextDisplay';
 import { MarkdownLink, tryPasteMarkdownLinks } from '@/lib/tiptapMarkdownLink';
+import { dedupeTeamMembersByUserId, memberMatchesMentionQuery } from '@/lib/mentionMatching';
 
 interface TeamMember {
     id: string;
@@ -71,8 +72,6 @@ const Mention = Node.create({
         ];
     },
 
-
-
     renderHTML({ node, HTMLAttributes }) {
         const { userId, name } = node.attrs;
         return [
@@ -94,8 +93,6 @@ const Mention = Node.create({
         const { userId, name } = node.attrs;
         return `[[mention:${userId}:${name}]]`;
     },
-
-
 });
 
 // Function to convert mention delimiters to styled links
@@ -143,6 +140,8 @@ const convertMentionSpansToDelimiters = (htmlContent: string): string => {
     );
 };
 
+export { memberMatchesMentionQuery, dedupeTeamMembersByUserId } from '@/lib/mentionMatching';
+
 export const TiptapEditorWithMentions: React.FC<TiptapEditorWithMentionsProps> = ({
     content,
     onChange,
@@ -158,8 +157,23 @@ export const TiptapEditorWithMentions: React.FC<TiptapEditorWithMentionsProps> =
     const mentionSuggestionsRef = useRef<MentionSuggestionsRef>(null);
     const editorRef = useRef<any>(null);
 
+    // TipTap's useEditor captures callbacks once; keep latest values in refs.
+    const uniqueTeamMembers = dedupeTeamMembersByUserId(teamMembers);
+    const teamMembersRef = useRef(uniqueTeamMembers);
+    const showMentionsRef = useRef(showMentions);
+    const mentionTriggerRef = useRef(mentionTrigger);
+    const contentRef = useRef(content);
+    const onChangeRef = useRef(onChange);
+    const onSubmitRef = useRef(onSubmit);
+    const uploadImageRef = useRef(uploadImage);
 
-
+    teamMembersRef.current = uniqueTeamMembers;
+    showMentionsRef.current = showMentions;
+    mentionTriggerRef.current = mentionTrigger;
+    contentRef.current = content;
+    onChangeRef.current = onChange;
+    onSubmitRef.current = onSubmit;
+    uploadImageRef.current = uploadImage;
 
     const editor = useEditor({
         extensions: [
@@ -188,19 +202,20 @@ export const TiptapEditorWithMentions: React.FC<TiptapEditorWithMentionsProps> =
             const contentWithDelimiters = convertMentionSpansToDelimiters(htmlContent);
 
             // Only update content if it actually changed to avoid interference
-            if (contentWithDelimiters !== content) {
-                onChange(contentWithDelimiters);
+            if (contentWithDelimiters !== contentRef.current) {
+                onChangeRef.current(contentWithDelimiters);
             }
 
-            // Handle mention logic
+            // Handle mention logic against the latest team member list
+            const members = teamMembersRef.current;
             const { state } = editor;
             const { from } = state.selection;
             const textBefore = state.doc.textBetween(Math.max(0, from - 50), from, '\n', '\n');
-            
+
             // First check for explicit @ trigger
             const mentionMatch = textBefore.match(/@(\w*)$/);
-            if (mentionMatch && teamMembers.length > 0) {
-                if (!showMentions || mentionTrigger !== '@') {
+            if (mentionMatch && members.length > 0) {
+                if (!showMentionsRef.current || mentionTriggerRef.current !== '@') {
                     const coords = editor.view.coordsAtPos(from);
                     setMentionPos({ x: coords.left, y: coords.bottom });
                     setShowMentions(true);
@@ -212,16 +227,11 @@ export const TiptapEditorWithMentions: React.FC<TiptapEditorWithMentionsProps> =
 
             // Then check if the current word matches a team member name (min 2 chars)
             const wordMatch = textBefore.match(/(?:^|\s)(\w{2,})$/);
-            if (wordMatch && teamMembers.length > 0) {
-                const typed = wordMatch[1].toLowerCase();
-                const hasMatch = teamMembers.some(m => {
-                    const name = m.profiles?.full_name?.toLowerCase() || '';
-                    const nickname = m.profiles?.nickname?.toLowerCase() || '';
-                    return name.split(/\s+/).some(part => part.startsWith(typed)) || 
-                           (nickname && nickname.startsWith(typed));
-                });
+            if (wordMatch && members.length > 0) {
+                const typed = wordMatch[1];
+                const hasMatch = members.some(m => memberMatchesMentionQuery(m, typed));
                 if (hasMatch) {
-                    if (!showMentions || mentionTrigger !== 'name') {
+                    if (!showMentionsRef.current || mentionTriggerRef.current !== 'name') {
                         const coords = editor.view.coordsAtPos(from);
                         setMentionPos({ x: coords.left, y: coords.bottom });
                         setShowMentions(true);
@@ -232,7 +242,7 @@ export const TiptapEditorWithMentions: React.FC<TiptapEditorWithMentionsProps> =
                 }
             }
 
-            if (showMentions) {
+            if (showMentionsRef.current) {
                 setShowMentions(false);
             }
         },
@@ -240,9 +250,9 @@ export const TiptapEditorWithMentions: React.FC<TiptapEditorWithMentionsProps> =
             attributes: {
                 class: RICH_TEXT_EDITOR_CLASS,
             },
-            handleKeyDown: (view, event) => {
+            handleKeyDown: (_view, event) => {
                 // Handle mention suggestions navigation
-                if (showMentions && mentionSuggestionsRef.current) {
+                if (showMentionsRef.current && mentionSuggestionsRef.current) {
                     const handled = mentionSuggestionsRef.current.onKeyDown(event);
                     if (handled) {
                         return true;
@@ -251,14 +261,12 @@ export const TiptapEditorWithMentions: React.FC<TiptapEditorWithMentionsProps> =
 
                 if (event.key === 'Enter' && !event.shiftKey) {
                     event.preventDefault();
-                    onSubmit();
+                    onSubmitRef.current();
                     return true;
                 }
 
-
-
                 // Handle escape to close mentions
-                if (event.key === 'Escape' && showMentions) {
+                if (event.key === 'Escape' && showMentionsRef.current) {
                     setShowMentions(false);
                     return true;
                 }
@@ -275,9 +283,10 @@ export const TiptapEditorWithMentions: React.FC<TiptapEditorWithMentionsProps> =
                 if (imageItem) {
                     event.preventDefault();
                     const file = imageItem.getAsFile();
-                    if (!file || !uploadImage) return true;
+                    const upload = uploadImageRef.current;
+                    if (!file || !upload) return true;
 
-                    uploadImage(file).then(url => {
+                    upload(file).then(url => {
                         if (url) {
                             const { tr } = view.state;
                             const node = view.state.schema.nodes.image.create({ src: url });
@@ -309,8 +318,6 @@ export const TiptapEditorWithMentions: React.FC<TiptapEditorWithMentionsProps> =
         }
     }, [content, editor]);
 
-
-
     // Store editor reference for mention handling
     useEffect(() => {
         editorRef.current = editor;
@@ -323,11 +330,12 @@ export const TiptapEditorWithMentions: React.FC<TiptapEditorWithMentionsProps> =
         const { from } = state.selection;
 
         const textBefore = state.doc.textBetween(Math.max(0, from - 50), from, '\n', '\n');
-        
-        let mentionStart: number;
-        let mentionEnd: number = from;
 
-        if (mentionTrigger === '@') {
+        let mentionStart: number;
+        const mentionEnd: number = from;
+        const trigger = mentionTriggerRef.current;
+
+        if (trigger === '@') {
             // Find the @ symbol position
             const mentionMatch = textBefore.match(/@(\w*)$/);
             if (!mentionMatch) { setShowMentions(false); return; }
@@ -339,7 +347,7 @@ export const TiptapEditorWithMentions: React.FC<TiptapEditorWithMentionsProps> =
             mentionStart = from - wordMatch[1].length;
         }
 
-        const nickname = member.profiles?.nickname;
+        const nickname = member.profiles?.nickname?.trim();
         const memberName = nickname || member.profiles?.full_name || 'Unknown User';
 
         editor.chain()
@@ -353,11 +361,11 @@ export const TiptapEditorWithMentions: React.FC<TiptapEditorWithMentionsProps> =
             .run();
 
         setShowMentions(false);
-    }, [editor, mentionTrigger]);
+    }, [editor]);
 
     // Click outside to close mentions
     useEffect(() => {
-        const handleClickOutside = (event: MouseEvent) => {
+        const handleClickOutside = () => {
             if (showMentions) {
                 setShowMentions(false);
             }
@@ -371,7 +379,7 @@ export const TiptapEditorWithMentions: React.FC<TiptapEditorWithMentionsProps> =
         <div className="relative">
             <EditorContent editor={editor} />
 
-            {showMentions && teamMembers.length > 0 && createPortal(
+            {showMentions && uniqueTeamMembers.length > 0 && createPortal(
                 <div
                     style={{
                         position: 'fixed',
@@ -383,7 +391,7 @@ export const TiptapEditorWithMentions: React.FC<TiptapEditorWithMentionsProps> =
                     <MentionSuggestions
                         ref={mentionSuggestionsRef}
                         query={mentionQuery}
-                        teamMembers={teamMembers}
+                        teamMembers={uniqueTeamMembers}
                         onSelect={handleMentionSelect}
                     />
                 </div>,
@@ -391,4 +399,4 @@ export const TiptapEditorWithMentions: React.FC<TiptapEditorWithMentionsProps> =
             )}
         </div>
     );
-}; 
+};

--- a/src/lib/mentionMatching.test.ts
+++ b/src/lib/mentionMatching.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+  dedupeTeamMembersByUserId,
+  memberMatchesMentionQuery,
+} from '@/lib/mentionMatching';
+
+const member = (full_name: string, user_id = 'u1', nickname?: string | null) => ({
+  id: `m-${user_id}`,
+  user_id,
+  profiles: { full_name, nickname: nickname ?? null },
+});
+
+describe('memberMatchesMentionQuery', () => {
+  it('matches prefix of first or last name', () => {
+    const carlos = member('Carlos Sotelo');
+    expect(memberMatchesMentionQuery(carlos, 'c')).toBe(true);
+    expect(memberMatchesMentionQuery(carlos, 'ca')).toBe(true);
+    expect(memberMatchesMentionQuery(carlos, 'sot')).toBe(true);
+  });
+
+  it('does not match mid-string letters (e.g. c in McIntyre)', () => {
+    const kim = member('Kimberly McIntyre');
+    expect(memberMatchesMentionQuery(kim, 'c')).toBe(false);
+    expect(memberMatchesMentionQuery(kim, 'kim')).toBe(true);
+    expect(memberMatchesMentionQuery(kim, 'mc')).toBe(true);
+  });
+
+  it('matches nicknames by prefix', () => {
+    const tiago = member('Tiago Marto', 'u2', 'TM');
+    expect(memberMatchesMentionQuery(tiago, 'tm')).toBe(true);
+    expect(memberMatchesMentionQuery(tiago, 't')).toBe(true);
+  });
+
+  it('returns all members for empty query', () => {
+    expect(memberMatchesMentionQuery(member('Anyone'), '')).toBe(true);
+  });
+});
+
+describe('dedupeTeamMembersByUserId', () => {
+  it('keeps the first row per user_id', () => {
+    const list = [
+      member('Kimberly McIntyre', 'kim-1'),
+      member('Kimberly McIntyre', 'kim-1'),
+      member('Carlos Sotelo', 'carlos-1'),
+    ];
+    const unique = dedupeTeamMembersByUserId(list);
+    expect(unique).toHaveLength(2);
+    expect(unique.map(m => m.user_id)).toEqual(['kim-1', 'carlos-1']);
+  });
+});

--- a/src/lib/mentionMatching.ts
+++ b/src/lib/mentionMatching.ts
@@ -1,0 +1,36 @@
+export interface MentionTeamMember {
+  id?: string;
+  user_id: string;
+  profiles?: {
+    full_name: string | null;
+    nickname?: string | null;
+    avatar_url?: string | null;
+  } | null;
+}
+
+/** Prefix-match full name, name parts, or nickname (avoid mid-string hits like "c" in McIntyre). */
+export const memberMatchesMentionQuery = (
+  member: Pick<MentionTeamMember, 'profiles'>,
+  query: string,
+): boolean => {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  const name = member.profiles?.full_name?.toLowerCase().trim() || '';
+  const nickname = member.profiles?.nickname?.toLowerCase().trim() || '';
+  if (name.startsWith(q)) return true;
+  if (name.split(/\s+/).some(part => part.startsWith(q))) return true;
+  if (nickname && nickname.startsWith(q)) return true;
+  return false;
+};
+
+/** Keep one row per user_id so duplicate memberships cannot flood suggestions. */
+export const dedupeTeamMembersByUserId = <T extends { user_id: string }>(members: T[]): T[] => {
+  const seen = new Set<string>();
+  const result: T[] = [];
+  for (const member of members) {
+    if (!member?.user_id || seen.has(member.user_id)) continue;
+    seen.add(member.user_id);
+    result.push(member);
+  }
+  return result;
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes [#87](https://github.com/justinloveless/retro-vote-sorter-board/issues/87) (also improves [#75](https://github.com/justinloveless/retro-vote-sorter-board/issues/75)).

Typing `@c` on a retro board was matching **Kimberly McIntyre** (substring `c` in “McIntyre”) and could show duplicate / stale suggestion rows, while **Carlos Sotelo** was hard to find. Root causes:

1. **Stale TipTap closures** – `useEditor` captured `teamMembers = []` on mount and never saw the loaded team roster.
2. **Overly loose filter** – suggestions used `String.includes`, so mid-name letters matched unrelated people.
3. **No dedupe / weak disambiguation** – duplicate `user_id` rows (if present) and identical display names were hard to tell apart.

## Changes
- Keep latest `teamMembers` / mention UI state in refs so TipTap callbacks stay current without remounting the editor.
- Match `@` queries by **prefix** of full name, name parts, or nickname.
- Dedupe suggestions by `user_id`.
- Show nickname (or a short id) when multiple people share the same full name.
- Unit tests for matching / dedupe helpers.

## Test plan
- [x] `npx vitest run src/lib/mentionMatching.test.ts`
- [ ] On a retro board, type `@c` → only Carlos (not Kimberly)
- [ ] Type `@kim` → Kimberly
- [ ] Mentions still work after the team member list finishes loading
- [ ] Arrow/Enter selection in the suggestion list still works

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-72](https://linear.app/dungeon-dwellers/issue/DUN-72/find-and-fix-one-issue)

<div><a href="https://cursor.com/agents/bc-6546f099-801f-48b6-81bd-8e6d7371bc9a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6546f099-801f-48b6-81bd-8e6d7371bc9a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

