### PR TITLE
fix(jira): speed up Browse Jira single-ticket search (DUN-73)

### DIFF
--- a/src/components/Neotro/EmbeddedTicketQueue.tsx
+++ b/src/components/Neotro/EmbeddedTicketQueue.tsx
@@ -23,6 +23,7 @@ import {
   JIRA_BROWSE_DISABLED_REASON_META,
 } from '@/lib/jiraBrowseDisabledReason';
 import { buildJiraBrowseIssuesBySprint } from '@/lib/jiraBrowseSprintBuckets';
+import { issueKeyFromSearchText } from '@/lib/jiraIssueKeySearch';
 import type { JiraTicketMeta } from '@/hooks/use-jira-ticket-metadata';
 import { usePersistedJiraBrowseCollapsedBuckets } from '@/hooks/use-persisted-jira-browse-collapsed-buckets';
 import { usePersistedJiraBrowseFilters } from '@/hooks/use-persisted-jira-browse-filters';
@@ -418,15 +419,20 @@ export const EmbeddedTicketQueue: React.FC<EmbeddedTicketQueueProps> = ({
       const includeKeySet = new Set<string>();
       for (const k of ticketKeysOnSessionRoundsRef.current) includeKeySet.add(k);
       const includeKeys = includeKeySet.size > 0 ? Array.from(includeKeySet) : undefined;
+      // Exact key → keysOnly path (skips multi-sprint board fan-out). Filters are ignored so
+      // estimated/Done tickets still resolve when the user pastes a specific key.
+      const exactKey = issueKeyFromSearchText(searchText);
       const { data, error } = await supabase.functions.invoke('get-jira-board-issues', {
-        body: {
-          teamId,
-          searchText: searchText || undefined,
-          statusFilter: apiStatusFilter,
-          pointsFilter: pointsFilter !== 'any' ? pointsFilter : undefined,
-          sprintScopeFilter,
-          includeKeys,
-        },
+        body: exactKey
+          ? { teamId, keysOnly: true, includeKeys: [exactKey] }
+          : {
+              teamId,
+              searchText: searchText || undefined,
+              statusFilter: apiStatusFilter,
+              pointsFilter: pointsFilter !== 'any' ? pointsFilter : undefined,
+              sprintScopeFilter,
+              includeKeys,
+            },
       });
       if (error) throw error;
       if (data?.error) throw new Error(data.error);

--- a/src/components/Neotro/TicketQueuePanel.tsx
+++ b/src/components/Neotro/TicketQueuePanel.tsx
@@ -26,6 +26,7 @@ import {
   JIRA_BROWSE_DISABLED_REASON_META,
 } from '@/lib/jiraBrowseDisabledReason';
 import { buildJiraBrowseIssuesBySprint } from '@/lib/jiraBrowseSprintBuckets';
+import { issueKeyFromSearchText } from '@/lib/jiraIssueKeySearch';
 
 interface JiraIssue {
   key: string;
@@ -248,15 +249,20 @@ export const TicketQueuePanel: React.FC<TicketQueuePanelProps> = ({
       const includeKeySet = new Set<string>();
       for (const k of ticketKeysOnSessionRoundsRef.current) includeKeySet.add(k);
       const includeKeys = includeKeySet.size > 0 ? Array.from(includeKeySet) : undefined;
+      // Exact key → keysOnly path (skips multi-sprint board fan-out). Filters are ignored so
+      // estimated/Done tickets still resolve when the user pastes a specific key.
+      const exactKey = issueKeyFromSearchText(searchText);
       const { data, error } = await supabase.functions.invoke('get-jira-board-issues', {
-        body: {
-          teamId,
-          searchText: searchText || undefined,
-          statusFilter: apiStatusFilter,
-          pointsFilter: pointsFilter !== 'any' ? pointsFilter : undefined,
-          sprintScopeFilter,
-          includeKeys,
-        },
+        body: exactKey
+          ? { teamId, keysOnly: true, includeKeys: [exactKey] }
+          : {
+              teamId,
+              searchText: searchText || undefined,
+              statusFilter: apiStatusFilter,
+              pointsFilter: pointsFilter !== 'any' ? pointsFilter : undefined,
+              sprintScopeFilter,
+              includeKeys,
+            },
       });
       if (error) throw error;
       if (data?.error) throw new Error(data.error);
@@ -273,7 +279,10 @@ export const TicketQueuePanel: React.FC<TicketQueuePanelProps> = ({
     if (isOpen && teamId && isJiraConfigured) {
       fetchAllIssues();
     }
-  }, [isOpen, teamId, isJiraConfigured, statusFilter, pointsFilter, sprintScopeFilter, fetchAllIssues]);
+    // Omit fetchAllIssues / searchText: typing in search should not hit Jira until Enter or Search.
+    // Filter changes still refetch using the latest fetchAllIssues from this render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, teamId, isJiraConfigured, statusFilter, pointsFilter, sprintScopeFilter]);
 
   const handleAddManualTicket = async () => {
     const key = manualTicketKey.trim();

--- a/src/lib/jiraIssueKeySearch.test.ts
+++ b/src/lib/jiraIssueKeySearch.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { issueKeyFromSearchText } from './jiraIssueKeySearch';
+
+describe('issueKeyFromSearchText', () => {
+  it('parses and normalizes keys', () => {
+    expect(issueKeyFromSearchText('RNMT-8100')).toBe('RNMT-8100');
+    expect(issueKeyFromSearchText('  rnmt-8107  ')).toBe('RNMT-8107');
+  });
+
+  it('rejects non-keys', () => {
+    expect(issueKeyFromSearchText('')).toBeNull();
+    expect(issueKeyFromSearchText('8100')).toBeNull();
+    expect(issueKeyFromSearchText('fix login')).toBeNull();
+    expect(issueKeyFromSearchText('RNMT-8100 extra')).toBeNull();
+  });
+});

--- a/src/lib/jiraIssueKeySearch.ts
+++ b/src/lib/jiraIssueKeySearch.ts
@@ -1,0 +1,8 @@
+/** Bare Jira issue key typed into Browse Jira search (e.g. RNMT-8100). */
+export function issueKeyFromSearchText(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null;
+  const t = raw.trim();
+  const m = t.match(/^([A-Za-z][A-Za-z0-9_]*)-(\d+)$/);
+  if (!m) return null;
+  return `${m[1].toUpperCase()}-${m[2]}`;
+}

--- a/supabase/functions/_shared/jiraBoardIssuesSearch.ts
+++ b/supabase/functions/_shared/jiraBoardIssuesSearch.ts
@@ -1,0 +1,30 @@
+/** Pure helpers for get-jira-board-issues search / browse path selection. */
+
+/** If the user typed a bare issue key, fetch it by key — board JQL sprint/issuetype filters often hide those issues. */
+export function issueKeyFromSearchText(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null;
+  const t = raw.trim();
+  const m = t.match(/^([A-Za-z][A-Za-z0-9_]*)-(\d+)$/);
+  if (!m) return null;
+  return `${m[1].toUpperCase()}-${m[2]}`;
+}
+
+export function hasNonEmptySearchText(searchText: unknown): boolean {
+  return typeof searchText === 'string' && searchText.trim().length > 0;
+}
+
+/**
+ * Board-ranked browse walks every active/future sprint + backlog (many sequential Jira calls).
+ * That is correct for the default board view, but far too slow when the user is searching —
+ * especially for a single issue key.
+ */
+export function shouldUseBoardRankedIssueFetch(opts: {
+  resolvedBoardId: number | null | undefined;
+  sprintScope: string;
+  searchText: unknown;
+}): boolean {
+  if (opts.resolvedBoardId == null) return false;
+  if (opts.sprintScope !== 'board-open-backlog') return false;
+  if (hasNonEmptySearchText(opts.searchText)) return false;
+  return true;
+}

--- a/supabase/functions/_shared/jiraBoardIssuesSearch_test.ts
+++ b/supabase/functions/_shared/jiraBoardIssuesSearch_test.ts
@@ -1,0 +1,85 @@
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts';
+import {
+  hasNonEmptySearchText,
+  issueKeyFromSearchText,
+  shouldUseBoardRankedIssueFetch,
+} from './jiraBoardIssuesSearch.ts';
+
+Deno.test('issueKeyFromSearchText parses bare keys and normalizes project casing', () => {
+  assertEquals(issueKeyFromSearchText('RNMT-8100'), 'RNMT-8100');
+  assertEquals(issueKeyFromSearchText('  rnmt-8100  '), 'RNMT-8100');
+  assertEquals(issueKeyFromSearchText('ABC_1-2'), 'ABC_1-2');
+});
+
+Deno.test('issueKeyFromSearchText rejects non-keys', () => {
+  assertEquals(issueKeyFromSearchText(''), null);
+  assertEquals(issueKeyFromSearchText('8100'), null);
+  assertEquals(issueKeyFromSearchText('RNMT-'), null);
+  assertEquals(issueKeyFromSearchText('fix login'), null);
+  assertEquals(issueKeyFromSearchText('RNMT-8100 extra'), null);
+  assertEquals(issueKeyFromSearchText(null), null);
+});
+
+Deno.test('hasNonEmptySearchText', () => {
+  assertEquals(hasNonEmptySearchText('RNMT-8100'), true);
+  assertEquals(hasNonEmptySearchText('  x  '), true);
+  assertEquals(hasNonEmptySearchText('   '), false);
+  assertEquals(hasNonEmptySearchText(undefined), false);
+});
+
+Deno.test('shouldUseBoardRankedIssueFetch is off when searching (incl. exact key)', () => {
+  assertEquals(
+    shouldUseBoardRankedIssueFetch({
+      resolvedBoardId: 42,
+      sprintScope: 'board-open-backlog',
+      searchText: 'RNMT-8100',
+    }),
+    false,
+  );
+  assertEquals(
+    shouldUseBoardRankedIssueFetch({
+      resolvedBoardId: 42,
+      sprintScope: 'board-open-backlog',
+      searchText: 'login',
+    }),
+    false,
+  );
+});
+
+Deno.test('shouldUseBoardRankedIssueFetch is on for default board browse', () => {
+  assertEquals(
+    shouldUseBoardRankedIssueFetch({
+      resolvedBoardId: 42,
+      sprintScope: 'board-open-backlog',
+      searchText: undefined,
+    }),
+    true,
+  );
+  assertEquals(
+    shouldUseBoardRankedIssueFetch({
+      resolvedBoardId: 42,
+      sprintScope: 'board-open-backlog',
+      searchText: '   ',
+    }),
+    true,
+  );
+});
+
+Deno.test('shouldUseBoardRankedIssueFetch is off without board or non-board scope', () => {
+  assertEquals(
+    shouldUseBoardRankedIssueFetch({
+      resolvedBoardId: undefined,
+      sprintScope: 'board-open-backlog',
+      searchText: undefined,
+    }),
+    false,
+  );
+  assertEquals(
+    shouldUseBoardRankedIssueFetch({
+      resolvedBoardId: 42,
+      sprintScope: 'all',
+      searchText: undefined,
+    }),
+    false,
+  );
+});

--- a/supabase/functions/get-jira-board-issues/index.ts
+++ b/supabase/functions/get-jira-board-issues/index.ts
@@ -7,20 +7,16 @@ import {
 } from '../_shared/jiraStoryPoints.ts';
 import { createGetSprintMeta } from '../_shared/jiraSprintFields.ts';
 import { loadBoardActiveFutureSprints } from '../_shared/loadBoardSprints.ts';
+import {
+  hasNonEmptySearchText,
+  issueKeyFromSearchText,
+  shouldUseBoardRankedIssueFetch,
+} from '../_shared/jiraBoardIssuesSearch.ts';
 
 const DEFAULT_STORY_POINTS_JQL_FIELD_NAME = 'Story Points';
 
 function escapeJqlString(s: string): string {
   return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-}
-
-/** If the user typed a bare issue key, fetch it by key — board JQL sprint/issuetype filters often hide those issues. */
-function issueKeyFromSearchText(raw: unknown): string | null {
-  if (typeof raw !== 'string') return null;
-  const t = raw.trim();
-  const m = t.match(/^([A-Za-z][A-Za-z0-9_]*)-(\d+)$/);
-  if (!m) return null;
-  return `${m[1].toUpperCase()}-${m[2]}`;
 }
 
 /** Project key from board config — needed when team stores numeric Agile board id (invalid in `project = "…"` JQL). */
@@ -206,6 +202,26 @@ async function fetchAllAgileBoardBacklogPaginated(
   return issueObjects;
 }
 
+/** Single-issue GET — preferred for exact key lookup (avoids deprecated /search and board fan-out). */
+async function fetchIssueByKey(
+  baseUrl: string,
+  authHeaders: Record<string, string>,
+  fieldsParam: string,
+  key: string,
+): Promise<Record<string, unknown> | null> {
+  try {
+    const res = await fetch(
+      `${baseUrl}/rest/api/3/issue/${encodeURIComponent(key)}?fields=${encodeURIComponent(fieldsParam)}`,
+      { headers: authHeaders },
+    );
+    if (!res.ok) return null;
+    const issue = await res.json();
+    return issue && typeof issue === 'object' ? issue as Record<string, unknown> : null;
+  } catch (_) {
+    return null;
+  }
+}
+
 async function fetchIssuesByKeyChunks(
   baseUrl: string,
   authHeaders: Record<string, string>,
@@ -217,11 +233,18 @@ async function fetchIssuesByKeyChunks(
   const seenKeys = new Set<string>();
   const fieldsArr = fieldsParam.split(',');
 
+  // One key: use the issue resource (fast + reliable). /rest/api/3/search is deprecated on Jira Cloud.
+  if (keysToFetch.length === 1) {
+    const issue = await fetchIssueByKey(baseUrl, authHeaders, fieldsParam, keysToFetch[0]);
+    if (issue?.key) allIssues.push(issue);
+    return allIssues;
+  }
+
   for (let i = 0; i < keysToFetch.length; i += KEY_CHUNK) {
     const chunk = keysToFetch.slice(i, i + KEY_CHUNK);
     const keysJql = `key in (${chunk.map((k: string) => `"${String(k).replace(/"/g, '\\"')}"`).join(', ')})`;
     try {
-      const incRes = await fetch(`${baseUrl}/rest/api/3/search`, {
+      const incRes = await fetch(`${baseUrl}/rest/api/3/search/jql`, {
         method: 'POST',
         headers: authHeaders,
         body: JSON.stringify({
@@ -230,7 +253,20 @@ async function fetchIssuesByKeyChunks(
           fields: fieldsArr,
         }),
       });
-      if (!incRes.ok) continue;
+      if (!incRes.ok) {
+        // Fallback: parallel issue GETs if enhanced search rejects the bulk JQL.
+        const fetched = await Promise.all(
+          chunk.map((k) => fetchIssueByKey(baseUrl, authHeaders, fieldsParam, k)),
+        );
+        for (const issue of fetched) {
+          const k = issue?.key as string | undefined;
+          if (k && !seenKeys.has(k)) {
+            seenKeys.add(k);
+            allIssues.push(issue!);
+          }
+        }
+        continue;
+      }
       const incData = await incRes.json();
       for (const issue of incData.issues || []) {
         const k = issue?.key;
@@ -296,6 +332,45 @@ Deno.serve(async (req) => {
     const isNumericBoardId =
       trimmedBoardSetting !== '' && !isNaN(boardIdNum) && String(boardIdNum) === trimmedBoardSetting;
 
+    const coreFieldNames = ['summary', 'status', 'priority', 'assignee', 'reporter', 'parent', 'issuetype'];
+    const buildFieldsParam = (sprintFieldId: string | null, storyPointsFieldId: string | null) => {
+      const pointFieldIdSet = new Set<string>([...JIRA_STORY_POINT_FIELD_FALLBACK_IDS]);
+      if (storyPointsFieldId) pointFieldIdSet.add(storyPointsFieldId);
+      const fieldsArray = [
+        ...coreFieldNames,
+        ...pointFieldIdSet,
+        ...(sprintFieldId ? [sprintFieldId] : ['customfield_10020', 'customfield_10021']),
+      ];
+      return [...new Set(fieldsArray)].join(',');
+    };
+
+    /**
+     * Exact issue-key search: one issue GET (plus team creds). Skip /field discovery and
+     * board/sprint fan-out (often 10+ sequential Jira calls). Ignore browse filters —
+     * typing a key means "get this ticket", even if estimated/Done/closed-sprint.
+     */
+    const exactSearchKey = issueKeyFromSearchText(searchText);
+    if (exactSearchKey && keysOnly !== true) {
+      const fieldsParamFast = buildFieldsParam(null, null);
+      const emptyName = new Map<number | string, string>();
+      const emptyStart = new Map<number | string, string>();
+      const getSprintMeta = createGetSprintMeta(emptyName, emptyStart);
+      const rawIssues = await fetchIssuesByKeyChunks(baseUrl, authHeaders, fieldsParamFast, [exactSearchKey]);
+      // deno-lint-ignore no-explicit-any
+      const issues = rawIssues.map((issue: any) => mapIssueToBrowseRow(issue, getSprintMeta, null));
+      return new Response(
+        JSON.stringify({
+          issues,
+          total: issues.length,
+          jql: `issuekey = "${exactSearchKey}"`,
+        }),
+        {
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+          status: 200,
+        },
+      );
+    }
+
     let sprintFieldId: string | null = null;
     let storyPointsFieldId: string | null = null;
     let fieldsList: { id?: string; name?: string; schema?: { custom?: string } }[] = [];
@@ -314,15 +389,7 @@ Deno.serve(async (req) => {
       /* ignore */
     }
 
-    const coreFieldNames = ['summary', 'status', 'priority', 'assignee', 'reporter', 'parent', 'issuetype'];
-    const pointFieldIdSet = new Set<string>([...JIRA_STORY_POINT_FIELD_FALLBACK_IDS]);
-    if (storyPointsFieldId) pointFieldIdSet.add(storyPointsFieldId);
-    const fieldsArray = [
-      ...coreFieldNames,
-      ...pointFieldIdSet,
-      ...(sprintFieldId ? [sprintFieldId] : ['customfield_10020', 'customfield_10021']),
-    ];
-    const fieldsParam = [...new Set(fieldsArray)].join(',');
+    const fieldsParam = buildFieldsParam(sprintFieldId, storyPointsFieldId);
 
     if (keysOnly === true) {
       if (!Array.isArray(includeKeys) || includeKeys.length === 0) {
@@ -354,6 +421,7 @@ Deno.serve(async (req) => {
       );
     }
 
+    const searching = hasNonEmptySearchText(searchText);
     const storyPointsJqlField = `"${escapeJqlString(DEFAULT_STORY_POINTS_JQL_FIELD_NAME)}"`;
 
     /** Jira `project` JQL must use a project key, not a numeric Agile board id (teams often store board id in jira_board_id). */
@@ -400,7 +468,8 @@ Deno.serve(async (req) => {
       }
     }
 
-    if (resolvedBoardId == null && projectKeyForJql) {
+    // Board discovery + sprint paging are only needed for ranked board browse (not text search).
+    if (!searching && resolvedBoardId == null && projectKeyForJql) {
       try {
         const boardsRes = await fetch(
           `${baseUrl}/rest/agile/1.0/board?projectKeyOrId=${encodeURIComponent(projectKeyForJql)}&maxResults=100`,
@@ -438,7 +507,7 @@ Deno.serve(async (req) => {
     const sprintIdToStartDate = new Map<number | string, string>();
     /** Active + future board sprints (for Agile sprint/issue ranked fetch). */
     let boardActiveFutureSprints: { id: number; startDate?: string; name?: string }[] = [];
-    if (resolvedBoardId != null) {
+    if (!searching && resolvedBoardId != null) {
       try {
         boardActiveFutureSprints = await loadBoardActiveFutureSprints(
           baseUrl,
@@ -472,9 +541,11 @@ Deno.serve(async (req) => {
 
     let jqlReturned: string;
 
-    const useBoardRankedIssueFetch =
-      resolvedBoardId != null &&
-      sprintScope === 'board-open-backlog';
+    const useBoardRankedIssueFetch = shouldUseBoardRankedIssueFetch({
+      resolvedBoardId,
+      sprintScope,
+      searchText,
+    });
 
     const maxPagesOrLoops = 100;
     const pushUniqueIssues = (raw: Record<string, unknown>[]) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Browsing Jira in a Poker Session and searching for a specific ticket (e.g. `RNMT-8100`) was taking several seconds and often returned **No issues found** even when the ticket existed.

### Root cause
`get-jira-board-issues` always used the **board-ranked** path (active/future sprints × paginated issue fetches + orphan discovery + backlog), then tried to resolve the typed key via deprecated `POST /rest/api/3/search`, which failed silently. Default browse filters (`unestimated`, exclude Done) also hid already-pointed tickets from the fan-out.

### Fix
- **Exact key fast path**: if search text is a bare issue key, fetch that issue with `GET /rest/api/3/issue/{key}` and return (skip `/field` discovery and sprint fan-out).
- **Key chunk fetch**: use `/rest/api/3/search/jql`, with per-issue GET fallback.
- **Text search**: skip board-ranked fan-out when any search text is present (use JQL search instead).
- **Frontend**: send `keysOnly` for bare keys; stop `TicketQueuePanel` from refetching on every keystroke.

### Verification (Mobile ALM / production function deployed for this test)
| Search | Before | After |
|--------|--------|-------|
| `RNMT-8107` | ~6–20s, not found | ~0.5s, found |
| `RNMT-8100` | ~21s, not found | ~0.3–0.4s, found |

![Before: RNMT-8100 not found](https://cursor.com/artifacts/c/art-f673cece-6914-4dba-bfac-b820b067e5e7)
![After: RNMT-8100 found](https://cursor.com/artifacts/c/art-2e444392-02ce-438a-b3a4-5b80920565f9)
![Network timing ~480ms](https://cursor.com/artifacts/c/art-bed17e05-1097-4f1f-b7ed-fccbf14f644b)

**Note:** `get-jira-board-issues` was deployed to the Supabase project during verification so the fix could be measured live. Frontend `keysOnly` / keystroke changes land with this PR’s app deploy.

## Test plan
- [x] Deno unit tests for search path helpers
- [x] Vitest for `issueKeyFromSearchText`
- [x] Live poker session (team `db1f0dff-62f1-455c-a251-98da5444cf7a`): search `RNMT-8100` / `RNMT-8107`
- [ ] Confirm default board browse (empty search) still loads sprint-ranked issues
- [ ] Confirm non-key text search still returns matching summaries without multi-sprint fan-out delay
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-73](https://linear.app/dungeon-dwellers/issue/DUN-73/investigate-why-searching-for-a-single-jira-ticket-is-slow)

<div><a href="https://cursor.com/agents/bc-362699da-2484-4f09-93ec-5f1503670cb4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-362699da-2484-4f09-93ec-5f1503670cb4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

