### PR TITLE
docs(DUN-74): Node + Postgres self-host migration plan

### DIFF
--- a/documentation/plans/csharp-pass-through-api-plan.md
+++ b/documentation/plans/csharp-pass-through-api-plan.md
@@ -1,5 +1,7 @@
 ## C# Passthrough API Plan (Front End → C# → Supabase)
 
+> **DUN-74 update:** The preferred self-host path is now **Node + PostgreSQL**, not full Supabase self-host and not C# as the primary stack. See `documentation/plans/self-host-node-postgres-migration-plan.md` and `tasks/tasks-self-host-node-postgres.md`. Keep this document as historical context; reuse inventory/phasing ideas only.
+
 Author: Principal Engineer
 
 Audience: Junior developer (follow every step exactly as written)

--- a/documentation/plans/self-host-coverage-tracker.md
+++ b/documentation/plans/self-host-coverage-tracker.md
@@ -2,30 +2,257 @@
 
 Companion to `documentation/plans/self-host-node-postgres-migration-plan.md` (DUN-74).
 
+**Phase 0 inventory date:** 2026-08-11 (from `main` / current branch FE sources under `src/`).
+
 Legend for Status: Not started | In progress | Covered | Switched | Deprecated
+
+Update this table whenever a call site is migrated.
+
+---
+
+## Inventory summary
+
+| Call type | Count (approx) | Notes |
+|-----------|----------------|-------|
+| `.from('<table>')` call sites | ~280 | Dominant path; PostgREST sidecar |
+| Distinct tables / views | 37 | Includes `poker_session_chat_with_details` view |
+| `functions.invoke` call sites | ~59 | 29 distinct edge functions referenced from FE |
+| `.rpc(...)` call sites | 6 | 5 distinct RPCs |
+| `.channel(...)` sites | 15 | Realtime / presence / broadcast |
+| Storage buckets used in FE | 3 | `avatars`, `poker-session-chat-images`, `retro-audio` (`tts-audio-cache` is edge-only today) |
+
+### Tables / views by FE `.from` frequency
+
+| Resource | ~calls | Domain |
+|----------|--------|--------|
+| poker_session_rounds | 33 | Poker |
+| teams | 26 | Teams / integrations settings on row |
+| retro_boards | 24 | Retro |
+| profiles | 20 | Auth / identity |
+| team_action_items | 18 | Teams |
+| poker_sessions | 16 | Poker |
+| team_members | 15 | Teams |
+| team_invitations | 11 | Invites |
+| app_config | 10 | Admin / config / toggle target |
+| retro_columns | 9 | Retro |
+| retro_items | 7 | Retro |
+| retro_board_config | 7 | Retro |
+| board_templates | 7 | Templates |
+| retro_comments | 6 | Retro |
+| poker_session_chat | 6 | Poker chat |
+| organizations | 5 | Orgs |
+| endorsement_types / endorsements | 5 each | Endorsements |
+| template_columns | 4 | Templates |
+| organization_members / organization_invitations | 4 / 3 | Orgs |
+| notifications | 4 | Notifications |
+| feature_flags (+ user/team overrides) | 4 each | Flags |
+| user_favorite_teams | 3 | Teams |
+| retro_votes | 3 | Retro |
+| org_team_invite_codes | 3 | Orgs |
+| user_recent_activity | 2 | Activity |
+| retro_user_readiness | 2 | Retro |
+| poker_session_chat_message_reactions | 2 | Poker chat |
+| endorsement_settings | 2 | Endorsements |
+| team_default_settings | 1 | Teams |
+| retro_board_sessions | 1 | Slack / retro |
+| poker_session_chat_with_details | 1 | Poker chat view |
+| jira_integration_settings | 1 | Jira |
+| feedback_reports | 1 | Feedback |
+
+Storage bucket string hits via `.from` (not PostgREST tables): `avatars` (4), `retro-audio` (4). Chat images use `poker-session-chat-images` via `storage.from`.
+
+### Edge functions referenced from FE
+
+| Function | ~calls | Priority |
+|----------|--------|----------|
+| update-jira-issue | 5 | P2 |
+| get-jira-board-issues | 5 | P2 |
+| admin-team-members | 5 | P0 |
+| get-jira-issue | 4 | P2 |
+| create-jira-issue | 4 | P2 |
+| send-invitation-email | 3 | P0 |
+| admin-send-notification | 3 | P0 |
+| admin-search-users | 3 | P0 |
+| update-jira-issue-points | 2 | P2 |
+| notify-team-invite | 2 | P0 |
+| get-jira-issue-v3 | 2 | P2 |
+| get-jira-issue-field-options | 2 | P2 |
+| check-subscription | 2 | P3 |
+| update-jira-issue-v2, update-jira-issue-sprint, send-slack-notification, send-poker-round-to-slack, search-jira-assignable-users, notify-retro-start, notify-org-invite, manage-jira-issue-link, get-jira-sprint-options, delete-session-data, customer-portal, create-feedback-github-issue, create-checkout, analyze-board-sentiment, admin-manage-subscription, add-jira-issue-comment | 1 each | P1–P3 |
+
+### RPCs
+
+| RPC | Files |
+|-----|-------|
+| get_user_email_if_admin | `src/hooks/useAuth.tsx` path via Account/AppHeader |
+| accept_team_invitation | `src/hooks/useInvitationAccept.ts` |
+| accept_org_invitation | `src/pages/OrgInviteAccept.tsx` |
+| get_org_team_invite | `src/pages/JoinOrg.tsx` |
+| seed_default_endorsement_types | `src/hooks/useEndorsementTypes.ts` |
+
+---
+
+## Coverage rows (by feature)
+
+### Auth
 
 | Feature | File (path) | Call Type | Resource | Self-host target | Status | Notes |
 |---|---|---|---|---|---|---|
-| Auth session | src/hooks/useAuth.tsx | Auth | supabase.auth | Node `/auth/v1/*` | Not started | Password + Google |
-| Auth form | src/components/AuthForm.tsx | Auth | OAuth + password | Node auth facade | Not started | |
-| Password reset | src/pages/ResetPassword.tsx | Auth | recovery tokens | Node recover/confirm | Not started | |
-| Profiles | src/hooks/useAuth.tsx | PostgREST | profiles | PostgREST/Node | Not started | Includes role=admin |
-| Notifications | src/hooks/useNotifications.ts | PostgREST + Realtime | notifications | REST + WS | Not started | |
-| Teams CRUD | src/hooks/useTeams.ts | PostgREST | teams | REST | Not started | |
-| Team members | src/hooks/useTeamMembers.ts | PostgREST | team_members | REST | Not started | |
-| Retro board | src/hooks/useRetroBoard.ts | PostgREST + Realtime | retro_* | REST + WS | Not started | Presence critical |
-| Poker session | src/hooks/usePokerSession.ts | PostgREST + Realtime | poker_* | REST + WS | Not started | Presence critical |
-| Poker chat | src/hooks/usePokerSessionChat.ts | PostgREST + Storage + Realtime | chat + images | REST + storage + WS | Not started | |
-| Feature flags | src/contexts/FeatureFlagContext.tsx | PostgREST + Realtime | feature_flags | REST + WS | Not started | |
-| Organizations | src/hooks/useOrganizations.ts | PostgREST + RPC | orgs / invites | REST + RPC ports | Not started | |
-| Admin notifications | src/components/admin/AdminSendNotification.tsx | Edge Function | admin-send-notification | Node admin route | Not started | |
-| Admin user search | src/components/admin/* | Edge Function | admin-search-users | Node admin route | Not started | |
-| Jira integrations | various hooks | Edge Functions | get/update-jira-* | Node `/api/jira/*` | Not started | Defer if unused |
-| Slack integrations | various | Edge Functions | slack-* | Node `/api/slack/*` | Not started | Defer if unused |
-| Stripe billing | subscription hooks | Edge Functions | check-subscription, checkout | Decision pending | Not started | |
-| Storage avatars | account components | Storage | avatars | MinIO/disk | Not started | |
+| Auth state / session | src/hooks/useAuth.tsx | Auth | onAuthStateChange, signOut, getSession | Node `/auth/v1/*` | Not started | |
+| Google OAuth | src/components/AuthForm.tsx | Auth | signInWithOAuth(google) | Node authorize/callback | Not started | Preserve identity UUID |
+| Password signup/signin | src/components/AuthForm.tsx | Auth | signUp, signInWithPassword | Node token endpoints | Not started | Import bcrypt hashes |
+| Password reset request | src/components/AuthForm.tsx | Auth | resetPasswordForEmail | Node recover | Not started | |
+| Password reset confirm | src/pages/ResetPassword.tsx | Auth | setSession, updateUser | Node confirm-reset | Not started | |
+| Change password | src/pages/Account.tsx | Auth | signInWithPassword, updateUser | Node | Not started | |
+| getUser helpers | many hooks | Auth | auth.getUser / getSession | Node | Not started | Scattered |
+
+### Profiles & config
+
+| Feature | File (path) | Call Type | Resource | Self-host target | Status | Notes |
+|---|---|---|---|---|---|---|
+| Profile load/update | src/hooks/useAuth.tsx | PostgREST | profiles | PostgREST | Not started | role=admin gate |
+| Theme profile fields | src/contexts/ThemeContext.tsx | PostgREST | profiles | PostgREST | Not started | |
+| Background profile fields | src/contexts/BackgroundContext.tsx | PostgREST | profiles | PostgREST | Not started | |
+| App config reads/writes | src/contexts/FeatureFlagContext.tsx, admin/*, Billing | PostgREST | app_config | PostgREST | Not started | Includes future backend_provider |
+| Feature flags | src/contexts/FeatureFlagContext.tsx | PostgREST + Realtime | feature_flags, overrides | PostgREST + WS | Not started | channel feature-flags-realtime |
+| Admin feature flag UI | src/components/admin/FeatureFlagManager.tsx | PostgREST + Edge | flags + admin-search-users / admin-team-members | PostgREST + Node | Not started | |
+| Tier limits | src/components/admin/TierLimitsManager.tsx | PostgREST | app_config, feature_flags | PostgREST | Not started | |
+| TTS URL config | src/components/admin/TtsUrlManager.tsx | PostgREST | app_config | PostgREST | Not started | |
+| GitHub issue settings | src/components/admin/GithubIssueSettings.tsx | PostgREST | app_config | PostgREST | Not started | |
+
+### Teams & members
+
+| Feature | File (path) | Call Type | Resource | Self-host target | Status | Notes |
+|---|---|---|---|---|---|---|
+| Teams CRUD | src/hooks/useTeams.ts | PostgREST | teams | PostgREST | Not started | |
+| Team settings page | src/pages/TeamSettings.tsx | PostgREST | teams | PostgREST | Not started | |
+| Team members | src/hooks/useTeamMembers.ts | PostgREST | team_members, profiles, invitations | PostgREST | Not started | |
+| Team data context | src/contexts/TeamDataContext.tsx | PostgREST | members, boards, action items, comments | PostgREST | Not started | Heavy aggregator |
+| Invite links | src/hooks/useInviteLinks.ts | PostgREST | team_invitations | PostgREST | Not started | |
+| Accept team invite | src/hooks/useInvitationAccept.ts | RPC | accept_team_invitation | Postgres RPC / Node | Not started | |
+| Send team invite email/notify | useTeamMembers / TeamMembersList | Edge | send-invitation-email, notify-team-invite | Node P0 | Not started | |
+| Favorite teams | src/pages/Teams.tsx | PostgREST | user_favorite_teams | PostgREST | Not started | |
+| Subscription limits | src/hooks/useSubscriptionLimits.ts | PostgREST + Edge | app_config, members, boards, check-subscription | Mixed | Not started | |
+| Admin manage members | src/components/admin/AdminManageTeamMembers.tsx | Edge | admin-team-members | Node P0 | Not started | |
+
+### Organizations
+
+| Feature | File (path) | Call Type | Resource | Self-host target | Status | Notes |
+|---|---|---|---|---|---|---|
+| Orgs CRUD / members | src/hooks/useOrganizations.ts | PostgREST + Edge | organizations*, invitations, notify/email | PostgREST + Node | Not started | |
+| Org selector | src/contexts/OrgSelectorContext.tsx | PostgREST | organization_members | PostgREST | Not started | |
+| Org admin codes | src/pages/OrgAdmin.tsx | PostgREST | teams, org_team_invite_codes | PostgREST | Not started | |
+| Join org | src/pages/JoinOrg.tsx | RPC + PostgREST | get_org_team_invite, teams | RPC + PostgREST | Not started | |
+| Accept org invite | src/pages/OrgInviteAccept.tsx | RPC | accept_org_invitation | RPC | Not started | |
+| Org dashboard | src/pages/OrgDashboard.tsx | PostgREST | teams | PostgREST | Not started | |
+
+### Retro boards
+
+| Feature | File (path) | Call Type | Resource | Self-host target | Status | Notes |
+|---|---|---|---|---|---|---|
+| Retro board core | src/hooks/useRetroBoard.ts | PostgREST + Realtime + Edge | retro_*, team_action_items, notify-retro-start | PostgREST + WS + Node | Not started | Largest retro surface; presence |
+| Team boards | src/hooks/useTeamBoards.ts | PostgREST | retro_boards, config, templates, team_default_settings | PostgREST | Not started | |
+| Room access | src/hooks/useRoomAccess.ts | PostgREST | retro_boards, config | PostgREST | Not started | |
+| User readiness | src/hooks/useUserReadiness.ts | PostgREST | retro_user_readiness | PostgREST | Not started | |
+| Retro page/room | src/pages/Retro.tsx, RetroRoom.tsx | PostgREST | retro_boards | PostgREST | Not started | |
+| Board templates | src/hooks/useBoardTemplates.ts | PostgREST | board_templates, template_columns | PostgREST | Not started | |
+| Action items UI | TeamSidebar / TeamActionItems* | PostgREST + Realtime | team_action_items | PostgREST + WS | Not started | |
+| Backfill action items | src/components/admin/BackfillActionItems.tsx | PostgREST | boards/columns/items/action_items | PostgREST | Not started | Admin |
+| Sentiment | src/components/retro/SentimentDisplay.tsx | Edge | analyze-board-sentiment | Node P3 | Not started | Optional |
+| Retro timer audio | src/components/retro/RetroTimer.tsx | Storage | retro-audio | Docker volume | Not started | upload + public URL |
+| Mentions received | src/components/account/MentionsReceived.tsx | PostgREST | members, boards, items, columns, teams | PostgREST | Not started | |
+
+### Poker
+
+| Feature | File (path) | Call Type | Resource | Self-host target | Status | Notes |
+|---|---|---|---|---|---|---|
+| Poker session | src/hooks/usePokerSession.ts | PostgREST + Realtime + Edge | sessions, rounds, members, delete-session-data, admin-send-notification | PostgREST + WS + Node | Not started | Presence critical |
+| Poker history / rounds | src/hooks/usePokerSessionHistory.ts | PostgREST + Realtime | poker_session_rounds, sessions | PostgREST + WS | Not started | |
+| Poker table context | src/components/Neotro/PokerTableComponent/context.tsx | PostgREST + Edge | rounds, admin-send-notification | PostgREST + Node | Not started | Many round updates |
+| Poker chat | src/hooks/usePokerSessionChat.ts | PostgREST + Storage + Realtime | chat, reactions, poker-session-chat-images | PostgREST + volume + WS | Not started | |
+| Poker helpers | src/lib/supabase/poker.ts, pokerSessionCloneSettings.ts | PostgREST | chat, sessions | PostgREST | Not started | |
+| Team poker list | src/components/team/TeamPokerSessions.tsx | PostgREST + Realtime | poker_sessions / rounds | PostgREST + WS | Not started | |
+| Poker config | src/components/Neotro/PokerConfig.tsx | PostgREST | team_members, profiles | PostgREST | Not started | |
+| Local advisor payload | src/hooks/_pokerLocalAdvisorPayload.ts | PostgREST + Edge | chat, teams, get-jira-issue | Mixed | Not started | |
+| Story points broadcast | src/lib/pokerJiraStoryPointsBroadcast.ts | Realtime | channel poker_session:* | WS | Not started | |
+
+### Jira / Slack / billing / misc edge
+
+| Feature | File (path) | Call Type | Resource | Self-host target | Status | Notes |
+|---|---|---|---|---|---|---|
+| Jira drawer / queue / points | JiraIssueDrawer, TicketQueue*, SubmitPoints*, EmbeddedTicketQueue, PokerAdvisorPanel, DesktopView | Edge | many get/update/create-jira-* | Node `/api/jira/*` P2 | Not started | Largest edge cluster |
+| Jira settings row | src/components/Neotro/PointDetails.tsx | PostgREST | jira_integration_settings | PostgREST | Not started | |
+| Team Jira/Slack flags | useJiraIntegration / useSlackIntegration | PostgREST | teams | PostgREST | Not started | |
+| Slack notify retro/poker | useSlackNotification / usePokerSlackNotification | Edge | send-slack-notification, send-poker-round-to-slack | Node P2 | Not started | |
+| Subscriptions | src/hooks/useSubscription.ts | Edge | check-subscription, create-checkout, customer-portal | Decision pending | Not started | P3 |
+| Admin subscriptions | src/components/admin/AdminSubscriptionManager.tsx | Edge | admin-manage-subscription | Node / defer | Not started | |
+| Feedback → GitHub | src/components/FeedbackButton.tsx | PostgREST + Edge | feedback_reports, create-feedback-github-issue | PostgREST + Node | Not started | |
+| Admin search users | ImpersonateUser / FeatureFlagManager | Edge | admin-search-users | Node P0 | Not started | |
+| Admin send notification | AdminSendNotification / poker paths | Edge | admin-send-notification | Node P0 | Not started | |
+| Admin email RPC | Account / AppHeader | RPC | get_user_email_if_admin | RPC | Not started | |
+
+### Endorsements & activity
+
+| Feature | File (path) | Call Type | Resource | Self-host target | Status | Notes |
+|---|---|---|---|---|---|---|
+| Endorsements | src/hooks/useEndorsements.ts | PostgREST + Realtime | endorsements | PostgREST + WS | Not started | |
+| Endorsement types | src/hooks/useEndorsementTypes.ts | PostgREST + RPC | types, settings, seed_default_* | PostgREST + RPC | Not started | |
+| Endorsements received UI | src/components/account/EndorsementsReceived.tsx | PostgREST | endorsements + joins | PostgREST | Not started | |
+| Recent activity | src/hooks/useRecentActivity.ts, src/lib/recentActivity.ts | PostgREST | user_recent_activity (+ joins) | PostgREST | Not started | |
+
+### Notifications
+
+| Feature | File (path) | Call Type | Resource | Self-host target | Status | Notes |
+|---|---|---|---|---|---|---|
+| Notifications list/mark | src/hooks/useNotifications.ts | PostgREST + Realtime | notifications | PostgREST + WS | Not started | channel realtime:notifications |
+
+### Storage (Docker volumes — locked)
+
+| Feature | File (path) | Call Type | Resource | Self-host target | Status | Notes |
+|---|---|---|---|---|---|---|
+| Avatars | Account.tsx, AccountDetails.tsx | Storage | avatars | Docker volume via Node | Not started | upload + public URL |
+| Poker chat images | src/hooks/usePokerSessionChat.ts | Storage | poker-session-chat-images | Docker volume via Node | Not started | |
+| Retro timer audio | src/components/retro/RetroTimer.tsx | Storage | retro-audio | Docker volume via Node | Not started | |
+| TTS cache | edge functions (not FE-direct) | Storage | tts-audio-cache | Docker volume if/when ported | Not started | Edge-only today |
+
+### Realtime channels (15 sites)
+
+| Area | Files | Channel pattern |
+|------|-------|-----------------|
+| Retro board | useRetroBoard.ts | `retro-board-{id}` (+ presence/broadcast) |
+| Poker session | usePokerSession.ts, use-jira-ticket-metadata.ts, pokerJiraStoryPointsBroadcast.ts | `poker_session:{id}` |
+| Poker rounds history | usePokerSessionHistory.ts | `poker_session_rounds-changes-for-{id}` |
+| Poker chat / reactions | usePokerSessionChat.ts | `poker_chat:{id}`, `poker_chat_reactions:{id}` |
+| Team poker lists | TeamPokerSessions.tsx | `team-poker-sessions-*`, `team-poker-rounds-*` |
+| Action items | TeamSidebar, TeamActionItems, TeamActionItemsComments | `team-action-items-*`, `tai-comments-*` |
+| Notifications | useNotifications.ts | `realtime:notifications` |
+| Feature flags | FeatureFlagContext.tsx | `feature-flags-realtime` |
+| Endorsements | useEndorsements.ts | `endorsements-{boardId}` |
+
+### Platform / dual-path (new work)
+
+| Feature | File (path) | Call Type | Resource | Self-host target | Status | Notes |
+|---|---|---|---|---|---|---|
 | Backend toggle | (new) Admin Backend page | Config | app_config.backend_provider | Node + FE facade | Not started | Admin-only |
-| PostgREST data path | selfhosted restClient | PostgREST | local tables + RLS | Coolify-internal PostgREST | Not started | Sidecar approved; no public domain |
+| Data client facade | (new) src/lib/backend/* | Facade | all of the above | getDataClient() | Not started | Phase 1 |
+| PostgREST data path | selfhosted restClient | PostgREST | local tables + RLS | Coolify-internal PostgREST | Not started | Locked |
+| Object storage volumes | Coolify compose | Ops | named Docker volumes | retroscope_uploads (+ buckets) | Not started | Locked storage choice |
 | Coolify deploy | docker-compose.selfhost.yml | Ops | web/api/postgres/postgrest | Coolify resource | Not started | Shared VPS; expose + limits |
 
-Update this table whenever a call site is migrated.
+---
+
+## Re-inventory command
+
+```bash
+# Tables
+rg -oN "\.from\(['\"][^'\"]+['\"]" src --glob '*.{ts,tsx}' \
+  | sed -E "s/.*\.from\(['\"]([^'\"]+)['\"].*/\1/" | sort | uniq -c | sort -rn
+
+# Edge functions
+rg -oN "functions\.invoke\(['\"][^'\"]+['\"]" src --glob '*.{ts,tsx}' \
+  | sed -E "s/.*invoke\(['\"]([^'\"]+)['\"].*/\1/" | sort | uniq -c | sort -rn
+
+# RPCs / channels
+rg -oN "\.rpc\(['\"][^'\"]+['\"]" src --glob '*.{ts,tsx}'
+rg -n "\.channel\(" src --glob '*.{ts,tsx}'
+```

--- a/documentation/plans/self-host-coverage-tracker.md
+++ b/documentation/plans/self-host-coverage-tracker.md
@@ -1,0 +1,29 @@
+# Self-Host Coverage Tracker (FE → Node / Postgres)
+
+Companion to `documentation/plans/self-host-node-postgres-migration-plan.md` (DUN-74).
+
+Legend for Status: Not started | In progress | Covered | Switched | Deprecated
+
+| Feature | File (path) | Call Type | Resource | Self-host target | Status | Notes |
+|---|---|---|---|---|---|---|
+| Auth session | src/hooks/useAuth.tsx | Auth | supabase.auth | Node `/auth/v1/*` | Not started | Password + Google |
+| Auth form | src/components/AuthForm.tsx | Auth | OAuth + password | Node auth facade | Not started | |
+| Password reset | src/pages/ResetPassword.tsx | Auth | recovery tokens | Node recover/confirm | Not started | |
+| Profiles | src/hooks/useAuth.tsx | PostgREST | profiles | PostgREST/Node | Not started | Includes role=admin |
+| Notifications | src/hooks/useNotifications.ts | PostgREST + Realtime | notifications | REST + WS | Not started | |
+| Teams CRUD | src/hooks/useTeams.ts | PostgREST | teams | REST | Not started | |
+| Team members | src/hooks/useTeamMembers.ts | PostgREST | team_members | REST | Not started | |
+| Retro board | src/hooks/useRetroBoard.ts | PostgREST + Realtime | retro_* | REST + WS | Not started | Presence critical |
+| Poker session | src/hooks/usePokerSession.ts | PostgREST + Realtime | poker_* | REST + WS | Not started | Presence critical |
+| Poker chat | src/hooks/usePokerSessionChat.ts | PostgREST + Storage + Realtime | chat + images | REST + storage + WS | Not started | |
+| Feature flags | src/contexts/FeatureFlagContext.tsx | PostgREST + Realtime | feature_flags | REST + WS | Not started | |
+| Organizations | src/hooks/useOrganizations.ts | PostgREST + RPC | orgs / invites | REST + RPC ports | Not started | |
+| Admin notifications | src/components/admin/AdminSendNotification.tsx | Edge Function | admin-send-notification | Node admin route | Not started | |
+| Admin user search | src/components/admin/* | Edge Function | admin-search-users | Node admin route | Not started | |
+| Jira integrations | various hooks | Edge Functions | get/update-jira-* | Node `/api/jira/*` | Not started | Defer if unused |
+| Slack integrations | various | Edge Functions | slack-* | Node `/api/slack/*` | Not started | Defer if unused |
+| Stripe billing | subscription hooks | Edge Functions | check-subscription, checkout | Decision pending | Not started | |
+| Storage avatars | account components | Storage | avatars | MinIO/disk | Not started | |
+| Backend toggle | (new) Admin Backend page | Config | app_config.backend_provider | Node + FE facade | Not started | Admin-only |
+
+Update this table whenever a call site is migrated.

--- a/documentation/plans/self-host-coverage-tracker.md
+++ b/documentation/plans/self-host-coverage-tracker.md
@@ -25,5 +25,7 @@ Legend for Status: Not started | In progress | Covered | Switched | Deprecated
 | Stripe billing | subscription hooks | Edge Functions | check-subscription, checkout | Decision pending | Not started | |
 | Storage avatars | account components | Storage | avatars | MinIO/disk | Not started | |
 | Backend toggle | (new) Admin Backend page | Config | app_config.backend_provider | Node + FE facade | Not started | Admin-only |
+| PostgREST data path | selfhosted restClient | PostgREST | local tables + RLS | Coolify-internal PostgREST | Not started | Sidecar approved; no public domain |
+| Coolify deploy | docker-compose.selfhost.yml | Ops | web/api/postgres/postgrest | Coolify resource | Not started | Shared VPS; expose + limits |
 
 Update this table whenever a call site is migrated.

--- a/documentation/plans/self-host-node-postgres-migration-plan.md
+++ b/documentation/plans/self-host-node-postgres-migration-plan.md
@@ -42,13 +42,17 @@ Still open: storage backend (disk volume vs MinIO vs Hetzner Object Storage), pr
 ```
 Browser (React SPA)
     │
-    ├─ Auth + REST + Edge replacements ──► Node API (Fastify)
-    │                                         │
-    │                                         ├─► PostgreSQL (app schema + auth schema + RLS)
-    │                                         ├─► Object storage (local disk or S3-compatible, e.g. MinIO / Hetzner Object Storage)
-    │                                         └─► WebSocket realtime (Socket.IO or `pg` LISTEN/NOTIFY fanout)
+    ├─ Auth + privileged/edge routes ──► Node API (Fastify)  ──┐
+    │                                                         ├─► PostgreSQL (schema + RLS)
+    ├─ Table CRUD (user JWT) ──► PostgREST (Coolify-internal) �─► PostgreSQL (schema + RLS)
+    ├─ Table CRUD (user JWT) ──► PostgREST (Coolify-internal) ┘
     │
-    └─ (optional during migration) ──► Hosted Supabase (when admin toggle = "supabase")
+    ├─ Realtime ──► Node WebSockets (Socket.IO / LISTEN-NOTIFY)
+    ├─ Storage ──► Docker volume (default) or S3-compatible
+    │
+    └─ (dual-path) ──► Hosted Supabase when admin toggle = "supabase"
+
+Edge: Coolify Traefik (TLS + domains). PostgREST has no public domain.
 ```
 
 ### Recommended lean stack (Coolify Docker Compose)
@@ -250,7 +254,7 @@ src/lib/backend/
     client.ts              # existing hosted client
   selfhosted/
     authClient.ts
-    restClient.ts          # PostgREST or proxy fluent API
+    restClient.ts          # PostgREST fluent API
     realtimeClient.ts
     storageClient.ts
 src/pages/admin/AdminBackendPage.tsx

--- a/documentation/plans/self-host-node-postgres-migration-plan.md
+++ b/documentation/plans/self-host-node-postgres-migration-plan.md
@@ -11,8 +11,9 @@
 | Data API sidecar | **PostgREST — yes** | Approved; keeps RLS + avoids rewriting ~280 FE query sites |
 | Orchestration | **Coolify** on the existing Hetzner VPS | VPS already hosts many personal projects via Coolify |
 | App stack | Node (Fastify) + Postgres + PostgREST + static FE | No full Supabase self-host |
+| Object storage | **Docker volumes** | Named volume (e.g. `retroscope_uploads`) mounted into Node; bucket prefixes for `avatars`, `poker-session-chat-images`, `retro-audio`, later `tts-audio-cache` |
 
-Still open: storage backend (disk volume vs MinIO vs Hetzner Object Storage), production domain / Coolify FQDNs.
+Still open for Phase 1: production Coolify FQDNs for `web` + `api` (needed for Google OAuth redirect URI).
 
 ---
 
@@ -42,13 +43,12 @@ Still open: storage backend (disk volume vs MinIO vs Hetzner Object Storage), pr
 ```
 Browser (React SPA)
     │
-    ├─ Auth + privileged/edge routes ──► Node API (Fastify)  ──┐
-    │                                                         ├─► PostgreSQL (schema + RLS)
-    ├─ Table CRUD (user JWT) ──► PostgREST (Coolify-internal) �─► PostgreSQL (schema + RLS)
-    ├─ Table CRUD (user JWT) ──► PostgREST (Coolify-internal) ┘
+    ├─ Auth + privileged/edge routes ──► Node API (Fastify) ──┐
+    │                                                        ├─► PostgreSQL (schema + RLS)
+    ├─ Table CRUD (user JWT) ──► PostgREST (internal only) ──┘
     │
     ├─ Realtime ──► Node WebSockets (Socket.IO / LISTEN-NOTIFY)
-    ├─ Storage ──► Docker volume (default) or S3-compatible
+    ├─ Storage ──► Docker volume (`retroscope_uploads` bucket prefixes)
     │
     └─ (dual-path) ──► Hosted Supabase when admin toggle = "supabase"
 
@@ -63,11 +63,11 @@ Edge: Coolify Traefik (TLS + domains). PostgREST has no public domain.
 | **Node (Fastify)** | Auth, edge-function ports, storage signed URLs, WebSockets; proxies/guards PostgREST | One process you control; small RAM footprint |
 | **PostgREST (sidecar)** | Expose tables with existing RLS via JWT `role` claim | Approved; avoids rewriting 280 query shapes; ~50–100MB RAM |
 | **FE (Nginx static)** | Built SPA image | Coolify Traefik terminates TLS |
-| **Volume / Object storage** | Replace Supabase Storage | Prefer a Docker volume first on shared VPS; MinIO only if you already run it |
+| **Docker volume storage** | Replace Supabase Storage | Locked: `retroscope_uploads` (or similar) with per-bucket prefixes; served/signed by Node |
 
 **Data path:** Browser → Node (auth + privileged routes) and/or PostgREST (table CRUD with user JWT). FE keeps a Supabase-compatible fluent client pointed at self-hosted URLs when the admin toggle is `selfhosted`.
 
-**Shared-VPS reality:** This app is one Coolify project among many. Budget Retroscope tightly so neighbors stay healthy. Target **steady-state ≤ ~1.0–1.5 GB RAM** for the whole compose stack (Postgres + PostgREST + Node + FE). Do **not** add Coqui TTS, pgAdmin, or MinIO to the production compose unless you already share those services cluster-wide.
+**Shared-VPS reality:** This app is one Coolify project among many. Budget Retroscope tightly so neighbors stay healthy. Target **steady-state ≤ ~1.0–1.5 GB RAM** for the whole compose stack (Postgres + PostgREST + Node + FE). Do **not** add Coqui TTS, pgAdmin, or MinIO to the production compose.
 
 ---
 
@@ -192,7 +192,7 @@ const client = mode === 'selfhosted' ? selfHostedClient : supabaseClient;
 2. Restore into VPS Postgres.
 3. Ensure roles exist for RLS: `anon`, `authenticated`, `service_role` (patterns already explored on the api-dotnet branch under `api/postgres/init/`).
 4. Replay/verify critical RPCs (`accept_team_invitation`, `is_team_member`, `get_user_email_if_admin`, etc.).
-5. Copy storage objects (avatars, chat images, TTS cache) to MinIO/disk; rewrite public URLs in DB if host changes.
+5. Copy storage objects (avatars, chat images, TTS cache) into the Coolify Docker volume bucket prefixes; rewrite public URLs in DB if host changes.
 
 ### Dual-path period
 
@@ -288,7 +288,7 @@ Ship Coolify-oriented compose files (reuse lessons from `feature/api-dotnet-solu
    - PostgREST stays **internal-only** (no public domain); Node proxies or FE talks through API/CORS as designed.
 4. **Vite env vars are build-time.** Set `VITE_*` in Coolify and **rebuild** when they change (`VITE_API_BASE_URL`, eventual self-host flags, etc.).
 5. **Set `deploy.resources.limits`** on every service so a runaway Postgres/Node cannot starve sibling apps.
-6. **Named volumes only for Retroscope data** (`retroscope_pg_data`, `retroscope_uploads`). Do not share a Postgres container with unrelated Coolify apps unless you intentionally run a central DB service — default is **dedicated Postgres in this compose** for blast-radius isolation.
+6. **Named volumes only for Retroscope data** (`retroscope_pg_data`, `retroscope_uploads`). Mount `retroscope_uploads` into the Node API for bucket prefixes (`avatars/`, `poker-session-chat-images/`, `retro-audio/`, …). Enable Coolify volume backups for both. Do not share a Postgres container with unrelated Coolify apps unless you intentionally run a central DB service — default is **dedicated Postgres in this compose** for blast-radius isolation.
 7. **WebSockets:** ensure Coolify/Traefik has websocket support enabled for the `api` domain (needed for self-hosted realtime).
 8. **Healthchecks** on `api` and `postgres` so Coolify restart policy behaves.
 
@@ -358,11 +358,13 @@ ALLOW_ORIGINS=https://retro.example.com
 
 ## Phased delivery
 
-### Phase 0 — Plan & inventory (this PR)
+### Phase 0 — Plan & inventory (**complete**)
 
 - Publish this plan + task list.
-- ~~PostgREST sidecar~~ — **accepted**.
-- Confirm Coolify domains + storage choice on the shared VPS.
+- PostgREST sidecar — **accepted**.
+- Object storage — **Docker volumes accepted**.
+- FE Supabase call-site inventory seeded in `documentation/plans/self-host-coverage-tracker.md`.
+- Coolify FQDNs for `web`/`api` remain open (needed to start Phase 1 OAuth wiring; compose scaffold can proceed with placeholders).
 
 ### Phase 1 — Skeleton on Coolify
 
@@ -431,9 +433,9 @@ ALLOW_ORIGINS=https://retro.example.com
 
 ---
 
-## Immediate next actions
+## Immediate next actions (Phase 1)
 
-1. Choose storage: **Docker volume (recommended default on shared Coolify)** vs MinIO vs Hetzner Object Storage.
-2. Pick Coolify FQDNs for `web` + `api` and add Google OAuth redirect URI for the API domain.
-3. Start Phase 1 scaffold PR: `server/` + Coolify compose (Postgres + PostgREST + Node + FE) + Admin Backend toggle.
-4. Schedule a staging Coolify resource + restore of production dump to validate schema/RLS under memory caps.
+1. Pick Coolify FQDNs for `web` + `api` (placeholders OK in compose until DNS exists).
+2. Scaffold `server/` Fastify app + `docker-compose.selfhost.yml` (Postgres, PostgREST, Node, FE, `retroscope_uploads` volume) with `expose` + resource limits.
+3. Add Admin Backend toggle wired to `app_config.backend_provider` (both modes still Supabase until Phase 2).
+4. Document Coolify env var block (build-time `VITE_*` vs runtime secrets).

--- a/documentation/plans/self-host-node-postgres-migration-plan.md
+++ b/documentation/plans/self-host-node-postgres-migration-plan.md
@@ -4,6 +4,16 @@
 
 **Non-goals:** Full Supabase Docker stack (GoTrue + Realtime + Storage + Kong + Studio + etc.) — too heavy for the target VPS. Rewriting the React UI. Shipping billing/Jira/Slack parity on day one.
 
+### Locked decisions
+
+| Decision | Choice | Notes |
+|----------|--------|-------|
+| Data API sidecar | **PostgREST — yes** | Approved; keeps RLS + avoids rewriting ~280 FE query sites |
+| Orchestration | **Coolify** on the existing Hetzner VPS | VPS already hosts many personal projects via Coolify |
+| App stack | Node (Fastify) + Postgres + PostgREST + static FE | No full Supabase self-host |
+
+Still open: storage backend (disk volume vs MinIO vs Hetzner Object Storage), production domain / Coolify FQDNs.
+
 ---
 
 ## Current state (main)
@@ -41,19 +51,19 @@ Browser (React SPA)
     └─ (optional during migration) ──► Hosted Supabase (when admin toggle = "supabase")
 ```
 
-### Recommended lean VPS stack
+### Recommended lean stack (Coolify Docker Compose)
 
 | Service | Role | Why this, not full Supabase |
 |---------|------|-----------------------------|
 | **PostgreSQL 16** | Source of truth; keep existing schema + RLS | Same DB you already have |
-| **Node (Fastify)** | Auth, REST facade, edge-function ports, storage signed URLs, WebSockets | One process you control; small RAM footprint |
-| **PostgREST (optional sidecar)** | Expose tables with existing RLS via JWT `role` claim | Avoids reimplementing 280 query shapes; ~50–100MB RAM |
-| **Nginx / Caddy** | TLS, static SPA, reverse proxy `/api`, `/auth`, `/realtime` | Standard VPS edge |
-| **MinIO or filesystem** | Replace Supabase Storage | Avatars/chat/TTS assets |
+| **Node (Fastify)** | Auth, edge-function ports, storage signed URLs, WebSockets; proxies/guards PostgREST | One process you control; small RAM footprint |
+| **PostgREST (sidecar)** | Expose tables with existing RLS via JWT `role` claim | Approved; avoids rewriting 280 query shapes; ~50–100MB RAM |
+| **FE (Nginx static)** | Built SPA image | Coolify Traefik terminates TLS |
+| **Volume / Object storage** | Replace Supabase Storage | Prefer a Docker volume first on shared VPS; MinIO only if you already run it |
 
-**Decision for Phase 1 data access:** Prefer **PostgREST sidecar** behind the Node gateway (or proxied by Node) so the FE can keep a Supabase-compatible query client during migration. If PostgREST is undesirable later, replace table access with typed Node repositories **after** auth/realtime/storage are stable — do not block cutover on rewriting every query.
+**Data path:** Browser → Node (auth + privileged routes) and/or PostgREST (table CRUD with user JWT). FE keeps a Supabase-compatible fluent client pointed at self-hosted URLs when the admin toggle is `selfhosted`.
 
-**Approximate VPS sizing (starting point):** 2 vCPU / 4 GB RAM / 40 GB SSD is enough for Postgres + Node + PostgREST + Nginx for a small team app. Full Supabase self-host typically wants 8 GB+; that is what we are avoiding.
+**Shared-VPS reality:** This app is one Coolify project among many. Budget Retroscope tightly so neighbors stay healthy. Target **steady-state ≤ ~1.0–1.5 GB RAM** for the whole compose stack (Postgres + PostgREST + Node + FE). Do **not** add Coqui TTS, pgAdmin, or MinIO to the production compose unless you already share those services cluster-wide.
 
 ---
 
@@ -163,7 +173,7 @@ const client = mode === 'selfhosted' ? selfHostedClient : supabaseClient;
 
 4. **Server enforcement** — Node health endpoints:
    - `GET /healthz` liveness
-   - `GET /readyz` checks Postgres (+ PostgREST if used)
+   - `GET /readyz` checks Postgres + PostgREST
    - Admin-only `GET /api/admin/backend-status`
 
 5. **Do not** put the toggle behind a public feature flag that non-admins can flip. Reuse admin gate from `AdminLayout`.
@@ -251,26 +261,94 @@ Replace direct imports of `@/integrations/supabase/client` gradually with `getDa
 
 ---
 
-## Hetzner / Lovable exit sequence
+## Coolify deployment (shared Hetzner VPS)
 
-### Deploy (self-hosted)
+The VPS already runs Coolify for many personal projects. Retroscope must be a **good neighbor**: no host port binds, hard memory limits, and no heavy optional sidecars in prod.
 
-1. Provision VPS + domain + TLS (Caddy or Nginx + Let’s Encrypt).
-2. `docker compose` services: `postgres`, `postgrest` (optional), `api` (Node), `web` (nginx static), optional `minio`, optional `tts`.
-3. CI: build FE + Node images; deploy on push to `main` or `deploy` branch.
-4. Set Google redirect URIs and Slack/Jira callbacks to the new domain.
+### Compose layout for Coolify
+
+Ship Coolify-oriented compose files (reuse lessons from `feature/api-dotnet-solution-setup-1` / `COOLIFY_DEPLOYMENT.md`, but Node instead of C#):
+
+| File | Coolify resource | Services |
+|------|------------------|----------|
+| `docker-compose.selfhost.yml` (or `.prod.yml`) | Production | `web`, `api`, `postgres`, `postgrest` |
+| `docker-compose.selfhost.dev.yml` | Optional staging resource | Same + slightly higher limits; no pgAdmin/TTS unless needed |
+
+**Coolify hard rules for this repo:**
+
+1. **Use `expose`, never `ports`** on shared host — Coolify/Traefik publishes via domains. Host port binds collide with other projects.
+2. **One Docker Compose resource per environment** (prod vs staging). Do not mix hot-reload/dev volume mounts into the prod resource.
+3. **Domains via Coolify UI**, e.g.:
+   - `web` → `retro.example.com` (container port 80)
+   - `api` → `retro-api.example.com` (container port 3000/8080)
+   - PostgREST stays **internal-only** (no public domain); Node proxies or FE talks through API/CORS as designed.
+4. **Vite env vars are build-time.** Set `VITE_*` in Coolify and **rebuild** when they change (`VITE_API_BASE_URL`, eventual self-host flags, etc.).
+5. **Set `deploy.resources.limits`** on every service so a runaway Postgres/Node cannot starve sibling apps.
+6. **Named volumes only for Retroscope data** (`retroscope_pg_data`, `retroscope_uploads`). Do not share a Postgres container with unrelated Coolify apps unless you intentionally run a central DB service — default is **dedicated Postgres in this compose** for blast-radius isolation.
+7. **WebSockets:** ensure Coolify/Traefik has websocket support enabled for the `api` domain (needed for self-hosted realtime).
+8. **Healthchecks** on `api` and `postgres` so Coolify restart policy behaves.
+
+### Suggested resource caps (starting point on a busy VPS)
+
+| Service | CPU limit | Memory limit |
+|---------|-----------|--------------|
+| `postgres` | 0.50 | 512M–768M |
+| `postgrest` | 0.25 | 128M–256M |
+| `api` (Node) | 0.50 | 256M–512M |
+| `web` (Nginx) | 0.10 | 64M–128M |
+
+Tune after soak; prefer raising Postgres before Node. Skip bundling Coqui TTS in this compose — if TTS is needed later, point at an existing shared service or keep that feature on the hosted path until cutover.
+
+### Env vars (Coolify)
+
+**Build-time (web):**
+
+```bash
+VITE_API_BASE_URL=https://retro-api.example.com
+# dual-path / toggle defaults as implemented
+```
+
+**Runtime (api / postgrest / postgres):**
+
+```bash
+DATABASE_URL=postgres://retroscope_app:...@postgres:5432/retroscope
+JWT_SECRET=...                 # shared with PostgREST for role claims
+PGRST_JWT_SECRET=...           # same secret
+PGRST_DB_URI=...
+PGRST_DB_ANON_ROLE=anon
+GOOGLE_CLIENT_ID=...
+GOOGLE_CLIENT_SECRET=...
+OAUTH_GOOGLE_REDIRECT_URI=https://retro-api.example.com/auth/v1/callback
+ALLOW_ORIGINS=https://retro.example.com
+# hosted Supabase keys only during dual-path period
+```
+
+### Reference from prior Coolify work
+
+`origin/feature/api-dotnet-solution-setup-1` already solved Coolify footguns (`expose` vs `ports`, separate `docker-compose.dev.yml`, build-time `VITE_*`). Steal those operational patterns; do not reuse the C# API as the long-term runtime.
+
+---
+
+## Lovable / Supabase exit sequence
+
+### Deploy (self-hosted via Coolify)
+
+1. Create Coolify Docker Compose resource → `docker-compose.selfhost.yml`.
+2. Attach domains, env vars, volume backups.
+3. Deploy; verify `/healthz`, FE load, CORS.
+4. Set Google redirect URIs (and Slack/Jira if used) to Coolify API domain.
 
 ### Leave Lovable
 
-1. Source of truth becomes GitHub (already true for agent work).
-2. Stop editing in Lovable; disable Lovable publish once VPS serves production traffic.
-3. Point DNS from `retro-scope.lovable.app` / custom domain to Hetzner.
+1. Source of truth stays GitHub; Coolify deploys from the repo.
+2. Stop Lovable publish once Coolify serves production traffic.
+3. Point custom DNS at the Coolify/Traefik endpoint (not Lovable).
 
 ### Leave hosted Supabase
 
 1. Toggle default → `selfhosted` after soak.
 2. Keep Supabase project read-only for ~2 weeks as rollback.
-3. Cancel Supabase subscription only after: auth login verified (Google + password), retro+poker realtime verified, storage URLs working, edge ports for features you use working, backup/restore tested.
+3. Cancel Supabase only after: Google + password auth verified, retro+poker realtime verified, storage URLs working, needed edge ports working, Coolify backup/restore tested.
 
 ---
 
@@ -279,12 +357,13 @@ Replace direct imports of `@/integrations/supabase/client` gradually with `getDa
 ### Phase 0 — Plan & inventory (this PR)
 
 - Publish this plan + task list.
-- Confirm VPS size, domain, and whether PostgREST sidecar is accepted.
+- ~~PostgREST sidecar~~ — **accepted**.
+- Confirm Coolify domains + storage choice on the shared VPS.
 
-### Phase 1 — Skeleton on VPS
+### Phase 1 — Skeleton on Coolify
 
 - `server/` Node Fastify app: health, config, JWT util.
-- Docker Compose: Postgres (+ init roles), Node, Nginx FE.
+- Coolify compose: Postgres (+ init roles), PostgREST, Node, Nginx FE — `expose` only, memory limits set.
 - Admin Backend page + `app_config.backend_provider` (toggle UI; both modes still point at Supabase until Phase 2).
 
 ### Phase 2 — Local auth
@@ -297,7 +376,7 @@ Replace direct imports of `@/integrations/supabase/client` gradually with `getDa
 ### Phase 3 — Local data path
 
 - Restore schema/data to VPS Postgres.
-- PostgREST (or Node proxy) + FE `restClient`.
+- PostgREST sidecar + FE `restClient` (Node may proxy).
 - Migrate high-traffic hooks behind facade: teams, profiles, notifications, retro board CRUD.
 - Admin dual-path compare for reads (optional).
 
@@ -328,15 +407,18 @@ Replace direct imports of `@/integrations/supabase/client` gradually with `getDa
 | Realtime parity gaps | Keep Supabase realtime until Socket adapter passes poker/retro QA checklist |
 | 280 call sites too many to rewrite | PostgREST + fluent proxy client (pattern from api-dotnet `supabaseProxyClient`) |
 | Toggle causes split-brain data | Prefer freeze + cutover; dual-path for reads/staging only |
-| Secrets in FE | Stop hardcoding anon keys; inject via Vite env at build; service secrets stay on server |
-| VPS backup neglect | Nightly `pg_dump` to Hetzner Object Storage / offsite; test restore once before go-live |
+| Secrets in FE | Stop hardcoding anon keys; inject via Vite env at Coolify **build**; service secrets stay on server |
+| Shared VPS noisy-neighbor | Hard memory/CPU limits; no host `ports:`; PostgREST not publicly exposed; skip heavy sidecars |
+| Coolify port conflicts | Always `expose`; let Traefik map domains (known footgun from prior Coolify work) |
+| VPS backup neglect | Coolify volume backups + nightly `pg_dump` offsite; test restore once before go-live |
 
 ---
 
 ## Acceptance criteria (DUN-74 done)
 
 - [ ] Plan approved (this doc).
-- [ ] App runs on Hetzner with Node + Postgres (no full Supabase stack).
+- [ ] App runs on Coolify (shared Hetzner VPS) with Node + Postgres + PostgREST (no full Supabase stack).
+- [ ] Compose uses `expose` + resource limits and coexists with other Coolify projects.
 - [ ] Google OAuth and email/password both work for migrated users with prior data intact.
 - [ ] Admin-only UI can switch backend provider; non-admins cannot.
 - [ ] Retro + poker usable on self-hosted (including live updates).
@@ -347,7 +429,7 @@ Replace direct imports of `@/integrations/supabase/client` gradually with `getDa
 
 ## Immediate next actions
 
-1. Approve stack choices: **PostgREST sidecar yes/no**, storage = disk vs MinIO vs Hetzner Object Storage.
-2. Reserve domain + Google OAuth redirect URIs.
-3. Start Phase 1 scaffold PR: `server/` + compose + Admin Backend toggle wired to `app_config`.
-4. Schedule a staging restore of production dump to validate schema/RLS on lean Postgres.
+1. Choose storage: **Docker volume (recommended default on shared Coolify)** vs MinIO vs Hetzner Object Storage.
+2. Pick Coolify FQDNs for `web` + `api` and add Google OAuth redirect URI for the API domain.
+3. Start Phase 1 scaffold PR: `server/` + Coolify compose (Postgres + PostgREST + Node + FE) + Admin Backend toggle.
+4. Schedule a staging Coolify resource + restore of production dump to validate schema/RLS under memory caps.

--- a/documentation/plans/self-host-node-postgres-migration-plan.md
+++ b/documentation/plans/self-host-node-postgres-migration-plan.md
@@ -1,0 +1,353 @@
+# Self-Host Migration Plan: Node + PostgreSQL (DUN-74)
+
+**Goal:** Stop paying for hosted Supabase and Lovable by running Retroscope on a Hetzner VPS with a lean stack: **Node API + PostgreSQL** (not full self-hosted Supabase). Preserve Google OAuth and email/password logins. Allow an **admin-only UI toggle** to switch between the hosted Supabase backend and the self-hosted backend during cutover.
+
+**Non-goals:** Full Supabase Docker stack (GoTrue + Realtime + Storage + Kong + Studio + etc.) — too heavy for the target VPS. Rewriting the React UI. Shipping billing/Jira/Slack parity on day one.
+
+---
+
+## Current state (main)
+
+| Area | Reality |
+|------|---------|
+| Frontend | Vite/React SPA; talks **directly** to hosted Supabase |
+| Auth | Supabase Auth: Google OAuth + email/password (`src/components/AuthForm.tsx`, `src/hooks/useAuth.tsx`) |
+| Data | ~280 `supabase.from(...)` call sites, ~6 RPCs, ~40 tables |
+| Edge functions | ~40 Deno functions (Jira, Slack, Stripe, AI/TTS, admin, invites) |
+| Realtime | Critical for retro boards + poker (~15 channels / presence / postgres_changes) |
+| Storage | Buckets: `avatars`, `poker-session-chat-images`, `tts-audio-cache`, `retro-audio` |
+| Admin | Gated by `profiles.role === 'admin'` under `/admin/*` |
+| Config | Hardcoded Supabase URL/anon key in `src/config/environment.ts` |
+
+**Related prior work (do not ignore):**
+
+- `origin/feature/api-dotnet-solution-setup-1` — C# dual-path proxy, local Postgres + PostgREST, local auth + Google OAuth, Coolify compose. **Useful as a design reference**, but this plan intentionally targets **Node** per DUN-74.
+- `origin/vps-supabase` — FE env injection for self-hosted Supabase URL/keys (still “Supabase-shaped”).
+- `documentation/plans/csharp-pass-through-api-plan.md` — typed passthrough roadmap (superseded for stack choice; keep coverage inventory ideas).
+
+---
+
+## Target architecture
+
+```
+Browser (React SPA)
+    │
+    ├─ Auth + REST + Edge replacements ──► Node API (Fastify)
+    │                                         │
+    │                                         ├─► PostgreSQL (app schema + auth schema + RLS)
+    │                                         ├─► Object storage (local disk or S3-compatible, e.g. MinIO / Hetzner Object Storage)
+    │                                         └─► WebSocket realtime (Socket.IO or `pg` LISTEN/NOTIFY fanout)
+    │
+    └─ (optional during migration) ──► Hosted Supabase (when admin toggle = "supabase")
+```
+
+### Recommended lean VPS stack
+
+| Service | Role | Why this, not full Supabase |
+|---------|------|-----------------------------|
+| **PostgreSQL 16** | Source of truth; keep existing schema + RLS | Same DB you already have |
+| **Node (Fastify)** | Auth, REST facade, edge-function ports, storage signed URLs, WebSockets | One process you control; small RAM footprint |
+| **PostgREST (optional sidecar)** | Expose tables with existing RLS via JWT `role` claim | Avoids reimplementing 280 query shapes; ~50–100MB RAM |
+| **Nginx / Caddy** | TLS, static SPA, reverse proxy `/api`, `/auth`, `/realtime` | Standard VPS edge |
+| **MinIO or filesystem** | Replace Supabase Storage | Avatars/chat/TTS assets |
+
+**Decision for Phase 1 data access:** Prefer **PostgREST sidecar** behind the Node gateway (or proxied by Node) so the FE can keep a Supabase-compatible query client during migration. If PostgREST is undesirable later, replace table access with typed Node repositories **after** auth/realtime/storage are stable — do not block cutover on rewriting every query.
+
+**Approximate VPS sizing (starting point):** 2 vCPU / 4 GB RAM / 40 GB SSD is enough for Postgres + Node + PostgREST + Nginx for a small team app. Full Supabase self-host typically wants 8 GB+; that is what we are avoiding.
+
+---
+
+## Design principles
+
+1. **Stable user IDs.** Migrate `auth.users` / `profiles` with the **same UUIDs** so all FK data (teams, boards, votes, poker) keeps working.
+2. **One data-access facade in the FE.** No more scattering `createClient` calls. Introduce `getDataClient()` that returns either the hosted Supabase client or the self-hosted proxy client based on the admin toggle.
+3. **Admin toggle is server-authoritative.** UI control writes `app_config` (or a dedicated `backend_mode` row); FE reads it. localStorage override is only for admin debugging, never the sole source of truth.
+4. **Cut over by capability, not big-bang.** Auth → CRUD → Storage → Edge ports → Realtime → decommission Supabase.
+5. **Reuse RLS.** Keep policies; issue JWTs with `role=authenticated` and `sub=<user uuid>` so PostgREST/RLS behave like today.
+
+---
+
+## Auth plan (Google + password)
+
+### What users need
+
+- Existing Google accounts keep working (same person, same data).
+- Existing email/password accounts keep working (or get a forced reset if hashes cannot be imported).
+- New signups work on self-hosted.
+
+### Node auth module (`server/auth`)
+
+Expose Supabase-compatible routes where practical so FE churn stays low:
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST | `/auth/v1/signup` | Email/password register |
+| POST | `/auth/v1/token?grant_type=password` | Login |
+| POST | `/auth/v1/token?grant_type=refresh_token` | Refresh |
+| GET | `/auth/v1/user` | Current user |
+| POST | `/auth/v1/logout` | Revoke refresh |
+| GET | `/auth/v1/authorize?provider=google` | Start Google OAuth |
+| GET | `/auth/v1/callback` | OAuth callback |
+| POST | `/auth/v1/recover` | Password reset email |
+| GET | `/auth/v1/.well-known/jwks.json` | JWT verification keys |
+
+**Libraries (suggested):** Fastify, `@fastify/jwt` or `jose`, `bcrypt`/`argon2`, `openid-client` (Google), `nodemailer` or Resend for reset mail, `pg`.
+
+### Google OAuth continuity
+
+1. Create a **new** Google OAuth client (or add redirect URIs) for the VPS domain: `https://<domain>/auth/v1/callback`.
+2. On first Google login after migration:
+   - Read Google `sub` + email.
+   - Look up `auth.identities` where `provider = 'google'` and `provider_id = <sub>`.
+   - If found → issue JWT for that existing user UUID.
+   - Else if email matches an existing user → link identity to that UUID (admin-configurable; default: auto-link verified Google email).
+   - Else → create user (or reject if invites-only).
+3. Export identities from Supabase before cutover:
+
+```sql
+-- Run against hosted Supabase (service role / SQL editor)
+select id, email, encrypted_password, email_confirmed_at, raw_app_meta_data, raw_user_meta_data, created_at
+from auth.users;
+
+select id, user_id, provider, identity_data, provider_id, created_at
+from auth.identities;
+```
+
+### Password continuity
+
+- Supabase stores bcrypt hashes in `auth.users.encrypted_password`. Import them into the local auth table and verify with the same algorithm.
+- If any hash format cannot be verified, force password reset for those users only; Google users are unaffected.
+- Keep QA account (`justin.n.loveless@gmail.com`) working in both backends during dual-path testing.
+
+### Session / FE changes
+
+- Abstract auth behind `src/lib/auth/client.ts` with the same surface used by `useAuth` (`signInWithPassword`, `signInWithOAuth`, `signUp`, `signOut`, `onAuthStateChange`, `resetPasswordForEmail`, `updateUser`).
+- Hosted mode: wrap current `supabase.auth`.
+- Self-hosted mode: talk to Node `/auth/v1/*`, store access/refresh tokens (localStorage or httpOnly cookie — prefer httpOnly cookie for production; localStorage OK for parity phase).
+
+---
+
+## Admin backend toggle
+
+### Requirements
+
+- Visible only when `profiles.role === 'admin'`.
+- Switches the **live** backend used by the SPA: `supabase` | `selfhosted`.
+- Survives refresh (persisted).
+- Safe: switching should not brick non-admin users; default for everyone follows server config.
+
+### Implementation
+
+1. **Config store** — row in `app_config`:
+
+```json
+{
+  "key": "backend_provider",
+  "value": { "mode": "supabase", "selfHostedApiBaseUrl": "https://api.example.com" }
+}
+```
+
+2. **Admin UI** — new section under Admin → Integrations (or `/admin/backend`):
+   - Radio/select: Hosted Supabase / Self-hosted Node
+   - Status chips: Auth OK, DB OK, Realtime OK (health probes)
+   - “Apply for all users” vs “Preview for my session only”
+   - Confirm dialog explaining dual-write / data divergence risks
+
+3. **FE routing**
+
+```ts
+// Conceptual
+const mode = adminSessionOverride ?? appConfig.backend_provider.mode;
+const client = mode === 'selfhosted' ? selfHostedClient : supabaseClient;
+```
+
+4. **Server enforcement** — Node health endpoints:
+   - `GET /healthz` liveness
+   - `GET /readyz` checks Postgres (+ PostgREST if used)
+   - Admin-only `GET /api/admin/backend-status`
+
+5. **Do not** put the toggle behind a public feature flag that non-admins can flip. Reuse admin gate from `AdminLayout`.
+
+---
+
+## Data migration
+
+### One-time export → import
+
+1. `pg_dump` schema + data from Supabase Postgres (exclude Supabase-internal noise if desired; **include** `auth.*` and `storage` object metadata).
+2. Restore into VPS Postgres.
+3. Ensure roles exist for RLS: `anon`, `authenticated`, `service_role` (patterns already explored on the api-dotnet branch under `api/postgres/init/`).
+4. Replay/verify critical RPCs (`accept_team_invitation`, `is_team_member`, `get_user_email_if_admin`, etc.).
+5. Copy storage objects (avatars, chat images, TTS cache) to MinIO/disk; rewrite public URLs in DB if host changes.
+
+### Dual-path period
+
+While toggle exists:
+
+| Mode | Auth | Data | Realtime |
+|------|------|------|----------|
+| `supabase` | Hosted Auth | Hosted PostgREST | Hosted Realtime |
+| `selfhosted` | Node Auth | Local Postgres via PostgREST/Node | Node WebSockets |
+
+Optional **shadow compare** (admin-only): call both backends for read endpoints and log diffs (pattern from C# `X-DualPath`). Useful before flipping default to self-hosted.
+
+**Warning:** Dual-write is hard. Prefer **read cutover after a freeze window**: put app in maintenance, final dump/restore, flip toggle, reopen. For long dual-path, treat self-hosted as staging with periodic refresh from prod dumps until go-live.
+
+---
+
+## Edge functions → Node ports
+
+Prioritize by “blocks leaving Supabase”:
+
+| Priority | Functions | Port to |
+|----------|-----------|---------|
+| P0 | `admin-search-users`, `admin-send-notification`, `admin-team-members`, `get-user-email`, invite notify/email | Node admin/notify modules |
+| P1 | `delete-session-data`, `cleanup-poker-sessions` | Node jobs / cron |
+| P2 | Jira suite (~15) | Node `/api/jira/*` using existing team credentials |
+| P2 | Slack suite | Node `/api/slack/*` |
+| P3 | Stripe (`check-subscription`, checkout, portal, admin-manage) | Keep on Supabase until billing needed self-hosted, or port with Stripe SDK |
+| P3 | OpenAI / TTS | Node; can keep pointing at existing Coqui `tts-server` compose service |
+
+Shared secrets move to VPS env / Docker secrets: `JWT_SECRET`, `GOOGLE_CLIENT_*`, `STRIPE_*`, `OPENAI_API_KEY`, Slack tokens, SMTP, service role equivalent.
+
+---
+
+## Realtime strategy
+
+Realtime is the hardest cutover piece (retro + poker collaboration).
+
+**Phase A (keep shipping):** When toggle = `supabase`, keep current channels. When toggle = `selfhosted`, use Node WebSocket gateway.
+
+**Phase B (self-hosted implementation):**
+
+1. Node subscribes to Postgres `LISTEN` channels or uses `pg_notify` triggers on hot tables (`retro_items`, `retro_votes`, `poker_session_rounds`, chat, notifications, feature_flags).
+2. Socket.IO rooms keyed by `board:{id}`, `poker:{sessionId}`, `user:{id}`.
+3. FE adapter implements the small subset of the Supabase realtime API used today: `channel`, `on('postgres_changes')`, `on('presence')`, `on('broadcast')`, `track`, `subscribe`.
+4. Presence: in-memory on Node (single instance) first; Redis adapter if you scale to multiple Node replicas later.
+
+Do **not** block auth/DB cutover on perfect presence parity — but poker/retro must be validated before flipping production default.
+
+---
+
+## Frontend migration shape
+
+```
+src/lib/backend/
+  types.ts                 # BackendMode, health types
+  config.ts                # read app_config + admin override
+  getDataClient.ts         # facade
+  supabase/
+    client.ts              # existing hosted client
+  selfhosted/
+    authClient.ts
+    restClient.ts          # PostgREST or proxy fluent API
+    realtimeClient.ts
+    storageClient.ts
+src/pages/admin/AdminBackendPage.tsx
+src/components/admin/BackendProviderToggle.tsx
+```
+
+Replace direct imports of `@/integrations/supabase/client` gradually with `getDataClient()`. Track remaining call sites in `documentation/plans/self-host-coverage-tracker.md`.
+
+---
+
+## Hetzner / Lovable exit sequence
+
+### Deploy (self-hosted)
+
+1. Provision VPS + domain + TLS (Caddy or Nginx + Let’s Encrypt).
+2. `docker compose` services: `postgres`, `postgrest` (optional), `api` (Node), `web` (nginx static), optional `minio`, optional `tts`.
+3. CI: build FE + Node images; deploy on push to `main` or `deploy` branch.
+4. Set Google redirect URIs and Slack/Jira callbacks to the new domain.
+
+### Leave Lovable
+
+1. Source of truth becomes GitHub (already true for agent work).
+2. Stop editing in Lovable; disable Lovable publish once VPS serves production traffic.
+3. Point DNS from `retro-scope.lovable.app` / custom domain to Hetzner.
+
+### Leave hosted Supabase
+
+1. Toggle default → `selfhosted` after soak.
+2. Keep Supabase project read-only for ~2 weeks as rollback.
+3. Cancel Supabase subscription only after: auth login verified (Google + password), retro+poker realtime verified, storage URLs working, edge ports for features you use working, backup/restore tested.
+
+---
+
+## Phased delivery
+
+### Phase 0 — Plan & inventory (this PR)
+
+- Publish this plan + task list.
+- Confirm VPS size, domain, and whether PostgREST sidecar is accepted.
+
+### Phase 1 — Skeleton on VPS
+
+- `server/` Node Fastify app: health, config, JWT util.
+- Docker Compose: Postgres (+ init roles), Node, Nginx FE.
+- Admin Backend page + `app_config.backend_provider` (toggle UI; both modes still point at Supabase until Phase 2).
+
+### Phase 2 — Local auth
+
+- Implement `/auth/v1/*` + Google OAuth.
+- Import users/identities from Supabase.
+- FE auth facade switches by toggle.
+- Password + Google login work against local auth with **same UUIDs**.
+
+### Phase 3 — Local data path
+
+- Restore schema/data to VPS Postgres.
+- PostgREST (or Node proxy) + FE `restClient`.
+- Migrate high-traffic hooks behind facade: teams, profiles, notifications, retro board CRUD.
+- Admin dual-path compare for reads (optional).
+
+### Phase 4 — Storage + critical edge ports
+
+- Avatars + poker chat images.
+- Admin + invite email functions.
+- Jira/Slack only if you use them daily.
+
+### Phase 5 — Realtime
+
+- WebSocket gateway + FE adapter.
+- Validate retro board + poker session collaboration.
+
+### Phase 6 — Production cutover
+
+- Maintenance window → final dump/restore → toggle default `selfhosted` → soak → remove Lovable/Supabase billing.
+- Delete hosted-only code paths after burn-in.
+
+---
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| UUID / identity mismatch breaks FK data | Export/import `auth.users` + `auth.identities`; never create parallel user rows for the same person |
+| Password hash import fails | Verify bcrypt round-trip in staging; fallback reset email |
+| Realtime parity gaps | Keep Supabase realtime until Socket adapter passes poker/retro QA checklist |
+| 280 call sites too many to rewrite | PostgREST + fluent proxy client (pattern from api-dotnet `supabaseProxyClient`) |
+| Toggle causes split-brain data | Prefer freeze + cutover; dual-path for reads/staging only |
+| Secrets in FE | Stop hardcoding anon keys; inject via Vite env at build; service secrets stay on server |
+| VPS backup neglect | Nightly `pg_dump` to Hetzner Object Storage / offsite; test restore once before go-live |
+
+---
+
+## Acceptance criteria (DUN-74 done)
+
+- [ ] Plan approved (this doc).
+- [ ] App runs on Hetzner with Node + Postgres (no full Supabase stack).
+- [ ] Google OAuth and email/password both work for migrated users with prior data intact.
+- [ ] Admin-only UI can switch backend provider; non-admins cannot.
+- [ ] Retro + poker usable on self-hosted (including live updates).
+- [ ] Lovable publish no longer required for production.
+- [ ] Hosted Supabase can be cancelled after soak without data loss.
+
+---
+
+## Immediate next actions
+
+1. Approve stack choices: **PostgREST sidecar yes/no**, storage = disk vs MinIO vs Hetzner Object Storage.
+2. Reserve domain + Google OAuth redirect URIs.
+3. Start Phase 1 scaffold PR: `server/` + compose + Admin Backend toggle wired to `app_config`.
+4. Schedule a staging restore of production dump to validate schema/RLS on lean Postgres.

--- a/scripts/create-self-host-phase-linear-tickets.mjs
+++ b/scripts/create-self-host-phase-linear-tickets.mjs
@@ -1,0 +1,389 @@
+#!/usr/bin/env node
+/**
+ * Create Linear tickets for DUN-74 self-host migration phases (Retroscope / DUN).
+ *
+ * Env:
+ *   LINEAR_API_KEY       (required)
+ *   LINEAR_TEAM_KEY      (default: DUN)
+ *   LINEAR_PROJECT_NAME  (default: Retroscope)
+ *   LINEAR_PARENT_ID     (optional override for parent issue id; default resolves DUN-74)
+ *
+ * CLI:
+ *   --dry-run   Resolve IDs / print payloads without creating
+ */
+
+const LINEAR_API = "https://api.linear.app/graphql";
+
+const PHASES = [
+  {
+    title: "Self-host Phase 0: Plan & inventory",
+    state: "completed",
+    description: `Parent: [DUN-74](https://linear.app) Self hosted migration.
+
+## Goal
+Lock architecture decisions and inventory FE Supabase coupling before implementation.
+
+## Status
+**Done** (see PR https://github.com/justinloveless/retro-vote-sorter-board/pull/172).
+
+## Locked decisions
+- PostgREST sidecar: yes
+- Coolify on shared Hetzner VPS
+- Object storage: Docker volumes (\`retroscope_uploads\` + bucket prefixes)
+- Stack: Node (Fastify) + Postgres + PostgREST + static FE
+
+## Deliverables
+- \`documentation/plans/self-host-node-postgres-migration-plan.md\`
+- \`documentation/plans/self-host-coverage-tracker.md\` (full FE inventory)
+- \`tasks/tasks-self-host-node-postgres.md\` (Phase 0 marked Done)
+
+## Inventory highlights
+- ~280 \`.from\` call sites / 37 tables
+- 29 edge functions, 5 RPCs, 15 realtime channels
+- FE storage buckets: avatars, poker-session-chat-images, retro-audio
+`,
+  },
+  {
+    title: "Self-host Phase 1: Coolify skeleton + admin backend toggle",
+    description: `Parent: DUN-74 Self hosted migration.
+
+## Goal
+Scaffold the lean Coolify stack and admin-only backend provider toggle (both modes still hosted Supabase until Phase 2).
+
+## Scope
+- Scaffold \`server/\` Fastify app (healthz/readyz, env config, Dockerfile)
+- \`docker-compose.selfhost.yml\`: postgres, postgrest, api, web
+- Named volumes: \`retroscope_pg_data\`, \`retroscope_uploads\`
+- Coolify rules: \`expose\` only (no host ports), CPU/memory limits, PostgREST internal-only
+- FE facade stub: \`src/lib/backend/getDataClient.ts\`
+- \`app_config.backend_provider\` + Admin \`/admin/backend\` toggle (admin-only)
+- Coolify env docs (build-time \`VITE_*\` vs runtime secrets)
+- Stub storage routes for volume bucket prefixes
+
+## Acceptance
+- Compose deploys on Coolify without port conflicts
+- Admin can open Backend page; non-admins cannot
+- Toggle persists via \`app_config\`; default remains supabase
+- Health endpoints green
+
+## Refs
+- Plan: \`documentation/plans/self-host-node-postgres-migration-plan.md\`
+- Tasks: \`tasks/tasks-self-host-node-postgres.md\` (Phase 1)
+`,
+  },
+  {
+    title: "Self-host Phase 2: Local auth (Google + password)",
+    description: `Parent: DUN-74 Self hosted migration.
+
+## Goal
+Replace hosted Supabase Auth with Node \`/auth/v1/*\` while preserving existing user UUIDs for Google OAuth and email/password users.
+
+## Scope
+- Auth schema: users, identities, refresh_tokens, verification codes
+- Password signup/login/refresh (bcrypt-compatible with Supabase hashes)
+- Google OAuth authorize + callback (Coolify API FQDN redirect URI)
+- Password reset email flow
+- Import script: Supabase \`auth.users\` / \`auth.identities\` → local (same UUIDs)
+- FE auth facade switched by admin backend toggle
+- QA: justin.n.loveless@gmail.com Google + password; profile UUID unchanged
+
+## Depends on
+- Phase 1 skeleton + toggle
+- Coolify API domain for OAuth redirect
+
+## Refs
+- Tasks: Phase 2 in \`tasks/tasks-self-host-node-postgres.md\`
+`,
+  },
+  {
+    title: "Self-host Phase 3: Local Postgres + PostgREST data path",
+    description: `Parent: DUN-74 Self hosted migration.
+
+## Goal
+Serve app data from VPS Postgres via PostgREST (Coolify-internal) behind the FE data facade.
+
+## Scope
+- Postgres roles + RLS bootstrap (\`anon\`, \`authenticated\`, \`service_role\`)
+- Staging \`pg_dump\` / \`pg_restore\` from hosted Supabase
+- PostgREST wired to local JWT secret (not publicly routed)
+- FE fluent rest client (Supabase-compatible \`.from().select()\` subset)
+- Migrate core hooks: profiles, teams, members, notifications, retro CRUD
+- Migrate poker + orgs hooks (realtime can still be hosted temporarily)
+- RPC parity for FE RPCs (accept invites, get_user_email_if_admin, etc.)
+
+## Depends on
+- Phase 1 facade + Phase 2 auth (for local JWT → RLS)
+
+## Refs
+- Coverage tracker: \`documentation/plans/self-host-coverage-tracker.md\`
+- Tasks: Phase 3
+`,
+  },
+  {
+    title: "Self-host Phase 4: Docker-volume storage + critical edge ports",
+    description: `Parent: DUN-74 Self hosted migration.
+
+## Goal
+Replace Supabase Storage with Docker volume uploads and port P0 admin/notify edge functions to Node.
+
+## Scope
+- Serve/sign files from \`retroscope_uploads\` prefixes: avatars, poker-session-chat-images, retro-audio
+- Copy existing Supabase Storage objects into the volume; fix public URLs if host changes
+- Port P0 edge functions: admin-search-users, admin-send-notification, admin-team-members, invite email/notify
+- Optional: Jira/Slack ports only if actively used
+- Explicit Stripe decision (keep on Supabase temporarily vs port)
+
+## Depends on
+- Phase 1 volume mount + Phase 2 auth + Phase 3 data
+
+## Refs
+- Tasks: Phase 4
+`,
+  },
+  {
+    title: "Self-host Phase 5: Self-hosted realtime (retro + poker)",
+    description: `Parent: DUN-74 Self hosted migration.
+
+## Goal
+Replace Supabase Realtime with Node WebSockets so collaborative retro/poker works in self-hosted mode.
+
+## Scope
+- Socket.IO (or equivalent) gateway + room model (\`board:{id}\`, \`poker:{sessionId}\`, \`user:{id}\`)
+- Postgres LISTEN/NOTIFY or triggers on hot tables
+- FE adapter for channel / postgres_changes / presence / broadcast subset used today
+- QA: retro voting + poker presence/rounds under \`backend_provider=selfhosted\`
+
+## Depends on
+- Phase 1 API + Phase 3 data
+
+## Refs
+- 15 channel sites listed in coverage tracker
+- Tasks: Phase 5
+`,
+  },
+  {
+    title: "Self-host Phase 6: Production cutover & decommission Supabase/Lovable",
+    description: `Parent: DUN-74 Self hosted migration.
+
+## Goal
+Cut production traffic to Coolify self-hosted stack and cancel hosted Supabase / Lovable after soak.
+
+## Scope
+- Coolify volume backups + nightly \`pg_dump\` restore drill (include uploads volume)
+- Maintenance window: final dump/restore + object copy
+- Flip admin default toggle → \`selfhosted\`; monitor; rollback = flip back
+- DNS / stop Lovable publish
+- Soak ~2 weeks, then cancel hosted Supabase
+- Remove dual-path / hosted-only FE code; coverage tracker 100%
+
+## Depends on
+- Phases 2–5 acceptance criteria green
+
+## Refs
+- Tasks: Phase 6
+- Plan acceptance criteria in \`documentation/plans/self-host-node-postgres-migration-plan.md\`
+`,
+  },
+];
+
+function env(name, fallback) {
+  const value = process.env[name];
+  if (value == null || value === "") return fallback;
+  return value;
+}
+
+async function linearGraphQL(apiKey, query, variables = {}) {
+  const res = await fetch(LINEAR_API, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: apiKey,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error(`Linear HTTP ${res.status}: ${JSON.stringify(json)}`);
+  }
+  if (json.errors?.length) {
+    throw new Error(`Linear GraphQL errors: ${JSON.stringify(json.errors)}`);
+  }
+  return json.data;
+}
+
+async function resolveTeamAndProject(apiKey, { teamKey, projectName }) {
+  const data = await linearGraphQL(
+    apiKey,
+    `
+    query ResolveTeamProject($teamKey: String!) {
+      teams(filter: { key: { eq: $teamKey } }) {
+        nodes {
+          id
+          key
+          name
+          states { nodes { id name type } }
+          projects { nodes { id name } }
+        }
+      }
+    }
+    `,
+    { teamKey }
+  );
+
+  const team = data.teams?.nodes?.[0];
+  if (!team) throw new Error(`No Linear team found with key "${teamKey}"`);
+
+  const project = (team.projects?.nodes || []).find(
+    (p) => p.name.toLowerCase() === projectName.toLowerCase()
+  );
+  if (!project) {
+    const available = (team.projects?.nodes || []).map((p) => p.name).join(", ") || "(none)";
+    throw new Error(`No project named "${projectName}" on team ${team.key}. Available: ${available}`);
+  }
+
+  return { team, project };
+}
+
+async function resolveParentIssue(apiKey, teamId, identifier = "DUN-74") {
+  const data = await linearGraphQL(
+    apiKey,
+    `
+    query FindParent($filter: IssueFilter!) {
+      issues(filter: $filter, first: 1) {
+        nodes { id identifier title url }
+      }
+    }
+    `,
+    {
+      filter: {
+        team: { id: { eq: teamId } },
+        number: { eq: Number(String(identifier).split("-").pop()) },
+      },
+    }
+  );
+  const issue = data.issues?.nodes?.[0];
+  if (!issue) throw new Error(`Could not resolve parent issue ${identifier}`);
+  return issue;
+}
+
+async function findExistingPhaseIssue(apiKey, teamId, projectId, title) {
+  const data = await linearGraphQL(
+    apiKey,
+    `
+    query FindExisting($filter: IssueFilter!) {
+      issues(filter: $filter, first: 5) {
+        nodes { id identifier title url }
+      }
+    }
+    `,
+    {
+      filter: {
+        team: { id: { eq: teamId } },
+        project: { id: { eq: projectId } },
+        title: { eq: title },
+      },
+    }
+  );
+  return data.issues?.nodes?.[0] || null;
+}
+
+async function createLinearIssue(apiKey, input) {
+  const data = await linearGraphQL(
+    apiKey,
+    `
+    mutation IssueCreate($input: IssueCreateInput!) {
+      issueCreate(input: $input) {
+        success
+        issue { id identifier url title }
+      }
+    }
+    `,
+    { input }
+  );
+  if (!data.issueCreate?.success || !data.issueCreate.issue) {
+    throw new Error(`issueCreate failed: ${JSON.stringify(data)}`);
+  }
+  return data.issueCreate.issue;
+}
+
+async function markIssueDone(apiKey, issueId, doneStateId) {
+  if (!doneStateId) return;
+  await linearGraphQL(
+    apiKey,
+    `
+    mutation IssueUpdate($id: String!, $input: IssueUpdateInput!) {
+      issueUpdate(id: $id, input: $input) { success }
+    }
+    `,
+    { id: issueId, input: { stateId: doneStateId } }
+  );
+}
+
+async function main() {
+  const dryRun = process.argv.includes("--dry-run");
+  const apiKey = env("LINEAR_API_KEY");
+  const teamKey = env("LINEAR_TEAM_KEY", "DUN");
+  const projectName = env("LINEAR_PROJECT_NAME", "Retroscope");
+  const parentOverride = env("LINEAR_PARENT_ID");
+
+  if (!apiKey) {
+    console.error("LINEAR_API_KEY is required");
+    process.exit(1);
+  }
+
+  const { team, project } = await resolveTeamAndProject(apiKey, { teamKey, projectName });
+  const doneState = (team.states?.nodes || []).find(
+    (s) => s.type === "completed" || /done|complete/i.test(s.name)
+  );
+  const parent = parentOverride
+    ? { id: parentOverride, identifier: "OVERRIDE", title: "override", url: "" }
+    : await resolveParentIssue(apiKey, team.id, "DUN-74");
+
+  const results = [];
+  for (const phase of PHASES) {
+    const existing = await findExistingPhaseIssue(apiKey, team.id, project.id, phase.title);
+    if (existing) {
+      results.push({ skipped: true, reason: "already exists", issue: existing });
+      continue;
+    }
+
+    const input = {
+      teamId: team.id,
+      projectId: project.id,
+      parentId: parent.id,
+      title: phase.title,
+      description: phase.description,
+    };
+
+    if (dryRun) {
+      results.push({ dryRun: true, input: { ...input, description: `[${phase.description.length} chars]` } });
+      continue;
+    }
+
+    const issue = await createLinearIssue(apiKey, input);
+    if (phase.state === "completed" && doneState?.id) {
+      await markIssueDone(apiKey, issue.id, doneState.id);
+    }
+    results.push({ created: true, issue, markedDone: phase.state === "completed" });
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        parent: { id: parent.id, identifier: parent.identifier, url: parent.url },
+        team: { id: team.id, key: team.key },
+        project: { id: project.id, name: project.name },
+        doneState: doneState ? { id: doneState.id, name: doneState.name } : null,
+        results,
+      },
+      null,
+      2
+    )
+  );
+}
+
+main().catch((err) => {
+  console.error(err.message || err);
+  process.exit(1);
+});

--- a/tasks/tasks-csharp-pass-through-api.md
+++ b/tasks/tasks-csharp-pass-through-api.md
@@ -1,5 +1,7 @@
 ## Tasks: C# Passthrough API (Front End → C# → Supabase)
 
+> **DUN-74:** Prefer the Node + PostgreSQL self-host task list instead: `tasks/tasks-self-host-node-postgres.md`.
+
 Source plan: `documentation/plans/csharp-pass-through-api-plan.md`
 
 Process guide: `documentation/plans/development-process.md`

--- a/tasks/tasks-self-host-node-postgres.md
+++ b/tasks/tasks-self-host-node-postgres.md
@@ -1,0 +1,86 @@
+## Tasks: Self-Host Migration — Node + PostgreSQL (DUN-74)
+
+Source plan: `documentation/plans/self-host-node-postgres-migration-plan.md`
+
+Status values: Not started | In progress | Blocked | In review | Done
+
+### Phase 0 — Plan
+
+| # | Task Name | Task Description | Status | Blocked By | Notes |
+|---|---|---|---|---|---|
+| 0.1 | Publish migration plan | Land plan doc + this task list; get stakeholder approval on PostgREST sidecar + storage choice | In review | - | DUN-74 |
+| 0.2 | Inventory FE Supabase call sites | Seed `documentation/plans/self-host-coverage-tracker.md` from ripgrep of `.from(`, `.rpc(`, `.functions.`, `.channel(`, `.storage.` | Not started | 0.1 | Reuse ideas from csharp-api-coverage-tracker |
+| 0.3 | Decide VPS topology | Confirm Hetzner size, domain, TLS, backup target | Not started | 0.1 | |
+
+### Phase 1 — Skeleton
+
+| # | Task Name | Task Description | Status | Blocked By | Notes |
+|---|---|---|---|---|---|
+| 1.1 | Scaffold `server/` Fastify app | Healthz/readyz, config from env, TypeScript build, Dockerfile | Not started | 0.1 | |
+| 1.2 | Compose stack | `docker-compose.selfhost.yml`: postgres, api, web (nginx), optional postgrest/minio | Not started | 1.1 | Keep under ~4GB RAM total |
+| 1.3 | FE backend facade stub | `src/lib/backend/getDataClient.ts` + mode types; default still Supabase | Not started | 0.1 | |
+| 1.4 | `app_config.backend_provider` | Migration + types for mode + self-hosted base URL | Not started | 1.3 | |
+| 1.5 | Admin Backend page | `/admin/backend` toggle UI, admin-only, confirm dialog, session preview override | Not started | 1.4 | Gate via `profiles.role === 'admin'` |
+| 1.6 | Nginx routes | Proxy `/api`, `/auth`, `/realtime` to Node; SPA fallback | Not started | 1.2 | |
+
+### Phase 2 — Auth
+
+| # | Task Name | Task Description | Status | Blocked By | Notes |
+|---|---|---|---|---|---|
+| 2.1 | Auth schema | Local `auth.users`, `auth.identities`, `auth.refresh_tokens`, verification codes | Not started | 1.2 | Preserve UUID PK shape |
+| 2.2 | Password signup/login/refresh | Supabase-compatible `/auth/v1/*` token endpoints | Not started | 2.1 | bcrypt compatible with Supabase hashes |
+| 2.3 | Google OAuth | authorize + callback; link by provider_id / verified email | Not started | 2.2 | New redirect URI on VPS domain |
+| 2.4 | Password reset email | Recover + confirm; SMTP/Resend | Not started | 2.2 | |
+| 2.5 | User/identity import script | Export from Supabase → import local with same UUIDs | Not started | 2.1 | |
+| 2.6 | FE auth facade | Switch `useAuth` to facade; toggle selects hosted vs Node auth | Not started | 2.2, 1.5 | |
+| 2.7 | Auth QA | Google + password for QA user; profile UUID unchanged | Not started | 2.3, 2.5, 2.6 | |
+
+### Phase 3 — Data
+
+| # | Task Name | Task Description | Status | Blocked By | Notes |
+|---|---|---|---|---|---|
+| 3.1 | Postgres roles + RLS bootstrap | `anon` / `authenticated` / `service_role`; grant patterns | Not started | 1.2 | See api-dotnet `api/postgres/init` as reference only |
+| 3.2 | Staging restore | `pg_dump`/`pg_restore` from hosted Supabase to VPS | Not started | 3.1 | |
+| 3.3 | PostgREST or Node REST proxy | JWT → DB role; expose tables | Not started | 3.2 | Prefer PostgREST sidecar |
+| 3.4 | FE rest client | Fluent proxy compatible with common `.from().select()` usage | Not started | 3.3, 1.3 | Inspired by csharp `supabaseProxyClient` |
+| 3.5 | Migrate core hooks | profiles, teams, members, notifications, retro board CRUD behind facade | Not started | 3.4 | |
+| 3.6 | Migrate poker + orgs hooks | Sessions, rounds, chat metadata (without realtime yet if needed) | Not started | 3.5 | |
+| 3.7 | RPC parity | Port or proxy critical RPCs used by FE | Not started | 3.3 | |
+
+### Phase 4 — Storage & edge ports
+
+| # | Task Name | Task Description | Status | Blocked By | Notes |
+|---|---|---|---|---|---|
+| 4.1 | Storage backend | Disk or MinIO; buckets for avatars + chat images | Not started | 1.2 | |
+| 4.2 | Copy existing objects | Migrate blobs; fix public URLs if host changes | Not started | 4.1, 3.2 | |
+| 4.3 | Admin/notify edge ports | search users, send notification, team members, invites email | Not started | 2.2, 3.3 | |
+| 4.4 | Jira/Slack ports (if used) | Move only integrations you rely on | Not started | 3.3 | Can defer |
+| 4.5 | Stripe decision | Keep on Supabase temporarily or port | Not started | - | Explicit product choice |
+
+### Phase 5 — Realtime
+
+| # | Task Name | Task Description | Status | Blocked By | Notes |
+|---|---|---|---|---|---|
+| 5.1 | WebSocket gateway | Socket.IO + room model for boards/sessions/users | Not started | 1.1, 3.2 | |
+| 5.2 | Postgres notify hooks | Triggers or LISTEN on hot tables | Not started | 5.1 | |
+| 5.3 | FE realtime adapter | Subset of supabase channel/presence/broadcast API | Not started | 5.1, 1.3 | |
+| 5.4 | Collaborative QA | Retro voting + poker presence/rounds under self-hosted mode | Not started | 5.3 | |
+
+### Phase 6 — Cutover
+
+| # | Task Name | Task Description | Status | Blocked By | Notes |
+|---|---|---|---|---|---|
+| 6.1 | Backup + restore drill | Nightly dump + successful restore test | Not started | 3.2 | |
+| 6.2 | Production freeze + final sync | Maintenance window; final dump/restore | Not started | 2.7, 3.5, 4.3, 5.4 | |
+| 6.3 | Flip default toggle to selfhosted | Monitor errors; rollback plan = flip back | Not started | 6.2 | |
+| 6.4 | DNS / leave Lovable | Serve production from VPS; stop Lovable publish | Not started | 6.3 | |
+| 6.5 | Decommission Supabase | After soak (~2 weeks), cancel hosted Supabase | Not started | 6.3, 6.4 | |
+| 6.6 | Remove hosted code paths | Delete dual-path once stable; tracker 100% | Not started | 6.5 | |
+
+### Reference (do not implement as primary path)
+
+| Item | Location | Use |
+|------|----------|-----|
+| C# dual-path proxy / local auth | `origin/feature/api-dotnet-solution-setup-1` | Design reference only |
+| Env-injected Supabase URL | `origin/vps-supabase` | Pattern for build-args |
+| Old C# passthrough plan | `documentation/plans/csharp-pass-through-api-plan.md` | Superseded stack choice for DUN-74 |

--- a/tasks/tasks-self-host-node-postgres.md
+++ b/tasks/tasks-self-host-node-postgres.md
@@ -8,20 +8,22 @@ Status values: Not started | In progress | Blocked | In review | Done
 
 | # | Task Name | Task Description | Status | Blocked By | Notes |
 |---|---|---|---|---|---|
-| 0.1 | Publish migration plan | Land plan doc + this task list; get stakeholder approval on PostgREST sidecar + storage choice | In review | - | DUN-74 |
+| 0.1 | Publish migration plan | Land plan doc + this task list | Done | - | DUN-74 |
 | 0.2 | Inventory FE Supabase call sites | Seed `documentation/plans/self-host-coverage-tracker.md` from ripgrep of `.from(`, `.rpc(`, `.functions.`, `.channel(`, `.storage.` | Not started | 0.1 | Reuse ideas from csharp-api-coverage-tracker |
-| 0.3 | Decide VPS topology | Confirm Hetzner size, domain, TLS, backup target | Not started | 0.1 | |
+| 0.3 | Coolify topology | Confirm Coolify FQDNs for web/api, storage choice, backup strategy on shared VPS | In progress | 0.1 | PostgREST sidecar **accepted**; hosting = Coolify |
+| 0.4 | Lock PostgREST decision | Use PostgREST sidecar in compose (not optional) | Done | 0.1 | Stakeholder approved |
 
 ### Phase 1 — Skeleton
 
 | # | Task Name | Task Description | Status | Blocked By | Notes |
 |---|---|---|---|---|---|
 | 1.1 | Scaffold `server/` Fastify app | Healthz/readyz, config from env, TypeScript build, Dockerfile | Not started | 0.1 | |
-| 1.2 | Compose stack | `docker-compose.selfhost.yml`: postgres, api, web (nginx), optional postgrest/minio | Not started | 1.1 | Keep under ~4GB RAM total |
+| 1.2 | Coolify compose stack | `docker-compose.selfhost.yml`: postgres, postgrest, api, web — `expose` only, memory/CPU limits, no host ports | Not started | 1.1 | Target ≤ ~1.0–1.5GB total; good neighbor on shared Coolify VPS |
 | 1.3 | FE backend facade stub | `src/lib/backend/getDataClient.ts` + mode types; default still Supabase | Not started | 0.1 | |
 | 1.4 | `app_config.backend_provider` | Migration + types for mode + self-hosted base URL | Not started | 1.3 | |
 | 1.5 | Admin Backend page | `/admin/backend` toggle UI, admin-only, confirm dialog, session preview override | Not started | 1.4 | Gate via `profiles.role === 'admin'` |
-| 1.6 | Nginx routes | Proxy `/api`, `/auth`, `/realtime` to Node; SPA fallback | Not started | 1.2 | |
+| 1.6 | Coolify domains + proxy | Map web/api FQDNs; keep PostgREST internal; enable WS on api; SPA nginx | Not started | 1.2 | Steal patterns from prior `COOLIFY_DEPLOYMENT.md` |
+| 1.7 | Coolify env docs | Document build-time `VITE_*` vs runtime secrets; sample Coolify env block | Not started | 1.2 | Rebuild FE when Vite vars change |
 
 ### Phase 2 — Auth
 
@@ -41,7 +43,7 @@ Status values: Not started | In progress | Blocked | In review | Done
 |---|---|---|---|---|---|
 | 3.1 | Postgres roles + RLS bootstrap | `anon` / `authenticated` / `service_role`; grant patterns | Not started | 1.2 | See api-dotnet `api/postgres/init` as reference only |
 | 3.2 | Staging restore | `pg_dump`/`pg_restore` from hosted Supabase to VPS | Not started | 3.1 | |
-| 3.3 | PostgREST or Node REST proxy | JWT → DB role; expose tables | Not started | 3.2 | Prefer PostgREST sidecar |
+| 3.3 | PostgREST sidecar | JWT → DB role; expose tables; not publicly routed in Coolify | Not started | 3.2 | Locked decision |
 | 3.4 | FE rest client | Fluent proxy compatible with common `.from().select()` usage | Not started | 3.3, 1.3 | Inspired by csharp `supabaseProxyClient` |
 | 3.5 | Migrate core hooks | profiles, teams, members, notifications, retro board CRUD behind facade | Not started | 3.4 | |
 | 3.6 | Migrate poker + orgs hooks | Sessions, rounds, chat metadata (without realtime yet if needed) | Not started | 3.5 | |

--- a/tasks/tasks-self-host-node-postgres.md
+++ b/tasks/tasks-self-host-node-postgres.md
@@ -2,28 +2,32 @@
 
 Source plan: `documentation/plans/self-host-node-postgres-migration-plan.md`
 
+Coverage tracker: `documentation/plans/self-host-coverage-tracker.md`
+
 Status values: Not started | In progress | Blocked | In review | Done
 
-### Phase 0 — Plan
+### Phase 0 — Plan (**Done**)
 
 | # | Task Name | Task Description | Status | Blocked By | Notes |
 |---|---|---|---|---|---|
 | 0.1 | Publish migration plan | Land plan doc + this task list | Done | - | DUN-74 |
-| 0.2 | Inventory FE Supabase call sites | Seed `documentation/plans/self-host-coverage-tracker.md` from ripgrep of `.from(`, `.rpc(`, `.functions.`, `.channel(`, `.storage.` | Not started | 0.1 | Reuse ideas from csharp-api-coverage-tracker |
-| 0.3 | Coolify topology | Confirm Coolify FQDNs for web/api, storage choice, backup strategy on shared VPS | In progress | 0.1 | PostgREST sidecar **accepted**; hosting = Coolify |
+| 0.2 | Inventory FE Supabase call sites | Full inventory in `self-host-coverage-tracker.md` (tables, RPCs, edge fns, realtime, storage) | Done | 0.1 | ~280 `.from`, 29 edge fns, 5 RPCs, 15 channels, 3 FE storage buckets |
+| 0.3 | Coolify topology | Coolify shared VPS constraints documented; compose rules (`expose`, limits) | Done | 0.1 | FQDNs still TBD for Phase 1 |
 | 0.4 | Lock PostgREST decision | Use PostgREST sidecar in compose (not optional) | Done | 0.1 | Stakeholder approved |
+| 0.5 | Lock storage decision | Docker volumes (`retroscope_uploads` + bucket prefixes) | Done | 0.1 | Stakeholder approved |
 
 ### Phase 1 — Skeleton
 
 | # | Task Name | Task Description | Status | Blocked By | Notes |
 |---|---|---|---|---|---|
 | 1.1 | Scaffold `server/` Fastify app | Healthz/readyz, config from env, TypeScript build, Dockerfile | Not started | 0.1 | |
-| 1.2 | Coolify compose stack | `docker-compose.selfhost.yml`: postgres, postgrest, api, web — `expose` only, memory/CPU limits, no host ports | Not started | 1.1 | Target ≤ ~1.0–1.5GB total; good neighbor on shared Coolify VPS |
+| 1.2 | Coolify compose stack | `docker-compose.selfhost.yml`: postgres, postgrest, api, web + `retroscope_pg_data` / `retroscope_uploads` — `expose` only, memory/CPU limits | Not started | 1.1 | Target ≤ ~1.0–1.5GB total |
 | 1.3 | FE backend facade stub | `src/lib/backend/getDataClient.ts` + mode types; default still Supabase | Not started | 0.1 | |
 | 1.4 | `app_config.backend_provider` | Migration + types for mode + self-hosted base URL | Not started | 1.3 | |
 | 1.5 | Admin Backend page | `/admin/backend` toggle UI, admin-only, confirm dialog, session preview override | Not started | 1.4 | Gate via `profiles.role === 'admin'` |
-| 1.6 | Coolify domains + proxy | Map web/api FQDNs; keep PostgREST internal; enable WS on api; SPA nginx | Not started | 1.2 | Steal patterns from prior `COOLIFY_DEPLOYMENT.md` |
+| 1.6 | Coolify domains + proxy | Map web/api FQDNs; keep PostgREST internal; enable WS on api; SPA nginx | Not started | 1.2 | Placeholders OK until DNS ready |
 | 1.7 | Coolify env docs | Document build-time `VITE_*` vs runtime secrets; sample Coolify env block | Not started | 1.2 | Rebuild FE when Vite vars change |
+| 1.8 | Uploads volume wiring | Mount `retroscope_uploads` into Node; stub storage routes for avatars/chat/audio prefixes | Not started | 1.2 | Storage choice locked |
 
 ### Phase 2 — Auth
 
@@ -31,7 +35,7 @@ Status values: Not started | In progress | Blocked | In review | Done
 |---|---|---|---|---|---|
 | 2.1 | Auth schema | Local `auth.users`, `auth.identities`, `auth.refresh_tokens`, verification codes | Not started | 1.2 | Preserve UUID PK shape |
 | 2.2 | Password signup/login/refresh | Supabase-compatible `/auth/v1/*` token endpoints | Not started | 2.1 | bcrypt compatible with Supabase hashes |
-| 2.3 | Google OAuth | authorize + callback; link by provider_id / verified email | Not started | 2.2 | New redirect URI on VPS domain |
+| 2.3 | Google OAuth | authorize + callback; link by provider_id / verified email | Not started | 2.2 | Needs Coolify API FQDN |
 | 2.4 | Password reset email | Recover + confirm; SMTP/Resend | Not started | 2.2 | |
 | 2.5 | User/identity import script | Export from Supabase → import local with same UUIDs | Not started | 2.1 | |
 | 2.6 | FE auth facade | Switch `useAuth` to facade; toggle selects hosted vs Node auth | Not started | 2.2, 1.5 | |
@@ -53,8 +57,8 @@ Status values: Not started | In progress | Blocked | In review | Done
 
 | # | Task Name | Task Description | Status | Blocked By | Notes |
 |---|---|---|---|---|---|
-| 4.1 | Storage backend | Disk or MinIO; buckets for avatars + chat images | Not started | 1.2 | |
-| 4.2 | Copy existing objects | Migrate blobs; fix public URLs if host changes | Not started | 4.1, 3.2 | |
+| 4.1 | Storage backend on volume | Serve/sign uploads from `retroscope_uploads` bucket prefixes | Not started | 1.8 | Docker volumes locked |
+| 4.2 | Copy existing objects | Migrate blobs from Supabase Storage into volume; fix public URLs if host changes | Not started | 4.1, 3.2 | |
 | 4.3 | Admin/notify edge ports | search users, send notification, team members, invites email | Not started | 2.2, 3.3 | |
 | 4.4 | Jira/Slack ports (if used) | Move only integrations you rely on | Not started | 3.3 | Can defer |
 | 4.5 | Stripe decision | Keep on Supabase temporarily or port | Not started | - | Explicit product choice |
@@ -72,10 +76,10 @@ Status values: Not started | In progress | Blocked | In review | Done
 
 | # | Task Name | Task Description | Status | Blocked By | Notes |
 |---|---|---|---|---|---|
-| 6.1 | Backup + restore drill | Nightly dump + successful restore test | Not started | 3.2 | |
-| 6.2 | Production freeze + final sync | Maintenance window; final dump/restore | Not started | 2.7, 3.5, 4.3, 5.4 | |
+| 6.1 | Backup + restore drill | Coolify volume backups + nightly dump + successful restore test | Not started | 3.2 | Include `retroscope_uploads` |
+| 6.2 | Production freeze + final sync | Maintenance window; final dump/restore + object copy | Not started | 2.7, 3.5, 4.3, 5.4 | |
 | 6.3 | Flip default toggle to selfhosted | Monitor errors; rollback plan = flip back | Not started | 6.2 | |
-| 6.4 | DNS / leave Lovable | Serve production from VPS; stop Lovable publish | Not started | 6.3 | |
+| 6.4 | DNS / leave Lovable | Serve production from Coolify; stop Lovable publish | Not started | 6.3 | |
 | 6.5 | Decommission Supabase | After soak (~2 weeks), cancel hosted Supabase | Not started | 6.3, 6.4 | |
 | 6.6 | Remove hosted code paths | Delete dual-path once stable; tracker 100% | Not started | 6.5 | |
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves planning for **DUN-74 (Self hosted migration)** and completes **Phase 0**.

This PR documents the path off hosted Supabase/Lovable onto the existing **Coolify / Hetzner VPS** with **Node + PostgreSQL + PostgREST**, plus an admin backend toggle for cutover.

### Deliverables
- `documentation/plans/self-host-node-postgres-migration-plan.md` — architecture, auth continuity, Coolify constraints, phased delivery
- `documentation/plans/self-host-coverage-tracker.md` — **full Phase 0 FE inventory** (tables, RPCs, edge functions, realtime, storage)
- `tasks/tasks-self-host-node-postgres.md` — task checklist; **Phase 0 marked Done**
- `scripts/create-self-host-phase-linear-tickets.mjs` — creates Phase 0–6 Linear sub-issues under DUN-74

### Locked decisions
1. **PostgREST sidecar — yes**
2. **Coolify** on the shared multi-project VPS (`expose` only, Traefik domains, hard resource limits)
3. **Docker volumes** for object storage (`retroscope_uploads` with bucket prefixes)
4. Target Retroscope steady-state **≤ ~1.0–1.5 GB RAM**

### Phase 0 inventory highlights
- ~280 `.from` call sites across 37 tables/views
- 29 distinct edge functions referenced from FE
- 5 RPCs, 15 realtime channel sites
- FE storage buckets: `avatars`, `poker-session-chat-images`, `retro-audio`

### Linear phase tickets (sub-issues of DUN-74)
- [DUN-75](https://linear.app/dungeon-dwellers/issue/DUN-75/self-host-phase-0-plan-and-inventory) — Phase 0: Plan & inventory (**Done**)
- [DUN-76](https://linear.app/dungeon-dwellers/issue/DUN-76/self-host-phase-1-coolify-skeleton-admin-backend-toggle) — Phase 1: Coolify skeleton + admin backend toggle
- [DUN-77](https://linear.app/dungeon-dwellers/issue/DUN-77/self-host-phase-2-local-auth-google-password) — Phase 2: Local auth (Google + password)
- [DUN-78](https://linear.app/dungeon-dwellers/issue/DUN-78/self-host-phase-3-local-postgres-postgrest-data-path) — Phase 3: Local Postgres + PostgREST data path
- [DUN-79](https://linear.app/dungeon-dwellers/issue/DUN-79/self-host-phase-4-docker-volume-storage-critical-edge-ports) — Phase 4: Docker-volume storage + critical edge ports
- [DUN-80](https://linear.app/dungeon-dwellers/issue/DUN-80/self-host-phase-5-self-hosted-realtime-retro-poker) — Phase 5: Self-hosted realtime (retro + poker)
- [DUN-81](https://linear.app/dungeon-dwellers/issue/DUN-81/self-host-phase-6-production-cutover-and-decommission-supabaselovable) — Phase 6: Production cutover & decommission Supabase/Lovable

### Still needed before/during Phase 1
- Coolify FQDNs for `web` + `api` (OAuth redirect URI)
- Scaffold: `server/` + `docker-compose.selfhost.yml` + admin backend toggle

### Out of scope for this PR
Phase 1 implementation code (next).

Linear Issue: [DUN-74](https://linear.app/dungeon-dwellers/issue/DUN-74/self-hosted-migration)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-74](https://linear.app/dungeon-dwellers/issue/DUN-74/self-hosted-migration)

<div><a href="https://cursor.com/agents/bc-5e88edcc-5118-4e7d-8a7f-7cbc43a2cb9e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e88edcc-5118-4e7d-8a7f-7cbc43a2cb9e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

