### PR TITLE
fix(DUN-82): Coolify web build — copy .npmrc for npm ci

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+node_modules
+dist
+.git
+.github
+coverage
+*.log
+.env
+.env.*
+bun.lock
+bun.lockb
+server/node_modules
+server/dist
+documentation
+tasks
+tools/poker-local-advisor/node_modules

--- a/COOLIFY_SELFHOST.md
+++ b/COOLIFY_SELFHOST.md
@@ -108,3 +108,16 @@ OAUTH_GOOGLE_REDIRECT_URI=https://retro-api.example.com/auth/v1/callback
 | web | 0.10 | 128M |
 
 Total ≈ **1.6GB** ceiling; tune after soak (prefer raising Postgres first).
+
+## Troubleshooting
+
+### `npm ci` / ERESOLVE during `web` build
+
+Coolify builds the frontend with Docker `npm ci`. This repo requires `.npmrc` (`legacy-peer-deps=true`) because Atlaskit pulls `react-intl@5` with a TypeScript 4 peer range while the app uses TypeScript 5.
+
+The root `Dockerfile` copies `.npmrc` before `npm ci`. Do not remove that step, and keep `.npmrc` in the repo.
+
+### PostgREST shows no healthcheck
+
+Expected. The official PostgREST image is scratch-based (no `wget`/`curl`). Use `GET /readyz` on the API domain for Postgres + PostgREST readiness.
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
 FROM node:20-alpine AS builder
 WORKDIR /app
-COPY package.json package-lock.json ./
+
+# .npmrc sets legacy-peer-deps=true (required for Atlaskit/react-intl peer graph).
+# scripts/ is needed so postinstall can run during npm ci.
+COPY package.json package-lock.json .npmrc ./
+COPY scripts ./scripts
 RUN npm ci
+
 COPY . .
 
 # Vite env vars are build-time — Coolify must rebuild web when these change.

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -42,11 +42,8 @@ services:
         condition: service_healthy
     expose:
       - '3000'
-    healthcheck:
-      test: ['CMD', 'wget', '--spider', '-q', 'http://localhost:3000']
-      interval: 30s
-      timeout: 5s
-      retries: 3
+    # No healthcheck: postgrest image is scratch-based (no wget/curl/shell).
+    # Readiness is covered by api /readyz.
     deploy:
       resources:
         limits:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -28,6 +28,6 @@ USER app
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD wget -qO- http://127.0.0.1:3000/healthz >/dev/null || exit 1
+  CMD node -e "fetch('http://127.0.0.1:3000/healthz').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
 
 CMD ["node", "dist/index.js"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Coolify deployment of `docker-compose.selfhost.yml` failed while building the `web` image:

```text
npm error code ERESOLVE
npm error While resolving: react-intl@5.25.1
npm error Found: typescript@5.6.3
...
npm error peerOptional typescript@"^4.5" from react-intl-next@5.25.1
target web: failed to solve: process "/bin/sh -c npm ci" did not complete successfully: exit code: 1
```

Local installs work because `.npmrc` sets `legacy-peer-deps=true`, but the root `Dockerfile` only copied `package.json` / `package-lock.json` before `npm ci`, so Docker/Coolify ignored that setting.

## Changes

- **`Dockerfile`**: copy `.npmrc` + `scripts/` before `npm ci` (peer deps + postinstall)
- **`.dockerignore`**: keep Coolify build context lean
- **`docker-compose.selfhost.yml`**: remove PostgREST `wget` healthcheck (scratch image has no shell tools)
- **`server/Dockerfile`**: healthcheck via Node `fetch` instead of `wget`
- **`COOLIFY_SELFHOST.md`**: troubleshooting notes for this failure mode

## Test plan

1. [x] Reproduce `npm ci` failure without `.npmrc`; confirm success with `.npmrc`
2. [x] `npm run build` succeeds locally after the Dockerfile change
3. [ ] Redeploy the Coolify Compose resource on `main` (or this branch) and confirm `web` + `api` images build
4. [ ] Hit `https://<api>/healthz` and `/readyz`

## Coolify config notes (ops)

From the failure log, the resource still carries leftover C#/dev env (`ASPNETCORE_ENVIRONMENT`, `VITE_USE_CSHARP_API`, `PGADMIN_*`) and a public domain on `postgres` (`postgres.178.156.151.60.sslip.io`). Prefer removing unused vars and attaching domains only to `web` / `api` per `COOLIFY_SELFHOST.md`.

Linear: [DUN-82](https://linear.app/dungeon-dwellers/issue/DUN-82/resolve-coolify-error)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-82](https://linear.app/dungeon-dwellers/issue/DUN-82/resolve-coolify-error)

<div><a href="https://cursor.com/agents/bc-c720c25b-12d4-4011-8440-d9ac4943711d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c720c25b-12d4-4011-8440-d9ac4943711d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

