### PR TITLE
fix(DUN-83): Keep TypeScript available during API Docker build

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -6,7 +6,8 @@ WORKDIR /app
 ENV GOMAXPROCS=1
 ENV UV_THREADPOOL_SIZE=2
 ENV npm_config_maxsockets=2
-ENV NODE_ENV=production
+# Do NOT set NODE_ENV=production before npm ci — that omits devDependencies
+# (typescript/tsc) and breaks `npm run build`. Production is set in runtime only.
 
 COPY package.json package-lock.json* ./
 RUN --mount=type=cache,target=/root/.npm \
@@ -14,7 +15,8 @@ RUN --mount=type=cache,target=/root/.npm \
 
 COPY tsconfig.json ./
 COPY src ./src
-RUN nice -n 10 npm run build && npm prune --omit=dev
+RUN nice -n 10 npm run build \
+  && npm prune --omit=dev
 
 FROM node:20-alpine AS runtime
 WORKDIR /app


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Coolify deploy of #175 failed on the `api` image:

```text
sh: tsc: not found
exit code: 127
```

## Cause

`server/Dockerfile` set `NODE_ENV=production` **before** `npm ci`. npm then omitted `devDependencies`, so `typescript` / `tsc` was never installed and `npm run build` failed.

## Fix

Remove `NODE_ENV=production` from the builder stage. Production remains set only on the runtime stage; `npm prune --omit=dev` still strips build tooling before the final image copy.

## Verified

- `NODE_ENV=production npm ci` → `tsc` missing (reproduces Coolify failure)
- unset `NODE_ENV` + `npm ci` → `tsc` present; `npm run build && npm prune --omit=dev` succeeds

## Deploy note

After merge, redeploy on Coolify. Your last log also showed `api` and `web` building in parallel — if the VPS still pegs CPU, add `COMPOSE_PARALLEL_LIMIT=1` on the resource (it was not in the previous `build-time.env`) and keep server **Concurrent builds = 1**.

Linear Issue: [DUN-83](https://linear.app/dungeon-dwellers/issue/DUN-83/coolify-deployments-eating-100-cpu)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-83](https://linear.app/dungeon-dwellers/issue/DUN-83/coolify-deployments-eating-100percent-cpu)

<div><a href="https://cursor.com/agents/bc-bb3ad57d-69da-446f-b4eb-85ec90fe52c5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb3ad57d-69da-446f-b4eb-85ec90fe52c5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

