### PR TITLE
fix(DUN-83): Hard-pin Coolify Vite build to one CPU

### DIFF
--- a/COOLIFY_SELFHOST.md
+++ b/COOLIFY_SELFHOST.md
@@ -49,17 +49,21 @@ This forces `api` and `web` images to build one at a time instead of in parallel
 | Cap | Value | Why |
 |-----|-------|-----|
 | `BUILD_MAX_OLD_SPACE_SIZE` / Node heap | `3072` (web) | Atlaskit needs ~3GB; old `8192` swap-thrashed small VPS hosts |
-| `GOMAXPROCS` | `1` | Limits esbuild/Go worker threads during build |
-| `UV_THREADPOOL_SIZE` | `2` | Limits libuv thread pool |
+| `taskset -c ${BUILD_CPU_LIST:-0}` | core `0` | **Hard** CPU pin for `npm ci` / `vite build` (`nice` alone still pegs all cores) |
+| `GOMAXPROCS` / `RAYON_NUM_THREADS` | `1` | Limits esbuild (Go) + SWC (Rayon) worker pools |
+| `UV_THREADPOOL_SIZE` | `1` | Limits libuv thread pool |
 | `npm_config_maxsockets` | `2` | Gentler `npm ci` network/extract parallelism |
-| `nice -n 10` | build steps | Yields CPU to Coolify + sibling apps |
+| `vite.build.reportCompressedSize` | `false` | Gzipping multi‑MB chunks for size logs pegged CPU at the end of step 6/6 |
 | npm `postinstall` during image build | skipped | Advisor zip runs once via `prebuild` |
 
-Optional override on the resource (only if a build OOMs):
+Optional overrides on the resource:
 
 ```bash
-BUILD_MAX_OLD_SPACE_SIZE=3584
+BUILD_MAX_OLD_SPACE_SIZE=3584   # only if the web build OOMs
+BUILD_CPU_LIST=0                # default; use 0,1 only on a larger host
 ```
+
+Expect the web image build to be slower (one core) but the VPS should stay responsive.
 
 If deploys still starve the host, offload builds to a Coolify [build server](https://coolify.io/docs/knowledge-base/server/build-server) so compile work never runs on the production VPS.
 
@@ -153,11 +157,12 @@ Total ≈ **1.6GB** ceiling; tune after soak (prefer raising Postgres first).
 
 ### VPS freezes / 100% CPU during Coolify deploy
 
-Image builds ignore runtime CPU limits. Confirm:
+Image builds ignore runtime CPU limits. The heavy spike is usually **web Dockerfile step 6/6** (`vite build` / Atlaskit). Confirm:
 
 1. Server **Concurrent builds = 1**
 2. Resource has `COMPOSE_PARALLEL_LIMIT=1`
-3. Latest Dockerfiles (GOMAXPROCS / 3GB heap caps) are on the deployed branch
+3. Deployed commit includes `taskset` CPU pinning + `reportCompressedSize: false`
+4. During deploy, `htop` should show the build bound to roughly **one** core
 
 A capped web build is slower but should leave the host responsive. If the machine has under ~4GB free RAM during deploy, add swap or use a Coolify build server.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,36 @@
 # syntax=docker/dockerfile:1
 # Coolify / shared VPS: runtime `deploy.resources.limits` do NOT apply during image
-# builds. Cap Node heap + Go/esbuild threads so deploys cannot freeze the host.
+# builds. Cap Node heap + pin the Vite build to one CPU so deploys cannot freeze the host.
 FROM node:20-alpine AS builder
 WORKDIR /app
 
 # Atlaskit Vite build needs ~3GB; 8192 thrash-freezes small Hetzner/Coolify hosts.
 ARG BUILD_MAX_OLD_SPACE_SIZE=3072
+# Comma-separated CPU list for taskset (default: core 0 only).
+ARG BUILD_CPU_LIST=0
 ENV BUILD_MAX_OLD_SPACE_SIZE=$BUILD_MAX_OLD_SPACE_SIZE
+ENV BUILD_CPU_LIST=$BUILD_CPU_LIST
 ENV NODE_OPTIONS=--max-old-space-size=${BUILD_MAX_OLD_SPACE_SIZE}
-# esbuild is Go-based; keep the host schedulable while Coolify builds.
+# esbuild (Go) + SWC (Rayon) + libuv — keep worker pools tiny; taskset enforces the hard cap.
 ENV GOMAXPROCS=1
-ENV UV_THREADPOOL_SIZE=2
+ENV RAYON_NUM_THREADS=1
+ENV UV_THREADPOOL_SIZE=1
 ENV npm_config_maxsockets=2
 ENV npm_config_fetch_retries=2
 
+RUN apk add --no-cache util-linux
+
 # .npmrc sets legacy-peer-deps=true (required for Atlaskit/react-intl peer graph).
 COPY package.json package-lock.json .npmrc ./
+COPY scripts/run-cpu-limited.sh ./scripts/run-cpu-limited.sh
+RUN chmod +x ./scripts/run-cpu-limited.sh
+
 # Skip postinstall during ci — prebuild (via npm run build) packs the advisor zip once.
 RUN --mount=type=cache,target=/root/.npm \
-  npm ci --ignore-scripts
+  ./scripts/run-cpu-limited.sh npm ci --ignore-scripts
 
 COPY . .
+RUN chmod +x ./scripts/run-cpu-limited.sh
 
 # Vite env vars are build-time — Coolify must rebuild web when these change.
 ARG VITE_API_BASE_URL=
@@ -30,7 +40,8 @@ ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
 ENV VITE_SUPABASE_URL=$VITE_SUPABASE_URL
 ENV VITE_SUPABASE_PUBLISHABLE_KEY=$VITE_SUPABASE_PUBLISHABLE_KEY
 
-RUN nice -n 10 npm run build
+# Step 6/6: Atlaskit vite build — must be CPU-pinned (nice alone is not enough).
+RUN ./scripts/run-cpu-limited.sh npm run build
 
 
 FROM nginx:stable-alpine

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -61,6 +61,8 @@ services:
     build:
       context: ./server
       dockerfile: Dockerfile
+      args:
+        BUILD_CPU_LIST: ${BUILD_CPU_LIST:-0}
     restart: unless-stopped
     environment:
       NODE_ENV: production
@@ -99,6 +101,8 @@ services:
       args:
         # Keep ≤3072 on shared Coolify VPS (see COOLIFY_SELFHOST.md / DUN-83).
         BUILD_MAX_OLD_SPACE_SIZE: ${BUILD_MAX_OLD_SPACE_SIZE:-3072}
+        # Pin vite build to one host CPU (taskset). Override only if you know you have spare cores.
+        BUILD_CPU_LIST: ${BUILD_CPU_LIST:-0}
         VITE_API_BASE_URL: ${VITE_API_BASE_URL:-https://retro-api.example.com}
         VITE_SUPABASE_URL: ${VITE_SUPABASE_URL}
         VITE_SUPABASE_PUBLISHABLE_KEY: ${VITE_SUPABASE_PUBLISHABLE_KEY}

--- a/scripts/run-cpu-limited.sh
+++ b/scripts/run-cpu-limited.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Pin heavy Coolify/Docker build steps to a single core.
+# `nice` alone does NOT cap CPU — a niced Vite build still pegs every core.
+set -eu
+
+CPU_LIST="${BUILD_CPU_LIST:-0}"
+export GOMAXPROCS="${GOMAXPROCS:-1}"
+export RAYON_NUM_THREADS="${RAYON_NUM_THREADS:-1}"
+export UV_THREADPOOL_SIZE="${UV_THREADPOOL_SIZE:-1}"
+
+if command -v taskset >/dev/null 2>&1; then
+  exec nice -n 19 taskset -c "$CPU_LIST" "$@"
+fi
+
+echo "run-cpu-limited: taskset not found; falling back to nice only" >&2
+exec nice -n 19 "$@"

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,19 +3,31 @@
 FROM node:20-alpine AS builder
 WORKDIR /app
 
+ARG BUILD_CPU_LIST=0
+ENV BUILD_CPU_LIST=$BUILD_CPU_LIST
 ENV GOMAXPROCS=1
-ENV UV_THREADPOOL_SIZE=2
+ENV RAYON_NUM_THREADS=1
+ENV UV_THREADPOOL_SIZE=1
 ENV npm_config_maxsockets=2
 # Do NOT set NODE_ENV=production before npm ci — that omits devDependencies
 # (typescript/tsc) and breaks `npm run build`. Production is set in runtime only.
 
+RUN apk add --no-cache util-linux
+
 COPY package.json package-lock.json* ./
+COPY run-cpu-limited.sh /usr/local/bin/run-cpu-limited
+RUN chmod +x /usr/local/bin/run-cpu-limited
+
 RUN --mount=type=cache,target=/root/.npm \
-  if [ -f package-lock.json ]; then npm ci --ignore-scripts; else npm install --ignore-scripts; fi
+  if [ -f package-lock.json ]; then \
+    run-cpu-limited npm ci --ignore-scripts; \
+  else \
+    run-cpu-limited npm install --ignore-scripts; \
+  fi
 
 COPY tsconfig.json ./
 COPY src ./src
-RUN nice -n 10 npm run build \
+RUN run-cpu-limited npm run build \
   && npm prune --omit=dev
 
 FROM node:20-alpine AS runtime

--- a/server/run-cpu-limited.sh
+++ b/server/run-cpu-limited.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Pin Coolify/Docker build steps to a single core (nice alone is not enough).
+set -eu
+
+CPU_LIST="${BUILD_CPU_LIST:-0}"
+export GOMAXPROCS="${GOMAXPROCS:-1}"
+export RAYON_NUM_THREADS="${RAYON_NUM_THREADS:-1}"
+export UV_THREADPOOL_SIZE="${UV_THREADPOOL_SIZE:-1}"
+
+if command -v taskset >/dev/null 2>&1; then
+  exec nice -n 19 taskset -c "$CPU_LIST" "$@"
+fi
+
+echo "run-cpu-limited: taskset not found; falling back to nice only" >&2
+exec nice -n 19 "$@"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -58,6 +58,9 @@ export default defineConfig(({ mode, command }) => {
     build: {
       // Atlaskit's editor graph is huge; sourcemaps blow up Node's heap during build.
       sourcemap: false,
+      // Gzipping multi‑MB Atlaskit chunks just to print sizes pegs shared Coolify VPS CPUs
+      // at the end of `vite build` (Docker step 6/6). Keep minify; skip the report.
+      reportCompressedSize: false,
     },
     optimizeDeps: {
       include: ["@atlaskit/renderer", "@atlaskit/editor-core", "react-intl-next"],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #175 / #176: deploys still pegged the VPS at **web Dockerfile step 6/6** (`vite build`). `nice` and `GOMAXPROCS` only reduce priority / Go threads — Node/SWC/Vite can still saturate every core, and Vite’s end-of-build **gzip size reporting** on multi‑MB Atlaskit chunks makes that spike worse right as the step finishes.

## Changes

- **`scripts/run-cpu-limited.sh`** (+ server copy): `taskset -c 0` + `nice -n 19` wrapper for Docker build steps
- **Web/API Dockerfiles**: install `util-linux`, pin `npm ci` / `npm run build`, set `RAYON_NUM_THREADS=1`
- **`vite.config.ts`**: `build.reportCompressedSize: false` (keeps minify; skips expensive gzip-for-logs)
- Compose/docs: `BUILD_CPU_LIST` override

## Verified

- `./scripts/run-cpu-limited.sh npm run build` succeeds with `BUILD_MAX_OLD_SPACE_SIZE=3072` (~1m on one core)
- Build output no longer prints per-chunk `gzip:` sizes

## Expectation after deploy

`htop` during step 6/6 should show ~**one** core busy, not all CPUs. Build is slower; host stays usable.

Still set on Coolify if not already:

- Server → Concurrent builds = `1`
- Resource env: `COMPOSE_PARALLEL_LIMIT=1`

Linear Issue: [DUN-83](https://linear.app/dungeon-dwellers/issue/DUN-83/coolify-deployments-eating-100-cpu)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-83](https://linear.app/dungeon-dwellers/issue/DUN-83/coolify-deployments-eating-100percent-cpu)

<div><a href="https://cursor.com/agents/bc-bb3ad57d-69da-446f-b4eb-85ec90fe52c5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb3ad57d-69da-446f-b4eb-85ec90fe52c5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

