### PR TITLE
fix(DUN-83): Prebuild Coolify images in GitHub Actions

### DIFF
--- a/.github/workflows/coolify-images.yml
+++ b/.github/workflows/coolify-images.yml
@@ -1,0 +1,134 @@
+# Build Retroscope images on GitHub runners and push to GHCR.
+# Coolify on the small Hetzner VPS should pull these (see docker-compose.selfhost.prebuilt.yml)
+# instead of running Atlaskit `vite build` locally (DUN-83).
+name: Coolify images
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Dockerfile'
+      - 'docker-compose.selfhost.prebuilt.yml'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.npmrc'
+      - 'nginx.conf'
+      - 'index.html'
+      - 'vite.config.ts'
+      - 'tsconfig*.json'
+      - 'postcss.config.js'
+      - 'tailwind.config.ts'
+      - 'components.json'
+      - 'public/**'
+      - 'src/**'
+      - 'scripts/**'
+      - 'tools/poker-local-advisor/**'
+      - 'server/**'
+      - '.github/workflows/coolify-images.yml'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  WEB_IMAGE: ghcr.io/${{ github.repository }}-web
+  API_IMAGE: ghcr.io/${{ github.repository }}-api
+
+jobs:
+  build-api:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push API image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./server
+          file: ./server/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.API_IMAGE }}:latest
+            ${{ env.API_IMAGE }}:${{ github.sha }}
+          cache-from: type=gha,scope=api
+          cache-to: type=gha,mode=max,scope=api
+
+  build-web:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Require Vite build-time vars
+        env:
+          VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
+          VITE_SUPABASE_URL: ${{ vars.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.VITE_SUPABASE_PUBLISHABLE_KEY }}
+        run: |
+          missing=0
+          for name in VITE_API_BASE_URL VITE_SUPABASE_URL VITE_SUPABASE_PUBLISHABLE_KEY; do
+            if [ -z "${!name}" ]; then
+              echo "::error::$name is not set (repo Variables / Secrets). See COOLIFY_SELFHOST.md."
+              missing=1
+            fi
+          done
+          exit "$missing"
+
+      - name: Build and push web image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.WEB_IMAGE }}:latest
+            ${{ env.WEB_IMAGE }}:${{ github.sha }}
+          build-args: |
+            BUILD_MAX_OLD_SPACE_SIZE=4096
+            VITE_API_BASE_URL=${{ vars.VITE_API_BASE_URL }}
+            VITE_SUPABASE_URL=${{ vars.VITE_SUPABASE_URL }}
+            VITE_SUPABASE_PUBLISHABLE_KEY=${{ secrets.VITE_SUPABASE_PUBLISHABLE_KEY }}
+          cache-from: type=gha,scope=web
+          cache-to: type=gha,mode=max,scope=web
+
+  deploy-coolify:
+    needs: [build-api, build-web]
+    if: ${{ vars.COOLIFY_DEPLOY_WEBHOOK != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Coolify redeploy
+        env:
+          WEBHOOK: ${{ vars.COOLIFY_DEPLOY_WEBHOOK }}
+          TOKEN: ${{ secrets.COOLIFY_TOKEN }}
+        run: |
+          if [ -n "$TOKEN" ]; then
+            curl --fail-with-body --request GET "$WEBHOOK" --header "Authorization: Bearer $TOKEN"
+          else
+            curl --fail-with-body --request GET "$WEBHOOK"
+          fi

--- a/COOLIFY_SELFHOST.md
+++ b/COOLIFY_SELFHOST.md
@@ -2,7 +2,10 @@
 
 Lean stack for Retroscope on a shared Coolify VPS: **Postgres + PostgREST + Node API + Nginx FE**.
 
-Compose file: `docker-compose.selfhost.yml`
+| Compose file | When to use |
+|--------------|-------------|
+| **`docker-compose.selfhost.prebuilt.yml`** | **Recommended on small Hetzner/Coolify hosts** — pulls GHCR images; VPS never runs `vite build` |
+| `docker-compose.selfhost.yml` | Local/dev or a dedicated build server (builds `api`/`web` from Dockerfiles) |
 
 ## Services & domains
 
@@ -24,48 +27,36 @@ Replace `retro.example.com` / `retro-api.example.com` with real FQDNs when DNS i
 5. Vite `VITE_*` vars are **build-time** — change → **rebuild** the `web` service.
 6. Cap **build** concurrency (see [Deploy CPU](#deploy-cpu-shared-vps)) — image builds ignore runtime CPU limits and can freeze a small Hetzner VPS.
 
-## Deploy CPU (shared VPS)
+## Deploy CPU (shared VPS) — use prebuilt images
 
-Coolify runs `docker compose build` on the same host as other apps. Runtime `deploy.resources.limits` do **not** apply during builds. Retroscope’s Atlaskit frontend `npm ci` + `vite build` is heavy enough to peg CPU and thrash memory if left unbounded.
+On a 2–4 GB / 3 vCPU Hetzner box, Atlaskit `vite build` will still saturate CPU and disk (multi‑GB `node_modules` reads during `transforming...`) even with `taskset` / `nice`. The browserslist “run `npx update-browserslist-db`” line in Coolify logs is only a **warning**, not a command Coolify runs.
 
-**Do this once on the Coolify server**
+**Recommended: build on GitHub Actions, pull on Coolify**
 
-1. **Servers → [your VPS] → Configuration → Advanced**
-2. Set **Number of concurrent builds** to **`1`** (Coolify default is `2`).
-3. Optionally raise **Deployment timeout** if a single capped build exceeds 60 minutes.
+1. In the GitHub repo set:
+   - **Variables:** `VITE_API_BASE_URL`, `VITE_SUPABASE_URL`
+   - **Secret:** `VITE_SUPABASE_PUBLISHABLE_KEY`
+   - Optional: Variable `COOLIFY_DEPLOY_WEBHOOK` + Secret `COOLIFY_TOKEN` to redeploy after push
+2. Merge to `main` (or run workflow **Coolify images** manually) so GHCR gets:
+   - `ghcr.io/justinloveless/retro-vote-sorter-board-web:latest`
+   - `ghcr.io/justinloveless/retro-vote-sorter-board-api:latest`
+3. If packages are private, on the VPS once:
+   ```bash
+   echo <GITHUB_PAT_with_read:packages> | docker login ghcr.io -u <github-user> --password-stdin
+   ```
+   Or set the GHCR package visibility to **Public**.
+4. In Coolify, point the resource compose path to **`docker-compose.selfhost.prebuilt.yml`** and redeploy.
+5. Confirm the deploy log shows **pull** for `web`/`api`, not `RUN vite build` / `npm ci`.
 
-**Do this on the Retroscope compose resource**
+`VITE_*` changes require a new Actions build (they are baked into the web image), then a Coolify pull/redeploy.
 
-Add environment variable:
+### Fallback: build on the VPS (not recommended on small hosts)
 
-```bash
-COMPOSE_PARALLEL_LIMIT=1
-```
+Use `docker-compose.selfhost.yml` only if you have spare CPU/RAM or a Coolify [build server](https://coolify.io/docs/knowledge-base/server/build-server).
 
-This forces `api` and `web` images to build one at a time instead of in parallel.
-
-**Already baked into the Dockerfiles**
-
-| Cap | Value | Why |
-|-----|-------|-----|
-| `BUILD_MAX_OLD_SPACE_SIZE` / Node heap | `3072` (web) | Atlaskit needs ~3GB; old `8192` swap-thrashed small VPS hosts |
-| `taskset -c ${BUILD_CPU_LIST:-0}` | core `0` | **Hard** CPU pin for `npm ci` / `vite build` (`nice` alone still pegs all cores) |
-| `GOMAXPROCS` / `RAYON_NUM_THREADS` | `1` | Limits esbuild (Go) + SWC (Rayon) worker pools |
-| `UV_THREADPOOL_SIZE` | `1` | Limits libuv thread pool |
-| `npm_config_maxsockets` | `2` | Gentler `npm ci` network/extract parallelism |
-| `vite.build.reportCompressedSize` | `false` | Gzipping multi‑MB chunks for size logs pegged CPU at the end of step 6/6 |
-| npm `postinstall` during image build | skipped | Advisor zip runs once via `prebuild` |
-
-Optional overrides on the resource:
-
-```bash
-BUILD_MAX_OLD_SPACE_SIZE=3584   # only if the web build OOMs
-BUILD_CPU_LIST=0                # default; use 0,1 only on a larger host
-```
-
-Expect the web image build to be slower (one core) but the VPS should stay responsive.
-
-If deploys still starve the host, offload builds to a Coolify [build server](https://coolify.io/docs/knowledge-base/server/build-server) so compile work never runs on the production VPS.
+1. Server → Advanced → **Concurrent builds = 1**
+2. Resource env: `COMPOSE_PARALLEL_LIMIT=1`
+3. Dockerfiles still apply `taskset`, heap caps, and `reportCompressedSize: false` — expect a slow, still-heavy build.
 
 ## Named volumes
 
@@ -122,14 +113,15 @@ OAUTH_GOOGLE_REDIRECT_URI=https://retro-api.example.com/auth/v1/callback
 
 ## Deploy steps
 
-1. Coolify → **New Resource** → **Docker Compose**.
-2. Point at this repo; set compose path to `docker-compose.selfhost.yml`.
-3. Paste env vars above.
-4. Domains:
+1. Publish images via GitHub Actions (**Coolify images** workflow) after setting `VITE_*` repo vars/secrets.
+2. Coolify → **New Resource** → **Docker Compose** (or edit existing).
+3. Point at this repo; set compose path to **`docker-compose.selfhost.prebuilt.yml`**.
+4. Paste **runtime** env vars above (Postgres/JWT/CORS). `VITE_*` are baked in CI — not required at Coolify build time when using prebuilt.
+5. Domains:
    - `web` → production FE FQDN, port `80`
    - `api` → API FQDN, port `3000`, WebSockets on
-5. Deploy.
-6. Verify:
+6. Deploy (should pull GHCR images only).
+7. Verify:
    - `https://retro-api.example.com/healthz` → `{ "status": "healthy" }`
    - `https://retro-api.example.com/readyz` → Postgres + PostgREST green
    - FE loads; Admin → **Backend** page (admin users only)
@@ -157,14 +149,9 @@ Total ≈ **1.6GB** ceiling; tune after soak (prefer raising Postgres first).
 
 ### VPS freezes / 100% CPU during Coolify deploy
 
-Image builds ignore runtime CPU limits. The heavy spike is usually **web Dockerfile step 6/6** (`vite build` / Atlaskit). Confirm:
+If logs show `vite build` / `transforming...` / huge disk reads, Coolify is still **building on the VPS**. Switch the compose path to `docker-compose.selfhost.prebuilt.yml` and confirm Actions has published GHCR images.
 
-1. Server **Concurrent builds = 1**
-2. Resource has `COMPOSE_PARALLEL_LIMIT=1`
-3. Deployed commit includes `taskset` CPU pinning + `reportCompressedSize: false`
-4. During deploy, `htop` should show the build bound to roughly **one** core
-
-A capped web build is slower but should leave the host responsive. If the machine has under ~4GB free RAM during deploy, add swap or use a Coolify build server.
+The browserslist “Please run: npx update-browserslist-db” line is informational only.
 
 ### `npm ci` / ERESOLVE during `web` build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ ENV RAYON_NUM_THREADS=1
 ENV UV_THREADPOOL_SIZE=1
 ENV npm_config_maxsockets=2
 ENV npm_config_fetch_retries=2
+# Warning-only; browserslist does not auto-update. Silence noisy Coolify logs.
+ENV BROWSERSLIST_IGNORE_OLD_DATA=1
 
 RUN apk add --no-cache util-linux
 

--- a/docker-compose.selfhost.prebuilt.yml
+++ b/docker-compose.selfhost.prebuilt.yml
@@ -1,11 +1,13 @@
-# Coolify production stack for Retroscope self-host (DUN-76 / Phase 1).
-# Rules: use `expose` only (no host `ports`), set CPU/memory limits,
-# keep PostgREST internal (no Coolify public domain).
+# Coolify production stack using GHCR prebuilt images (DUN-83).
+# Prefer this on small Hetzner/Coolify hosts — the VPS only pulls images; it never
+# runs Atlaskit `vite build` / `npm ci` (which pegs CPU + disk).
 #
-# Build CPU (DUN-83): Prefer docker-compose.selfhost.prebuilt.yml on small VPS
-# hosts so Coolify never runs vite/npm ci. This file builds from Dockerfiles
-# (local/dev or build server only). If you must build here: set
-# COMPOSE_PARALLEL_LIMIT=1 and Concurrent builds = 1.
+# Images are published by .github/workflows/coolify-images.yml
+#   ghcr.io/<owner>/retro-vote-sorter-board-web:latest
+#   ghcr.io/<owner>/retro-vote-sorter-board-api:latest
+#
+# Coolify: set compose path to this file, authenticate GHCR on the server if
+# packages are private, then deploy (pull + up only).
 
 services:
   postgres:
@@ -47,8 +49,6 @@ services:
         condition: service_healthy
     expose:
       - '3000'
-    # No healthcheck: postgrest image is scratch-based (no wget/curl/shell).
-    # Readiness is covered by api /readyz.
     deploy:
       resources:
         limits:
@@ -56,11 +56,7 @@ services:
           memory: 256M
 
   api:
-    build:
-      context: ./server
-      dockerfile: Dockerfile
-      args:
-        BUILD_CPU_LIST: ${BUILD_CPU_LIST:-0}
+    image: ${API_IMAGE:-ghcr.io/justinloveless/retro-vote-sorter-board-api:latest}
     restart: unless-stopped
     environment:
       NODE_ENV: production
@@ -82,7 +78,13 @@ services:
     expose:
       - '3000'
     healthcheck:
-      test: ['CMD', 'wget', '-qO-', 'http://127.0.0.1:3000/healthz']
+      test:
+        [
+          'CMD',
+          'node',
+          '-e',
+          "fetch('http://127.0.0.1:3000/healthz').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+        ]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -93,17 +95,7 @@ services:
           memory: 512M
 
   web:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      args:
-        # Keep ≤3072 on shared Coolify VPS (see COOLIFY_SELFHOST.md / DUN-83).
-        BUILD_MAX_OLD_SPACE_SIZE: ${BUILD_MAX_OLD_SPACE_SIZE:-3072}
-        # Pin vite build to one host CPU (taskset). Override only if you know you have spare cores.
-        BUILD_CPU_LIST: ${BUILD_CPU_LIST:-0}
-        VITE_API_BASE_URL: ${VITE_API_BASE_URL:-https://retro-api.example.com}
-        VITE_SUPABASE_URL: ${VITE_SUPABASE_URL}
-        VITE_SUPABASE_PUBLISHABLE_KEY: ${VITE_SUPABASE_PUBLISHABLE_KEY}
+    image: ${WEB_IMAGE:-ghcr.io/justinloveless/retro-vote-sorter-board-web:latest}
     restart: unless-stopped
     depends_on:
       - api


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On-VPS CPU pinning is not enough. Your Hetzner graph matches Atlaskit `vite build` **transforming...**: ~1.5 GB/s disk reads through `node_modules`, then all 3 vCPUs pegged. The browserslist “run `npx update-browserslist-db`” line is only a **warning** in the log — Coolify is not running that command.

**Fix:** build `web`/`api` on GitHub Actions → push to GHCR → Coolify **pulls** via a prebuilt compose file so the VPS never runs Vite.

## Changes

- `.github/workflows/coolify-images.yml` — build/push `*-web` and `*-api` to GHCR; optional Coolify webhook
- `docker-compose.selfhost.prebuilt.yml` — `image:` only for `web`/`api` (no `build:`)
- Docs: switch Coolify compose path + required `VITE_*` repo vars/secrets
- `BROWSERSLIST_IGNORE_OLD_DATA=1` in web Dockerfile
- API compose healthcheck uses `node` (image has no `wget`)

## Coolify cutover

1. Repo **Variables:** `VITE_API_BASE_URL`, `VITE_SUPABASE_URL`
2. Repo **Secret:** `VITE_SUPABASE_PUBLISHABLE_KEY`
3. Merge / run workflow **Coolify images**
4. GHCR login on VPS if packages are private (or make packages public)
5. Coolify compose path → `docker-compose.selfhost.prebuilt.yml`
6. Redeploy — logs should show **pull**, not `vite build`

Linear Issue: [DUN-83](https://linear.app/dungeon-dwellers/issue/DUN-83/coolify-deployments-eating-100-cpu)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-83](https://linear.app/dungeon-dwellers/issue/DUN-83/coolify-deployments-eating-100percent-cpu)

<div><a href="https://cursor.com/agents/bc-bb3ad57d-69da-446f-b4eb-85ec90fe52c5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb3ad57d-69da-446f-b4eb-85ec90fe52c5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

