### PR TITLE
feat(poker): show who currently has the spotlight (DUN-85)

### DIFF
--- a/src/components/Neotro/PokerBottomBar.tsx
+++ b/src/components/Neotro/PokerBottomBar.tsx
@@ -51,7 +51,17 @@ export const PokerBottomBar: React.FC<PokerBottomBarProps> = ({
   mobilePanelKeys,
 }) => {
   const showObserverButton = !!(onEnterObserverMode || onLeaveObserverMode);
-  const { isSpotlightMine, onSpotlightClick } = usePokerTable();
+  const { isSpotlightMine, spotlightHolderDisplayName, onSpotlightClick } = usePokerTable();
+  const spotlightButtonLabel = isSpotlightMine
+    ? 'Stop spotlighting'
+    : spotlightHolderDisplayName
+      ? `${spotlightHolderDisplayName} has the spotlight — click to take it`
+      : 'Spotlight this round';
+  const spotlightButtonAriaLabel = isSpotlightMine
+    ? 'Stop spotlighting'
+    : spotlightHolderDisplayName
+      ? `Take spotlight from ${spotlightHolderDisplayName}`
+      : 'Spotlight this round';
   const panels = PANELS.filter(
     (p) => (!p.requiresJira || isJiraConfigured) &&
       (p.key !== 'settings' || visibility.settings) &&
@@ -65,19 +75,28 @@ export const PokerBottomBar: React.FC<PokerBottomBarProps> = ({
         <div className="contents">
         {isMobile && (
           <div className="contents">
+            {spotlightHolderDisplayName && (
+              <span
+                className="max-w-[5.5rem] truncate px-1 text-[11px] font-medium text-amber-800 dark:text-amber-300"
+                title={`${spotlightHolderDisplayName} has the spotlight`}
+                aria-live="polite"
+              >
+                {spotlightHolderDisplayName}
+              </span>
+            )}
             <Tooltip>
               <TooltipTrigger asChild>
                 <NeotroPressableButton
                   variant="gold"
                   isActive={isSpotlightMine}
                   onClick={onSpotlightClick}
-                  aria-label={isSpotlightMine ? 'Stop spotlighting' : 'Spotlight this round'}
+                  aria-label={spotlightButtonAriaLabel}
                 >
                   <Spotlight className="h-4 w-4" />
                 </NeotroPressableButton>
               </TooltipTrigger>
               <TooltipContent side="top">
-                {isSpotlightMine ? 'Stop spotlighting' : 'Spotlight this round'}
+                {spotlightButtonLabel}
               </TooltipContent>
             </Tooltip>
           </div>

--- a/src/components/Neotro/PokerTableComponent/context.tsx
+++ b/src/components/Neotro/PokerTableComponent/context.tsx
@@ -163,6 +163,8 @@ interface PokerTableContextProps {
 
   spotlightRoundNumber: number | null;
   isSpotlightMine: boolean;
+  /** Display name of who currently holds spotlight; null when nobody does. */
+  spotlightHolderDisplayName: string | null;
   onSpotlightClick: () => void;
 }
 
@@ -585,11 +587,8 @@ export const PokerTableProvider: React.FC<PokerTableProviderProps> = ({ children
 
   const isViewingHistoryEffective = effectiveCurrentRound ? !effectiveCurrentRound.is_active : isViewingHistory;
 
-  const spotlightOtherDisplayName = useMemo(() => {
+  const spotlightNameFromSelections = useMemo(() => {
     if (!spotlightUserId) return '';
-    if (spotlightUserId === activeUserId) {
-      return isSpotlightMine ? '' : 'You (another window)';
-    }
     const rn = session?.spotlight_round_number;
     if (typeof rn === 'number') {
       const spotlightRound = roundsForUI.find((r) => r.round_number === rn);
@@ -605,11 +604,62 @@ export const PokerTableProvider: React.FC<PokerTableProviderProps> = ({ children
     return '';
   }, [
     spotlightUserId,
-    activeUserId,
-    isSpotlightMine,
     session?.selections,
     session?.spotlight_round_number,
     roundsForUI,
+  ]);
+
+  const [spotlightProfileName, setSpotlightProfileName] = useState('');
+
+  useEffect(() => {
+    if (!spotlightUserId || spotlightUserId === activeUserId || spotlightNameFromSelections) {
+      setSpotlightProfileName('');
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      const { data } = await supabase
+        .from('profiles')
+        .select('nickname, full_name')
+        .eq('id', spotlightUserId)
+        .maybeSingle();
+      if (cancelled) return;
+      const name = data?.nickname?.trim() || data?.full_name?.trim() || '';
+      setSpotlightProfileName(name);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [spotlightUserId, activeUserId, spotlightNameFromSelections]);
+
+  /** Name used in takeover dialog when someone else (or another window) holds spotlight. */
+  const spotlightOtherDisplayName = useMemo(() => {
+    if (!spotlightUserId) return '';
+    if (spotlightUserId === activeUserId) {
+      return isSpotlightMine ? '' : 'You (another window)';
+    }
+    return spotlightNameFromSelections || spotlightProfileName;
+  }, [
+    spotlightUserId,
+    activeUserId,
+    isSpotlightMine,
+    spotlightNameFromSelections,
+    spotlightProfileName,
+  ]);
+
+  /** Visible label for who currently has spotlight (including "You"). */
+  const spotlightHolderDisplayName = useMemo(() => {
+    if (!spotlightUserId) return null;
+    if (spotlightUserId === activeUserId) {
+      return isSpotlightMine ? 'You' : 'You (another window)';
+    }
+    return spotlightNameFromSelections || spotlightProfileName || 'Someone';
+  }, [
+    spotlightUserId,
+    activeUserId,
+    isSpotlightMine,
+    spotlightNameFromSelections,
+    spotlightProfileName,
   ]);
 
   const [spotlightTakeoverOpen, setSpotlightTakeoverOpen] = useState(false);
@@ -1513,6 +1563,7 @@ export const PokerTableProvider: React.FC<PokerTableProviderProps> = ({ children
     pokerToolbarExtras,
     spotlightRoundNumber,
     isSpotlightMine,
+    spotlightHolderDisplayName,
     onSpotlightClick,
   };
 

--- a/src/components/Neotro/RoundSelector.tsx
+++ b/src/components/Neotro/RoundSelector.tsx
@@ -107,10 +107,22 @@ export const RoundSelector: React.FC<RoundSelectorProps> = ({
   const {
     spotlightRoundNumber,
     isSpotlightMine,
+    spotlightHolderDisplayName,
     onSpotlightClick,
     activateRoundById,
     reorderRounds,
   } = usePokerTable();
+
+  const spotlightButtonLabel = isSpotlightMine
+    ? 'Stop spotlighting'
+    : spotlightHolderDisplayName
+      ? `${spotlightHolderDisplayName} has the spotlight — click to take it`
+      : 'Spotlight this round';
+  const spotlightButtonAriaLabel = isSpotlightMine
+    ? 'Stop spotlighting'
+    : spotlightHolderDisplayName
+      ? `Take spotlight from ${spotlightHolderDisplayName}`
+      : 'Spotlight this round';
 
   const currentPointsLabel = useMemo(() => {
     const rawTicket = displayTicketNumber || currentRound?.ticket_number || '';
@@ -564,22 +576,33 @@ export const RoundSelector: React.FC<RoundSelectorProps> = ({
               {theme === 'light' ? '🌙' : '☀️'}
             </Button>
             {!isMobile && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <NeotroPressableButton
-                    variant="gold"
-                    size="sm"
-                    isActive={isSpotlightMine}
-                    onClick={onSpotlightClick}
-                    aria-label={isSpotlightMine ? 'Stop spotlighting' : 'Spotlight this round'}
+              <div className="flex min-w-0 items-center gap-1.5">
+                {spotlightHolderDisplayName && (
+                  <span
+                    className="hidden max-w-[6.5rem] truncate text-xs font-medium text-amber-800 dark:text-amber-300 sm:inline"
+                    title={`${spotlightHolderDisplayName} has the spotlight`}
+                    aria-live="polite"
                   >
-                    <Spotlight className="h-4 w-4" />
-                  </NeotroPressableButton>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">
-                  {isSpotlightMine ? 'Stop spotlighting' : 'Spotlight this round'}
-                </TooltipContent>
-              </Tooltip>
+                    {spotlightHolderDisplayName}
+                  </span>
+                )}
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <NeotroPressableButton
+                      variant="gold"
+                      size="sm"
+                      isActive={isSpotlightMine}
+                      onClick={onSpotlightClick}
+                      aria-label={spotlightButtonAriaLabel}
+                    >
+                      <Spotlight className="h-4 w-4" />
+                    </NeotroPressableButton>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    {spotlightButtonLabel}
+                  </TooltipContent>
+                </Tooltip>
+              </div>
             )}
             {(onEnterObserverMode || onLeaveObserverMode) && (
               <Tooltip>
@@ -723,6 +746,11 @@ export const RoundSelector: React.FC<RoundSelectorProps> = ({
                         type="button"
                         className="relative z-[1] inline-flex items-center gap-2 px-2 py-1.5 text-xs whitespace-nowrap"
                         onClick={() => handleChipClick(index)}
+                        aria-label={
+                          isSpotlightRound && spotlightHolderDisplayName
+                            ? `${item.ticketKey}, spotlight held by ${spotlightHolderDisplayName}`
+                            : undefined
+                        }
                       >
                         {iconUrl ? (
                           <img src={iconUrl} alt="" className="h-3.5 w-3.5 shrink-0" />
@@ -730,6 +758,14 @@ export const RoundSelector: React.FC<RoundSelectorProps> = ({
                           <Ticket className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                         )}
                         <span className="font-mono font-semibold">{item.ticketKey}</span>
+                        {isSpotlightRound && spotlightHolderDisplayName && (
+                          <span
+                            className="relative z-[1] rounded bg-amber-500/20 px-1.5 py-0.5 text-[10px] font-medium text-amber-900 dark:text-amber-200"
+                            title={`${spotlightHolderDisplayName} has the spotlight`}
+                          >
+                            {spotlightHolderDisplayName}
+                          </span>
+                        )}
                         {item.isPendingRound && (
                           <span className="rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-medium text-amber-800 dark:text-amber-300">
                             Pending


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
On poker sessions, participants could see *that* a round was spotlighted (cone / gold button), but not **who** held the spotlight unless they tried to take it.

## Changes
- Resolve and expose `spotlightHolderDisplayName` from the poker table context (selections first, then profile lookup fallback).
- Show the holder name next to the spotlight button (desktop toolbar + mobile bottom bar).
- Show an amber name badge on the spotlighted round chip.
- Update spotlight button tooltips/aria labels to name the current holder when taking over.

## Testing
Manually verified on local app (`localhost:8081`) in poker session `XXT98F`:
- Taking spotlight shows **You** next to the gold button and as a badge on the spotlighted round chip.
- Stopping spotlight clears both labels.

![Spotlight active showing You labels](https://cursor.com/artifacts/c/art-c4e88630-afc8-425a-b312-a6f1fcd19ebd)
![Spotlight cleared](https://cursor.com/artifacts/c/art-645f59e5-23af-4882-bd1b-fa86fcea27da)

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-85](https://linear.app/dungeon-dwellers/issue/DUN-85/show-who-has-spotlight)

<div><a href="https://cursor.com/agents/bc-0ce3fe4c-8282-4515-b77e-b703b9b2a0ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ce3fe4c-8282-4515-b77e-b703b9b2a0ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

