### PR TITLE
feat(poker): show spotlight holder avatar instead of name (DUN-87)

### DIFF
--- a/src/components/Neotro/PokerBottomBar.tsx
+++ b/src/components/Neotro/PokerBottomBar.tsx
@@ -2,7 +2,18 @@ import React from 'react';
 import { MessageCircle, Search, GalleryHorizontalEnd, Settings, Eye, EyeOff, Menu, Spotlight } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { NeotroPressableButton } from '@/components/Neotro/NeotroPressableButton';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { usePokerTable } from '@/components/Neotro/PokerTableComponent/context';
+
+function spotlightHolderInitials(name: string) {
+  if (!name) return '?';
+  return name
+    .split(/\s+/)
+    .map((part) => part[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2);
+}
 
 export interface PanelVisibility {
   chat: boolean;
@@ -51,7 +62,13 @@ export const PokerBottomBar: React.FC<PokerBottomBarProps> = ({
   mobilePanelKeys,
 }) => {
   const showObserverButton = !!(onEnterObserverMode || onLeaveObserverMode);
-  const { isSpotlightMine, spotlightHolderDisplayName, onSpotlightClick } = usePokerTable();
+  const {
+    isSpotlightMine,
+    spotlightHolderDisplayName,
+    spotlightHolderAvatarName,
+    spotlightHolderAvatarUrl,
+    onSpotlightClick,
+  } = usePokerTable();
   const spotlightButtonLabel = isSpotlightMine
     ? 'Stop spotlighting'
     : spotlightHolderDisplayName
@@ -77,11 +94,22 @@ export const PokerBottomBar: React.FC<PokerBottomBarProps> = ({
           <div className="contents">
             {spotlightHolderDisplayName && (
               <span
-                className="max-w-[5.5rem] truncate px-1 text-[11px] font-medium text-amber-800 dark:text-amber-300"
+                className="inline-flex px-0.5"
                 title={`${spotlightHolderDisplayName} has the spotlight`}
                 aria-live="polite"
               >
-                {spotlightHolderDisplayName}
+                <Avatar className="h-6 w-6 ring-2 ring-amber-400/70">
+                  <AvatarImage
+                    src={spotlightHolderAvatarUrl ?? undefined}
+                    alt={spotlightHolderAvatarName || spotlightHolderDisplayName}
+                  />
+                  <AvatarFallback className="bg-amber-500/20 text-[10px] font-semibold text-amber-900 dark:text-amber-200">
+                    {spotlightHolderInitials(
+                      spotlightHolderAvatarName || spotlightHolderDisplayName
+                    )}
+                  </AvatarFallback>
+                </Avatar>
+                <span className="sr-only">{`${spotlightHolderDisplayName} has the spotlight`}</span>
               </span>
             )}
             <Tooltip>

--- a/src/components/Neotro/PokerBottomBar.tsx
+++ b/src/components/Neotro/PokerBottomBar.tsx
@@ -98,12 +98,12 @@ export const PokerBottomBar: React.FC<PokerBottomBarProps> = ({
                 title={`${spotlightHolderDisplayName} has the spotlight`}
                 aria-live="polite"
               >
-                <Avatar className="h-6 w-6 ring-2 ring-amber-400/70">
+                <Avatar className="h-7 w-7 ring-2 ring-amber-400/80">
                   <AvatarImage
                     src={spotlightHolderAvatarUrl ?? undefined}
                     alt={spotlightHolderAvatarName || spotlightHolderDisplayName}
                   />
-                  <AvatarFallback className="bg-amber-500/20 text-[10px] font-semibold text-amber-900 dark:text-amber-200">
+                  <AvatarFallback className="bg-amber-500/25 text-[11px] font-semibold text-amber-950 dark:text-amber-100">
                     {spotlightHolderInitials(
                       spotlightHolderAvatarName || spotlightHolderDisplayName
                     )}

--- a/src/components/Neotro/PokerTableComponent/context.tsx
+++ b/src/components/Neotro/PokerTableComponent/context.tsx
@@ -165,6 +165,10 @@ interface PokerTableContextProps {
   isSpotlightMine: boolean;
   /** Display name of who currently holds spotlight; null when nobody does. */
   spotlightHolderDisplayName: string | null;
+  /** Name used for avatar initials/alt (prefers profile/selection name over "You"). */
+  spotlightHolderAvatarName: string | null;
+  /** Profile avatar URL for the spotlight holder; null when nobody holds it or no avatar set. */
+  spotlightHolderAvatarUrl: string | null;
   onSpotlightClick: () => void;
 }
 
@@ -609,28 +613,35 @@ export const PokerTableProvider: React.FC<PokerTableProviderProps> = ({ children
     roundsForUI,
   ]);
 
-  const [spotlightProfileName, setSpotlightProfileName] = useState('');
+  const [spotlightProfile, setSpotlightProfile] = useState<{
+    name: string;
+    avatarUrl: string | null;
+  }>({ name: '', avatarUrl: null });
 
   useEffect(() => {
-    if (!spotlightUserId || spotlightUserId === activeUserId || spotlightNameFromSelections) {
-      setSpotlightProfileName('');
+    if (!spotlightUserId) {
+      setSpotlightProfile({ name: '', avatarUrl: null });
       return;
     }
+    setSpotlightProfile({ name: '', avatarUrl: null });
     let cancelled = false;
     void (async () => {
       const { data } = await supabase
         .from('profiles')
-        .select('nickname, full_name')
+        .select('nickname, full_name, avatar_url')
         .eq('id', spotlightUserId)
         .maybeSingle();
       if (cancelled) return;
       const name = data?.nickname?.trim() || data?.full_name?.trim() || '';
-      setSpotlightProfileName(name);
+      setSpotlightProfile({
+        name,
+        avatarUrl: data?.avatar_url?.trim() || null,
+      });
     })();
     return () => {
       cancelled = true;
     };
-  }, [spotlightUserId, activeUserId, spotlightNameFromSelections]);
+  }, [spotlightUserId]);
 
   /** Name used in takeover dialog when someone else (or another window) holds spotlight. */
   const spotlightOtherDisplayName = useMemo(() => {
@@ -638,13 +649,13 @@ export const PokerTableProvider: React.FC<PokerTableProviderProps> = ({ children
     if (spotlightUserId === activeUserId) {
       return isSpotlightMine ? '' : 'You (another window)';
     }
-    return spotlightNameFromSelections || spotlightProfileName;
+    return spotlightNameFromSelections || spotlightProfile.name;
   }, [
     spotlightUserId,
     activeUserId,
     isSpotlightMine,
     spotlightNameFromSelections,
-    spotlightProfileName,
+    spotlightProfile.name,
   ]);
 
   /** Visible label for who currently has spotlight (including "You"). */
@@ -653,14 +664,31 @@ export const PokerTableProvider: React.FC<PokerTableProviderProps> = ({ children
     if (spotlightUserId === activeUserId) {
       return isSpotlightMine ? 'You' : 'You (another window)';
     }
-    return spotlightNameFromSelections || spotlightProfileName || 'Someone';
+    return spotlightNameFromSelections || spotlightProfile.name || 'Someone';
   }, [
     spotlightUserId,
     activeUserId,
     isSpotlightMine,
     spotlightNameFromSelections,
-    spotlightProfileName,
+    spotlightProfile.name,
   ]);
+
+  /** Prefer real name for avatar initials/alt; falls back to display label. */
+  const spotlightHolderAvatarName = useMemo(() => {
+    if (!spotlightUserId) return null;
+    return (
+      spotlightNameFromSelections ||
+      spotlightProfile.name ||
+      spotlightHolderDisplayName
+    );
+  }, [
+    spotlightUserId,
+    spotlightNameFromSelections,
+    spotlightProfile.name,
+    spotlightHolderDisplayName,
+  ]);
+
+  const spotlightHolderAvatarUrl = spotlightUserId ? spotlightProfile.avatarUrl : null;
 
   const [spotlightTakeoverOpen, setSpotlightTakeoverOpen] = useState(false);
 
@@ -1564,6 +1592,8 @@ export const PokerTableProvider: React.FC<PokerTableProviderProps> = ({ children
     spotlightRoundNumber,
     isSpotlightMine,
     spotlightHolderDisplayName,
+    spotlightHolderAvatarName,
+    spotlightHolderAvatarUrl,
     onSpotlightClick,
   };
 

--- a/src/components/Neotro/RoundSelector.tsx
+++ b/src/components/Neotro/RoundSelector.tsx
@@ -596,12 +596,12 @@ export const RoundSelector: React.FC<RoundSelectorProps> = ({
                     title={`${spotlightHolderDisplayName} has the spotlight`}
                     aria-live="polite"
                   >
-                    <Avatar className="h-6 w-6 ring-2 ring-amber-400/70">
+                    <Avatar className="h-7 w-7 ring-2 ring-amber-400/80">
                       <AvatarImage
                         src={spotlightHolderAvatarUrl ?? undefined}
                         alt={spotlightHolderAvatarName || spotlightHolderDisplayName}
                       />
-                      <AvatarFallback className="bg-amber-500/20 text-[10px] font-semibold text-amber-900 dark:text-amber-200">
+                      <AvatarFallback className="bg-amber-500/25 text-[11px] font-semibold text-amber-950 dark:text-amber-100">
                         {spotlightHolderInitials(
                           spotlightHolderAvatarName || spotlightHolderDisplayName
                         )}
@@ -784,14 +784,14 @@ export const RoundSelector: React.FC<RoundSelectorProps> = ({
                         <span className="font-mono font-semibold">{item.ticketKey}</span>
                         {isSpotlightRound && spotlightHolderDisplayName && (
                           <Avatar
-                            className="relative z-[1] h-5 w-5 ring-1 ring-amber-400/70"
+                            className="relative z-[1] h-6 w-6 ring-1 ring-amber-400/80"
                             title={`${spotlightHolderDisplayName} has the spotlight`}
                           >
                             <AvatarImage
                               src={spotlightHolderAvatarUrl ?? undefined}
                               alt=""
                             />
-                            <AvatarFallback className="bg-amber-500/20 text-[8px] font-semibold text-amber-900 dark:text-amber-200">
+                            <AvatarFallback className="bg-amber-500/25 text-[10px] font-semibold text-amber-950 dark:text-amber-100">
                               {spotlightHolderInitials(
                                 spotlightHolderAvatarName || spotlightHolderDisplayName
                               )}

--- a/src/components/Neotro/RoundSelector.tsx
+++ b/src/components/Neotro/RoundSelector.tsx
@@ -31,9 +31,20 @@ import {
   ContextMenuTrigger,
 } from '@/components/ui/context-menu';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { usePokerTable } from '@/components/Neotro/PokerTableComponent/context';
 
 type PokerRoundGameStateMerge = Pick<PokerSessionState, 'game_state' | 'average_points' | 'selections'>;
+
+function spotlightHolderInitials(name: string) {
+  if (!name) return '?';
+  return name
+    .split(/\s+/)
+    .map((part) => part[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2);
+}
 
 interface RoundSelectorProps {
   rounds: PokerSessionRound[];
@@ -108,6 +119,8 @@ export const RoundSelector: React.FC<RoundSelectorProps> = ({
     spotlightRoundNumber,
     isSpotlightMine,
     spotlightHolderDisplayName,
+    spotlightHolderAvatarName,
+    spotlightHolderAvatarUrl,
     onSpotlightClick,
     activateRoundById,
     reorderRounds,
@@ -579,11 +592,22 @@ export const RoundSelector: React.FC<RoundSelectorProps> = ({
               <div className="flex min-w-0 items-center gap-1.5">
                 {spotlightHolderDisplayName && (
                   <span
-                    className="hidden max-w-[6.5rem] truncate text-xs font-medium text-amber-800 dark:text-amber-300 sm:inline"
+                    className="hidden sm:inline-flex"
                     title={`${spotlightHolderDisplayName} has the spotlight`}
                     aria-live="polite"
                   >
-                    {spotlightHolderDisplayName}
+                    <Avatar className="h-6 w-6 ring-2 ring-amber-400/70">
+                      <AvatarImage
+                        src={spotlightHolderAvatarUrl ?? undefined}
+                        alt={spotlightHolderAvatarName || spotlightHolderDisplayName}
+                      />
+                      <AvatarFallback className="bg-amber-500/20 text-[10px] font-semibold text-amber-900 dark:text-amber-200">
+                        {spotlightHolderInitials(
+                          spotlightHolderAvatarName || spotlightHolderDisplayName
+                        )}
+                      </AvatarFallback>
+                    </Avatar>
+                    <span className="sr-only">{`${spotlightHolderDisplayName} has the spotlight`}</span>
                   </span>
                 )}
                 <Tooltip>
@@ -759,12 +783,20 @@ export const RoundSelector: React.FC<RoundSelectorProps> = ({
                         )}
                         <span className="font-mono font-semibold">{item.ticketKey}</span>
                         {isSpotlightRound && spotlightHolderDisplayName && (
-                          <span
-                            className="relative z-[1] rounded bg-amber-500/20 px-1.5 py-0.5 text-[10px] font-medium text-amber-900 dark:text-amber-200"
+                          <Avatar
+                            className="relative z-[1] h-5 w-5 ring-1 ring-amber-400/70"
                             title={`${spotlightHolderDisplayName} has the spotlight`}
                           >
-                            {spotlightHolderDisplayName}
-                          </span>
+                            <AvatarImage
+                              src={spotlightHolderAvatarUrl ?? undefined}
+                              alt=""
+                            />
+                            <AvatarFallback className="bg-amber-500/20 text-[8px] font-semibold text-amber-900 dark:text-amber-200">
+                              {spotlightHolderInitials(
+                                spotlightHolderAvatarName || spotlightHolderDisplayName
+                              )}
+                            </AvatarFallback>
+                          </Avatar>
                         )}
                         {item.isPendingRound && (
                           <span className="rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-medium text-amber-800 dark:text-amber-300">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Replaces the spotlight holder **name** label (from DUN-85) with their **profile picture / avatar** in the poker session UI (DUN-87).

## Changes
- Load `avatar_url` from `profiles` for the current spotlight holder
- Show an amber-ringed avatar next to the spotlight control (desktop RoundSelector + mobile bottom bar)
- Show the same avatar on the spotlighted round chip instead of a name badge
- Keep the display name for tooltips, aria labels, screen readers, and initials fallback when no avatar is set

## Testing
- `tsc --noEmit` passes
- Manual QA on local app: logged in, took spotlight in a poker session; avatar renders next to the spotlight control (profile image from Supabase) and hover still reports who holds the spotlight

![Spotlight avatar in toolbar](https://cursor.com/artifacts/c/art-eee5986e-d227-4261-8705-fbe14b65515d)
![Spotlight active with tooltip](https://cursor.com/artifacts/c/art-6edd33f7-0b6b-44cc-aa20-bc2883236fab)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-87](https://linear.app/dungeon-dwellers/issue/DUN-87/spotlight-profile-picture)

<div><a href="https://cursor.com/agents/bc-63ebbe77-8c1b-4f7b-82a3-b1d688bc70d3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63ebbe77-8c1b-4f7b-82a3-b1d688bc70d3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

