### PR TITLE
fix(DUN-86): restore Atlaskit description editor load

### DIFF
--- a/src/components/Neotro/AtlaskitDescriptionEditor.tsx
+++ b/src/components/Neotro/AtlaskitDescriptionEditor.tsx
@@ -3,6 +3,7 @@ import { IntlProvider } from 'react-intl-next';
 import { SmartCardProvider, CardClient } from '@atlaskit/link-provider';
 import { jiraAtlaskitIntlMessages } from '@/lib/jiraAtlaskitIntlMessages';
 import { ensureAtlaskitFeatureGates } from '@/lib/ensureAtlaskitFeatureGates';
+import { patchProseMirrorSelectionJsonID } from '@/lib/patchProseMirrorSelection';
 type EditorActions = any;
 
 export interface AtlaskitDescriptionEditorHandle {
@@ -38,20 +39,10 @@ const AtlaskitDescriptionEditorInner: React.ForwardRefRenderFunction<
 
   React.useEffect(() => {
     let cancelled = false;
+    // Ensure patch is applied even if this module loads without going through main.tsx
+    // (tests, alternate entrypoints). Idempotent.
+    patchProseMirrorSelectionJsonID();
     ensureAtlaskitFeatureGates()
-      .then(() => {
-        if (cancelled) return;
-        return import('prosemirror-state');
-      })
-      .then((pm) => {
-        if (cancelled || !pm) return;
-        const { Selection } = pm;
-        const orig = Selection.jsonID;
-        Selection.jsonID = function (id: string, cls: any) {
-          try { return orig.call(this, id, cls); } catch { return cls; }
-        };
-      })
-      .catch(() => {})
       .then(() => {
         if (cancelled) return;
         return import('@atlaskit/editor-core');

--- a/src/components/Neotro/JiraIssueDrawer.tsx
+++ b/src/components/Neotro/JiraIssueDrawer.tsx
@@ -887,12 +887,8 @@ export const JiraIssueDrawer: React.FC<JiraIssueDrawerProps> = ({
     if (!isAdfDoc(fields?.description)) return;
     if (adfRendererComponent || adfRendererLoadFailed) return;
     let cancelled = false;
-    import('prosemirror-state').then(({ Selection }) => {
-      const orig = Selection.jsonID;
-      Selection.jsonID = function (id: string, cls: any) {
-        try { return orig.call(this, id, cls); } catch { return cls; }
-      };
-    }).catch(() => {}).then(() => import('@atlaskit/renderer'))
+    import('@/lib/patchProseMirrorSelection')
+      .then(() => import('@atlaskit/renderer'))
       .then((mod) => {
         if (cancelled) return;
         setAdfRendererComponent(() => mod.ReactRenderer as AdfRendererComponent);

--- a/src/lib/patchProseMirrorSelection.test.ts
+++ b/src/lib/patchProseMirrorSelection.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { Selection } from 'prosemirror-state';
+import { patchProseMirrorSelectionJsonID } from '@/lib/patchProseMirrorSelection';
+
+describe('patchProseMirrorSelectionJsonID', () => {
+  it('allows duplicate selection JSON ID registration', () => {
+    patchProseMirrorSelectionJsonID();
+
+    class FirstSel extends Selection {
+      eq() {
+        return false;
+      }
+      map() {
+        return this;
+      }
+      getBookmark() {
+        return {
+          map: () => this,
+          resolve: () => this as unknown as Selection,
+        };
+      }
+    }
+
+    class SecondSel extends Selection {
+      eq() {
+        return false;
+      }
+      map() {
+        return this;
+      }
+      getBookmark() {
+        return {
+          map: () => this,
+          resolve: () => this as unknown as Selection,
+        };
+      }
+    }
+
+    const id = `test-dup-${Math.random().toString(36).slice(2)}`;
+    expect(() => Selection.jsonID(id, FirstSel as any)).not.toThrow();
+    expect(() => Selection.jsonID(id, SecondSel as any)).not.toThrow();
+  });
+});

--- a/src/lib/patchProseMirrorSelection.ts
+++ b/src/lib/patchProseMirrorSelection.ts
@@ -1,0 +1,31 @@
+import { Selection } from 'prosemirror-state';
+
+let patched = false;
+
+/**
+ * Atlaskit renderer + editor-core both register selection JSON IDs (e.g. "gapcursor").
+ * In the Vite production bundle they share one `prosemirror-state`, so the second
+ * `Selection.jsonID` call throws and the dynamic `import('@atlaskit/editor-core')`
+ * fails permanently — surfacing as "Failed to load editor."
+ *
+ * Call this before any Atlaskit editor/renderer code evaluates.
+ */
+export function patchProseMirrorSelectionJsonID(): void {
+  if (patched) return;
+  patched = true;
+
+  const orig = Selection.jsonID.bind(Selection);
+  Selection.jsonID = function patchedSelectionJsonID(id: string, cls: any) {
+    try {
+      return orig(id, cls);
+    } catch (err) {
+      if (err instanceof RangeError && /Duplicate use of selection JSON ID/.test(String(err.message))) {
+        return cls;
+      }
+      throw err;
+    }
+  };
+}
+
+// Side effect for `import '@/lib/patchProseMirrorSelection'` from main.tsx
+patchProseMirrorSelectionJsonID();

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,6 @@
 import './processPolyfill';
+// Must run before App (and Atlaskit) so duplicate gapcursor JSON IDs don't break editor-core import.
+import './lib/patchProseMirrorSelection';
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Editing a Jira ticket description in a poker session showed **Failed to load editor.**

**Root cause:** In the Vite production bundle, the app shell and `@atlaskit/editor-core` share one `prosemirror-state`. The shell already registers the `gapcursor` selection JSON ID, so importing `editor-core` threw:

`RangeError: Duplicate use of selection JSON ID gapcursor`

That failed dynamic import is what surfaces the italic error in `AtlaskitDescriptionEditor`.

## Changes
- Add `patchProseMirrorSelectionJsonID()` and apply it from `main.tsx` before App/Atlaskit evaluate
- Reuse the idempotent patch from the description editor and ADF renderer load paths
- Add a unit test covering duplicate `Selection.jsonID` registration

## Local verification
Verified against the fixed `AtlaskitDescriptionEditor` on the local Vite dev server, plus a production `vite preview` import check.

### Editor loads (dev)
![Atlaskit description editor loaded locally](https://cursor.com/artifacts/c/art-e2173936-cc24-436c-873a-218da73ea48d)

Status line: `OK: editor mounted in ~1s` — toolbar and contenteditable are present (not “Failed to load editor”).

### Editor is interactive (dev)
![Typing into the Atlaskit description editor locally](https://cursor.com/artifacts/c/art-d3702f36-8d6d-4c24-afc4-25e4aabc3601)

### Production build import (vite preview)
![Production editor-core dynamic import succeeds](https://cursor.com/artifacts/c/art-42482e03-fbf2-4086-84bb-e3c1bca8f6bc)

After booting the production bundle, the same editor-core chunk that previously failed with the gapcursor `RangeError` now exports `Editor` successfully.

## Testing
- `npx vitest run src/lib/patchProseMirrorSelection.test.ts` (passed)
- Local Playwright: mount `AtlaskitDescriptionEditor` at `/editor-mount.html` → editor UI + typing
- Local Playwright: production preview dynamic `import()` of editor-core chunk → success

### Manual (staging/prod with Jira)
- Open a poker session with Jira configured
- Edit an ADF ticket description
- Confirm the Atlaskit editor loads (not “Failed to load editor”)

Linear Issue: [DUN-86](https://linear.app/dungeon-dwellers/issue/DUN-86/unable-to-load-editor)

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-86](https://linear.app/dungeon-dwellers/issue/DUN-86/unable-to-load-editor)

<div><a href="https://cursor.com/agents/bc-7352bc07-d259-4f6b-8382-dd9a4d897d91?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7352bc07-d259-4f6b-8382-dd9a4d897d91&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

