### PR TITLE
fix: Create PostgREST roles on every Coolify deploy

### DIFF
--- a/COOLIFY_SELFHOST.md
+++ b/COOLIFY_SELFHOST.md
@@ -163,3 +163,26 @@ The root `Dockerfile` copies `.npmrc` before `npm ci`. Do not remove that step, 
 
 Expected. The official PostgREST image is scratch-based (no `wget`/`curl`). Use `GET /readyz` on the API domain for Postgres + PostgREST readiness.
 
+### `password authentication failed for user "authenticator"` / role does not exist
+
+Postgres only runs `/docker-entrypoint-initdb.d` on a **brand-new** data volume. If `retroscope_pg_data` already existed from an earlier deploy, the `authenticator` / `retroscope_app` roles were never created.
+
+Compose includes a `db-init` one-shot that re-applies `server/postgres/init/01-roles.sql` on every deploy. Redeploy after that change lands.
+
+**Immediate fix (no code wait):** in Coolify → postgres terminal / execute:
+
+```bash
+psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f /docker-entrypoint-initdb.d/01-roles.sql
+```
+
+Or, if the mount is missing, paste the contents of `server/postgres/init/01-roles.sql` into `psql` as the `postgres` superuser.
+
+Ensure Coolify env matches the bootstrap passwords (or change both together):
+
+```bash
+PGRST_DB_URI=postgresql://authenticator:retroscope_authenticator_pass@postgres:5432/retroscope
+DATABASE_URL=postgresql://retroscope_app:retroscope_app_pass@postgres:5432/retroscope
+```
+
+Then restart `postgrest` (and `api`).
+

--- a/docker-compose.selfhost.prebuilt.yml
+++ b/docker-compose.selfhost.prebuilt.yml
@@ -33,6 +33,29 @@ services:
           cpus: '0.50'
           memory: 768M
 
+  # docker-entrypoint-initdb.d only runs on an empty volume. Re-apply idempotent
+  # roles on every deploy so PostgREST's authenticator exists after volume reuse.
+  db-init:
+    image: postgres:16-alpine
+    restart: on-failure
+    environment:
+      PGHOST: postgres
+      PGPORT: '5432'
+      PGUSER: ${POSTGRES_USER:-postgres}
+      PGPASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+      PGDATABASE: ${POSTGRES_DB:-retroscope}
+    volumes:
+      - ./server/postgres/init:/init:ro
+    command: ['psql', '-v', 'ON_ERROR_STOP=1', '-f', '/init/01-roles.sql']
+    depends_on:
+      postgres:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          cpus: '0.10'
+          memory: 64M
+
   postgrest:
     image: postgrest/postgrest:v12.2.3
     restart: unless-stopped
@@ -47,6 +70,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      db-init:
+        condition: service_completed_successfully
     expose:
       - '3000'
     deploy:
@@ -73,6 +98,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      db-init:
+        condition: service_completed_successfully
       postgrest:
         condition: service_started
     expose:

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -31,6 +31,29 @@ services:
           cpus: '0.50'
           memory: 768M
 
+  # docker-entrypoint-initdb.d only runs on an empty volume. Re-apply idempotent
+  # roles on every deploy so PostgREST's authenticator exists after volume reuse.
+  db-init:
+    image: postgres:16-alpine
+    restart: on-failure
+    environment:
+      PGHOST: postgres
+      PGPORT: '5432'
+      PGUSER: ${POSTGRES_USER:-postgres}
+      PGPASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+      PGDATABASE: ${POSTGRES_DB:-retroscope}
+    volumes:
+      - ./server/postgres/init:/init:ro
+    command: ['psql', '-v', 'ON_ERROR_STOP=1', '-f', '/init/01-roles.sql']
+    depends_on:
+      postgres:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          cpus: '0.10'
+          memory: 64M
+
   postgrest:
     image: postgrest/postgrest:v12.2.3
     restart: unless-stopped
@@ -45,6 +68,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      db-init:
+        condition: service_completed_successfully
     expose:
       - '3000'
     # No healthcheck: postgrest image is scratch-based (no wget/curl/shell).
@@ -77,12 +102,20 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      db-init:
+        condition: service_completed_successfully
       postgrest:
         condition: service_started
     expose:
       - '3000'
     healthcheck:
-      test: ['CMD', 'wget', '-qO-', 'http://127.0.0.1:3000/healthz']
+      test:
+        [
+          'CMD',
+          'node',
+          '-e',
+          "fetch('http://127.0.0.1:3000/healthz').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+        ]
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PostgREST fails with `Role "authenticator" does not exist` because Postgres only runs `/docker-entrypoint-initdb.d` when `retroscope_pg_data` is **empty**. Reused Coolify volumes skip `01-roles.sql`.

## Changes

- Add `db-init` one-shot service to both selfhost compose files — runs idempotent `server/postgres/init/01-roles.sql` after Postgres is healthy
- `postgrest` / `api` wait on `service_completed_successfully`
- Document immediate manual fix + env password alignment in `COOLIFY_SELFHOST.md`
- Align source-build compose API healthcheck with `node` (image has no `wget`)

## Immediate workaround (before merge)

As the Postgres superuser on the running DB, apply `server/postgres/init/01-roles.sql`, then restart `postgrest`.

Confirm Coolify has:

```bash
PGRST_DB_URI=postgresql://authenticator:retroscope_authenticator_pass@postgres:5432/retroscope
DATABASE_URL=postgresql://retroscope_app:retroscope_app_pass@postgres:5432/retroscope
```

Linear Issue: [DUN-83](https://linear.app/dungeon-dwellers/issue/DUN-83/coolify-deployments-eating-100-cpu) (follow-on from self-host Coolify bring-up)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-83](https://linear.app/dungeon-dwellers/issue/DUN-83/coolify-deployments-eating-100percent-cpu)

<div><a href="https://cursor.com/agents/bc-bb3ad57d-69da-446f-b4eb-85ec90fe52c5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb3ad57d-69da-446f-b4eb-85ec90fe52c5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

