### PR TITLE
fix: Coolify db-init configs + deploy webhook after GHCR

### DIFF
--- a/.github/workflows/coolify-images.yml
+++ b/.github/workflows/coolify-images.yml
@@ -1,6 +1,10 @@
 # Build Retroscope images on GitHub runners and push to GHCR.
 # Coolify on the small Hetzner VPS should pull these (see docker-compose.selfhost.prebuilt.yml)
 # instead of running Atlaskit `vite build` locally (DUN-83).
+#
+# Deploy ordering: disable Coolify "Auto Deploy" on git push for this resource.
+# Set secret COOLIFY_WEBHOOK (Deploy Webhook URL from Coolify) so this workflow
+# redeploys ONLY after api/web images are on GHCR.
 name: Coolify images
 
 on:
@@ -9,6 +13,7 @@ on:
     paths:
       - 'Dockerfile'
       - 'docker-compose.selfhost.prebuilt.yml'
+      - 'docker-compose.selfhost.yml'
       - 'package.json'
       - 'package-lock.json'
       - '.npmrc'
@@ -119,16 +124,30 @@ jobs:
 
   deploy-coolify:
     needs: [build-api, build-web]
-    if: ${{ vars.COOLIFY_DEPLOY_WEBHOOK != '' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger Coolify redeploy
+      - name: Trigger Coolify redeploy after GHCR push
         env:
-          WEBHOOK: ${{ vars.COOLIFY_DEPLOY_WEBHOOK }}
+          # Prefer secret (Coolify docs). Var name kept as fallback.
+          WEBHOOK: ${{ secrets.COOLIFY_WEBHOOK }}
+          WEBHOOK_FALLBACK: ${{ vars.COOLIFY_DEPLOY_WEBHOOK }}
           TOKEN: ${{ secrets.COOLIFY_TOKEN }}
         run: |
-          if [ -n "$TOKEN" ]; then
-            curl --fail-with-body --request GET "$WEBHOOK" --header "Authorization: Bearer $TOKEN"
-          else
-            curl --fail-with-body --request GET "$WEBHOOK"
+          set -euo pipefail
+          URL="${WEBHOOK:-}"
+          if [ -z "$URL" ]; then
+            URL="${WEBHOOK_FALLBACK:-}"
           fi
+          if [ -z "$URL" ]; then
+            echo "::warning::deploy-coolify skipped: set GitHub Actions secret COOLIFY_WEBHOOK to your Coolify Deploy Webhook URL."
+            echo "Also disable Coolify git Auto Deploy for this resource so deploys wait for GHCR images."
+            exit 0
+          fi
+          echo "Triggering Coolify webhook after images were pushed..."
+          if [ -n "${TOKEN:-}" ]; then
+            curl --fail-with-body --request GET "$URL" --header "Authorization: Bearer $TOKEN"
+          else
+            curl --fail-with-body --request GET "$URL"
+          fi
+          echo
+          echo "Coolify deploy triggered."

--- a/.github/workflows/coolify-images.yml
+++ b/.github/workflows/coolify-images.yml
@@ -2,9 +2,10 @@
 # Coolify on the small Hetzner VPS should pull these (see docker-compose.selfhost.prebuilt.yml)
 # instead of running Atlaskit `vite build` locally (DUN-83).
 #
-# Deploy ordering: disable Coolify "Auto Deploy" on git push for this resource.
-# Set secret COOLIFY_WEBHOOK (Deploy Webhook URL from Coolify) so this workflow
-# redeploys ONLY after api/web images are on GHCR.
+# Deploy ordering (GitHub App users): keep the GitHub App installed, but disable
+# Coolify "Auto Deploy" so merge-to-main does not race GHCR. Set secret
+# COOLIFY_WEBHOOK to the resource's Deploy Webhook URL (CI → Coolify). That is
+# not a manual Git webhook — the App still owns git access.
 name: Coolify images
 
 on:

--- a/COOLIFY_SELFHOST.md
+++ b/COOLIFY_SELFHOST.md
@@ -171,15 +171,9 @@ Expected. The official PostgREST image is scratch-based (no `wget`/`curl`). Use 
 
 Postgres only runs `/docker-entrypoint-initdb.d` on a **brand-new** data volume. If `retroscope_pg_data` already existed from an earlier deploy, the `authenticator` / `retroscope_app` roles were never created.
 
-Compose includes a `db-init` one-shot that re-applies `server/postgres/init/01-roles.sql` on every deploy. Redeploy after that change lands.
+Compose includes a `db-init` one-shot that re-applies `server/postgres/init/01-roles.sql` on every deploy (via Docker **configs**, not bind mounts — Coolify empties `./` bind mounts).
 
-**Immediate fix (no code wait):** in Coolify → postgres terminal / execute:
-
-```bash
-psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f /docker-entrypoint-initdb.d/01-roles.sql
-```
-
-Or, if the mount is missing, paste the contents of `server/postgres/init/01-roles.sql` into `psql` as the `postgres` superuser.
+**Immediate fix (no code wait):** in Coolify → postgres terminal, paste/run the contents of `server/postgres/init/01-roles.sql` as the `postgres` superuser, then restart `postgrest`.
 
 Ensure Coolify env matches the bootstrap passwords (or change both together):
 
@@ -188,5 +182,12 @@ PGRST_DB_URI=postgresql://authenticator:retroscope_authenticator_pass@postgres:5
 DATABASE_URL=postgresql://retroscope_app:retroscope_app_pass@postgres:5432/retroscope
 ```
 
-Then restart `postgrest` (and `api`).
+### `db-init`: `/init/01-roles.sql: No such file or directory`
+
+Old compose used a bind mount Coolify rewrites to an empty host dir. Use a release that defines `configs.retroscope_roles_sql` (file → `/init/01-roles.sql`).
+
+### `deploy-coolify` skipped / Coolify deploys before new images exist
+
+1. GitHub Actions secret **`COOLIFY_WEBHOOK`** must be set (Coolify → resource → Deploy Webhook URL). Without it the job no-ops.
+2. **Disable Coolify Auto Deploy** on git push for this app; otherwise Coolify redeploys from git immediately and pulls stale `:latest` while Actions is still building.
 

--- a/COOLIFY_SELFHOST.md
+++ b/COOLIFY_SELFHOST.md
@@ -33,17 +33,25 @@ On a 2–4 GB / 3 vCPU Hetzner box, Atlaskit `vite build` will still saturat
 
 **Recommended: build on GitHub Actions, pull on Coolify**
 
+Keep your **GitHub App** connection (repo access). For prebuilt images you only change *when* Coolify deploys:
+
+| Mechanism | Role |
+|-----------|------|
+| **GitHub App** | Stays installed — Coolify can read the repo / compose file |
+| **Auto Deploy** (Advanced → Deployment & Git) | **Turn OFF** — otherwise merge-to-main deploys immediately and pulls stale GHCR `:latest` while Actions is still building |
+| **Deploy Webhook** (not a “manual Git webhook”) | Coolify URL that **GitHub Actions** calls *after* images are pushed. Direction is CI → Coolify, opposite of the GitHub App’s git events |
+
 1. In the GitHub repo set:
    - **Variables:** `VITE_API_BASE_URL`, `VITE_SUPABASE_URL`
-   - **Secrets:** `VITE_SUPABASE_PUBLISHABLE_KEY`, **`COOLIFY_WEBHOOK`** (required for post-image deploy)
-   - Optional secret: `COOLIFY_TOKEN` if your Coolify webhook requires Bearer auth
+   - **Secrets:** `VITE_SUPABASE_PUBLISHABLE_KEY`, **`COOLIFY_WEBHOOK`**
+   - Optional secret: `COOLIFY_TOKEN` if your Coolify instance requires Bearer auth on deploy API calls
 2. In Coolify for this resource:
    - Compose path: **`docker-compose.selfhost.prebuilt.yml`**
-   - **Disable Auto Deploy** on git push (Configuration → General / Webhooks). Git auto-deploy races GHCR and starts before new images exist.
-   - Copy **Deploy Webhook** URL → GitHub secret `COOLIFY_WEBHOOK`
+   - **Disable Auto Deploy** (Configuration → Advanced → Deployment & Git). Leave the GitHub App source as-is.
+   - Open the resource **Deploy Webhook** / deploy API URL → save it as GitHub secret `COOLIFY_WEBHOOK`
 3. Merge to `main` (or run workflow **Coolify images** manually). Order is:
    1. Actions builds/pushes `*-api` + `*-web` to GHCR  
-   2. `deploy-coolify` calls the webhook  
+   2. `deploy-coolify` calls the Deploy Webhook  
    3. Coolify pulls (`pull_policy: always`) and restarts
 4. If packages are private, on the VPS once:
    ```bash
@@ -52,7 +60,9 @@ On a 2–4 GB / 3 vCPU Hetzner box, Atlaskit `vite build` will still saturat
    Or set the GHCR package visibility to **Public**.
 5. Confirm deploy logs show **pull** for `web`/`api`, not `RUN vite build` / `npm ci`.
 
-`VITE_*` changes require a new Actions build (baked into the web image), then the webhook redeploy.
+`VITE_*` changes require a new Actions build (baked into the web image), then the post-image redeploy.
+
+If you keep GitHub App **Auto Deploy** on, every merge will race GHCR; you’d need to click **Redeploy** in Coolify after the Actions workflow finishes (or accept stale images).
 
 ### Fallback: build on the VPS (not recommended on small hosts)
 
@@ -188,6 +198,8 @@ Old compose used a bind mount Coolify rewrites to an empty host dir. Use a relea
 
 ### `deploy-coolify` skipped / Coolify deploys before new images exist
 
-1. GitHub Actions secret **`COOLIFY_WEBHOOK`** must be set (Coolify → resource → Deploy Webhook URL). Without it the job no-ops.
-2. **Disable Coolify Auto Deploy** on git push for this app; otherwise Coolify redeploys from git immediately and pulls stale `:latest` while Actions is still building.
+Using a **GitHub App** does not set `COOLIFY_WEBHOOK` by itself. The App notifies Coolify of git changes; the Actions job needs the separate **Deploy Webhook** URL.
+
+1. Coolify → resource → copy **Deploy Webhook** → GitHub Actions secret **`COOLIFY_WEBHOOK`**. Without it, `deploy-coolify` warns and exits 0 (appears “skipped” / no-op).
+2. Coolify → Advanced → Deployment & Git → **disable Auto Deploy**. Keep the GitHub App; only stop deploy-on-push so CI can deploy after GHCR is updated.
 

--- a/COOLIFY_SELFHOST.md
+++ b/COOLIFY_SELFHOST.md
@@ -35,20 +35,24 @@ On a 2–4 GB / 3 vCPU Hetzner box, Atlaskit `vite build` will still saturat
 
 1. In the GitHub repo set:
    - **Variables:** `VITE_API_BASE_URL`, `VITE_SUPABASE_URL`
-   - **Secret:** `VITE_SUPABASE_PUBLISHABLE_KEY`
-   - Optional: Variable `COOLIFY_DEPLOY_WEBHOOK` + Secret `COOLIFY_TOKEN` to redeploy after push
-2. Merge to `main` (or run workflow **Coolify images** manually) so GHCR gets:
-   - `ghcr.io/justinloveless/retro-vote-sorter-board-web:latest`
-   - `ghcr.io/justinloveless/retro-vote-sorter-board-api:latest`
-3. If packages are private, on the VPS once:
+   - **Secrets:** `VITE_SUPABASE_PUBLISHABLE_KEY`, **`COOLIFY_WEBHOOK`** (required for post-image deploy)
+   - Optional secret: `COOLIFY_TOKEN` if your Coolify webhook requires Bearer auth
+2. In Coolify for this resource:
+   - Compose path: **`docker-compose.selfhost.prebuilt.yml`**
+   - **Disable Auto Deploy** on git push (Configuration → General / Webhooks). Git auto-deploy races GHCR and starts before new images exist.
+   - Copy **Deploy Webhook** URL → GitHub secret `COOLIFY_WEBHOOK`
+3. Merge to `main` (or run workflow **Coolify images** manually). Order is:
+   1. Actions builds/pushes `*-api` + `*-web` to GHCR  
+   2. `deploy-coolify` calls the webhook  
+   3. Coolify pulls (`pull_policy: always`) and restarts
+4. If packages are private, on the VPS once:
    ```bash
    echo <GITHUB_PAT_with_read:packages> | docker login ghcr.io -u <github-user> --password-stdin
    ```
    Or set the GHCR package visibility to **Public**.
-4. In Coolify, point the resource compose path to **`docker-compose.selfhost.prebuilt.yml`** and redeploy.
-5. Confirm the deploy log shows **pull** for `web`/`api`, not `RUN vite build` / `npm ci`.
+5. Confirm deploy logs show **pull** for `web`/`api`, not `RUN vite build` / `npm ci`.
 
-`VITE_*` changes require a new Actions build (they are baked into the web image), then a Coolify pull/redeploy.
+`VITE_*` changes require a new Actions build (baked into the web image), then the webhook redeploy.
 
 ### Fallback: build on the VPS (not recommended on small hosts)
 

--- a/docker-compose.selfhost.prebuilt.yml
+++ b/docker-compose.selfhost.prebuilt.yml
@@ -7,7 +7,14 @@
 #   ghcr.io/<owner>/retro-vote-sorter-board-api:latest
 #
 # Coolify: set compose path to this file, authenticate GHCR on the server if
-# packages are private, then deploy (pull + up only).
+# packages are private, disable git auto-deploy, and let GitHub Actions call the
+# deploy webhook AFTER images are pushed (see COOLIFY_SELFHOST.md).
+
+configs:
+  # Use compose configs (not bind mounts). Coolify remaps ./host paths to empty
+  # persistent dirs, which broke db-init (/init/01-roles.sql missing).
+  retroscope_roles_sql:
+    file: ./server/postgres/init/01-roles.sql
 
 services:
   postgres:
@@ -19,7 +26,10 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
     volumes:
       - retroscope_pg_data:/var/lib/postgresql/data
-      - ./server/postgres/init:/docker-entrypoint-initdb.d:ro
+    configs:
+      - source: retroscope_roles_sql
+        target: /docker-entrypoint-initdb.d/01-roles.sql
+        mode: 0444
     expose:
       - '5432'
     healthcheck:
@@ -44,8 +54,10 @@ services:
       PGUSER: ${POSTGRES_USER:-postgres}
       PGPASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
       PGDATABASE: ${POSTGRES_DB:-retroscope}
-    volumes:
-      - ./server/postgres/init:/init:ro
+    configs:
+      - source: retroscope_roles_sql
+        target: /init/01-roles.sql
+        mode: 0444
     command: ['psql', '-v', 'ON_ERROR_STOP=1', '-f', '/init/01-roles.sql']
     depends_on:
       postgres:
@@ -82,6 +94,7 @@ services:
 
   api:
     image: ${API_IMAGE:-ghcr.io/justinloveless/retro-vote-sorter-board-api:latest}
+    pull_policy: always
     restart: unless-stopped
     environment:
       NODE_ENV: production
@@ -123,6 +136,7 @@ services:
 
   web:
     image: ${WEB_IMAGE:-ghcr.io/justinloveless/retro-vote-sorter-board-web:latest}
+    pull_policy: always
     restart: unless-stopped
     depends_on:
       - api

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -7,6 +7,11 @@
 # (local/dev or build server only). If you must build here: set
 # COMPOSE_PARALLEL_LIMIT=1 and Concurrent builds = 1.
 
+configs:
+  # Prefer compose configs over bind mounts (Coolify remaps ./ binds to empty dirs).
+  retroscope_roles_sql:
+    file: ./server/postgres/init/01-roles.sql
+
 services:
   postgres:
     image: postgres:16-alpine
@@ -17,7 +22,10 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
     volumes:
       - retroscope_pg_data:/var/lib/postgresql/data
-      - ./server/postgres/init:/docker-entrypoint-initdb.d:ro
+    configs:
+      - source: retroscope_roles_sql
+        target: /docker-entrypoint-initdb.d/01-roles.sql
+        mode: 0444
     expose:
       - '5432'
     healthcheck:
@@ -42,8 +50,10 @@ services:
       PGUSER: ${POSTGRES_USER:-postgres}
       PGPASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
       PGDATABASE: ${POSTGRES_DB:-retroscope}
-    volumes:
-      - ./server/postgres/init:/init:ro
+    configs:
+      - source: retroscope_roles_sql
+        target: /init/01-roles.sql
+        mode: 0444
     command: ['psql', '-v', 'ON_ERROR_STOP=1', '-f', '/init/01-roles.sql']
     depends_on:
       postgres:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Three Coolify bring-up issues:

1. **`db-init`: `/init/01-roles.sql` missing** — Coolify remaps relative bind mounts to empty dirs. Switched to Docker Compose **`configs`**.
2. **`deploy-coolify` skipped** — now uses secret **`COOLIFY_WEBHOOK`** with a clear warning if unset.
3. **Deploy races GHCR** — GitHub App **Auto Deploy** starts on merge before images exist. Keep the GitHub App; turn **Auto Deploy** off; let Actions call Coolify’s **Deploy Webhook** after GHCR push (`pull_policy: always` on `api`/`web`).

## GitHub App users

You do **not** need a manual Git webhook. The App stays for repo access. Only change *when* deploy runs:

1. Coolify → Advanced → Deployment & Git → **disable Auto Deploy**
2. Copy resource **Deploy Webhook** URL → GitHub secret `COOLIFY_WEBHOOK`
3. Merge; Actions builds images, then triggers Coolify

## Immediate workaround for roles (before merge)

In the postgres container, run `server/postgres/init/01-roles.sql` as superuser, then restart `postgrest`.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-83](https://linear.app/dungeon-dwellers/issue/DUN-83/coolify-deployments-eating-100percent-cpu)

<div><a href="https://cursor.com/agents/bc-bb3ad57d-69da-446f-b4eb-85ec90fe52c5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb3ad57d-69da-446f-b4eb-85ec90fe52c5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

