### PR TITLE
fix: Authenticate Coolify deploy webhook (fix 401)

### DIFF
--- a/.github/workflows/coolify-images.yml
+++ b/.github/workflows/coolify-images.yml
@@ -129,7 +129,7 @@ jobs:
     steps:
       - name: Trigger Coolify redeploy after GHCR push
         env:
-          # Prefer secret (Coolify docs). Var name kept as fallback.
+          # /api/v1/deploy?... requires Authorization: Bearer <API token>.
           WEBHOOK: ${{ secrets.COOLIFY_WEBHOOK }}
           WEBHOOK_FALLBACK: ${{ vars.COOLIFY_DEPLOY_WEBHOOK }}
           TOKEN: ${{ secrets.COOLIFY_TOKEN }}
@@ -144,11 +144,20 @@ jobs:
             echo "Also disable Coolify git Auto Deploy for this resource so deploys wait for GHCR images."
             exit 0
           fi
-          echo "Triggering Coolify webhook after images were pushed..."
-          if [ -n "${TOKEN:-}" ]; then
-            curl --fail-with-body --request GET "$URL" --header "Authorization: Bearer $TOKEN"
-          else
-            curl --fail-with-body --request GET "$URL"
+          if [ -z "${TOKEN:-}" ]; then
+            echo "::error::COOLIFY_TOKEN is required. Coolify /api/v1/deploy returns 401 without Authorization: Bearer <token>."
+            echo "Create one in Coolify → Keys & Tokens → API Tokens (permission: deploy), then add it as GitHub Actions secret COOLIFY_TOKEN."
+            exit 1
           fi
+          # Prefer force=true so Coolify re-pulls GHCR :latest after our push.
+          case "$URL" in
+            *force=*) ;;
+            *\?*) URL="${URL}&force=true" ;;
+            *) URL="${URL}?force=true" ;;
+          esac
+          echo "Triggering Coolify deploy API after images were pushed..."
+          curl --fail-with-body --request GET "$URL" \
+            --header "Authorization: Bearer ${TOKEN}" \
+            --header "Accept: application/json"
           echo
           echo "Coolify deploy triggered."

--- a/COOLIFY_SELFHOST.md
+++ b/COOLIFY_SELFHOST.md
@@ -52,16 +52,16 @@ Keep your **GitHub App** connection (repo access). For prebuilt images you only 
    - Compose path: **`docker-compose.selfhost.prebuilt.yml`**
    - **Disable Auto Deploy** (Configuration → Advanced → Deployment & Git). Leave the GitHub App source as-is.
    - On self-hosted Coolify, ensure **API access is enabled** (and GitHub Actions IPs are allowed if you use an API IP allowlist)
-3. Merge to `main` (or run workflow **Coolify images** manually). Order is:
+4. Merge to `main` (or run workflow **Coolify images** manually). Order is:
    1. Actions builds/pushes `*-api` + `*-web` to GHCR  
-   2. `deploy-coolify` calls the Deploy Webhook  
+   2. `deploy-coolify` calls the Deploy Webhook with `Authorization: Bearer`  
    3. Coolify pulls (`pull_policy: always`) and restarts
-4. If packages are private, on the VPS once:
+5. If packages are private, on the VPS once:
    ```bash
    echo <GITHUB_PAT_with_read:packages> | docker login ghcr.io -u <github-user> --password-stdin
    ```
    Or set the GHCR package visibility to **Public**.
-5. Confirm deploy logs show **pull** for `web`/`api`, not `RUN vite build` / `npm ci`.
+6. Confirm deploy logs show **pull** for `web`/`api`, not `RUN vite build` / `npm ci`.
 
 `VITE_*` changes require a new Actions build (baked into the web image), then the post-image redeploy.
 

--- a/COOLIFY_SELFHOST.md
+++ b/COOLIFY_SELFHOST.md
@@ -41,14 +41,17 @@ Keep your **GitHub App** connection (repo access). For prebuilt images you only 
 | **Auto Deploy** (Advanced → Deployment & Git) | **Turn OFF** — otherwise merge-to-main deploys immediately and pulls stale GHCR `:latest` while Actions is still building |
 | **Deploy Webhook** (not a “manual Git webhook”) | Coolify URL that **GitHub Actions** calls *after* images are pushed. Direction is CI → Coolify, opposite of the GitHub App’s git events |
 
-1. In the GitHub repo set:
+1. In Coolify, create an API token: **Keys & Tokens → API Tokens** with at least **`deploy`** permission. Copy the full token (includes `id|secret`).
+2. In the GitHub repo set:
    - **Variables:** `VITE_API_BASE_URL`, `VITE_SUPABASE_URL`
-   - **Secrets:** `VITE_SUPABASE_PUBLISHABLE_KEY`, **`COOLIFY_WEBHOOK`**
-   - Optional secret: `COOLIFY_TOKEN` if your Coolify instance requires Bearer auth on deploy API calls
-2. In Coolify for this resource:
+   - **Secrets:**
+     - `VITE_SUPABASE_PUBLISHABLE_KEY`
+     - **`COOLIFY_WEBHOOK`** — resource Deploy Webhook URL (`https://<coolify>/api/v1/deploy?uuid=...`)
+     - **`COOLIFY_TOKEN`** — the API token (required; bare webhook calls return `401 Unauthenticated`)
+3. In Coolify for this resource:
    - Compose path: **`docker-compose.selfhost.prebuilt.yml`**
    - **Disable Auto Deploy** (Configuration → Advanced → Deployment & Git). Leave the GitHub App source as-is.
-   - Open the resource **Deploy Webhook** / deploy API URL → save it as GitHub secret `COOLIFY_WEBHOOK`
+   - On self-hosted Coolify, ensure **API access is enabled** (and GitHub Actions IPs are allowed if you use an API IP allowlist)
 3. Merge to `main` (or run workflow **Coolify images** manually). Order is:
    1. Actions builds/pushes `*-api` + `*-web` to GHCR  
    2. `deploy-coolify` calls the Deploy Webhook  
@@ -198,8 +201,19 @@ Old compose used a bind mount Coolify rewrites to an empty host dir. Use a relea
 
 ### `deploy-coolify` skipped / Coolify deploys before new images exist
 
-Using a **GitHub App** does not set `COOLIFY_WEBHOOK` by itself. The App notifies Coolify of git changes; the Actions job needs the separate **Deploy Webhook** URL.
+Using a **GitHub App** does not set `COOLIFY_WEBHOOK` by itself. The App notifies Coolify of git changes; the Actions job needs the separate **Deploy Webhook** URL plus an API token.
 
-1. Coolify → resource → copy **Deploy Webhook** → GitHub Actions secret **`COOLIFY_WEBHOOK`**. Without it, `deploy-coolify` warns and exits 0 (appears “skipped” / no-op).
-2. Coolify → Advanced → Deployment & Git → **disable Auto Deploy**. Keep the GitHub App; only stop deploy-on-push so CI can deploy after GHCR is updated.
+1. Coolify → resource → copy **Deploy Webhook** → GitHub secret **`COOLIFY_WEBHOOK`**. Without it, `deploy-coolify` warns and exits 0.
+2. Coolify → Keys & Tokens → API Tokens → create token with **`deploy`** → GitHub secret **`COOLIFY_TOKEN`**.
+3. Coolify → Advanced → Deployment & Git → **disable Auto Deploy**. Keep the GitHub App; only stop deploy-on-push so CI can deploy after GHCR is updated.
+
+### `deploy-coolify` → `401 Unauthenticated`
+
+The Deploy Webhook is Coolify’s `/api/v1/deploy` API. It always needs:
+
+```bash
+Authorization: Bearer <COOLIFY_TOKEN>
+```
+
+Create/rotate the token under **Keys & Tokens → API Tokens**, store the full value as `COOLIFY_TOKEN`, and confirm API access is enabled on self-hosted Coolify.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`deploy-coolify` hit Coolify `/api/v1/deploy` and got `401 Unauthenticated` because that API always requires:

```http
Authorization: Bearer <api-token>
```

`COOLIFY_WEBHOOK` alone is not enough.

## Changes

- Require GitHub secret **`COOLIFY_TOKEN`**; fail with a clear error if missing
- Always send the Bearer header
- Append `force=true` so Coolify re-pulls GHCR `:latest`
- Document creating a Coolify API token with **`deploy`** permission

## What you need to do

1. Coolify → **Keys & Tokens → API Tokens** → New token with **`deploy`**
2. Copy the **full** token value (includes `id|...`)
3. GitHub → Actions secrets → set **`COOLIFY_TOKEN`**
4. Keep **`COOLIFY_WEBHOOK`** as the Deploy Webhook URL
5. On self-hosted Coolify, confirm API access is enabled

Then re-run **Coolify images** (or merge this PR).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-83](https://linear.app/dungeon-dwellers/issue/DUN-83/coolify-deployments-eating-100percent-cpu)

<div><a href="https://cursor.com/agents/bc-bb3ad57d-69da-446f-b4eb-85ec90fe52c5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb3ad57d-69da-446f-b4eb-85ec90fe52c5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

