### PR TITLE
fix: Inline Postgres roles SQL for Coolify (no bind mounts)

### DIFF
--- a/COOLIFY_SELFHOST.md
+++ b/COOLIFY_SELFHOST.md
@@ -192,9 +192,11 @@ PGRST_DB_URI=postgresql://authenticator:retroscope_authenticator_pass@postgres:5
 DATABASE_URL=postgresql://retroscope_app:retroscope_app_pass@postgres:5432/retroscope
 ```
 
-### `db-init`: `/init/01-roles.sql: No such file or directory`
+### `db-init`: `/init/01-roles.sql` missing or `bind source path does not exist`
 
-Old compose used a bind mount Coolify rewrites to an empty host dir. Use a release that defines `configs.retroscope_roles_sql` (file → `/init/01-roles.sql`).
+Coolify runs `docker compose` inside a helper container. Host bind mounts and `configs.file:` paths under `/artifacts/...` are **not** visible to the Docker daemon, so they fail.
+
+Use a release that defines `configs.retroscope_roles_sql` with **inline `content:`** (not `file:`).
 
 ### `deploy-coolify` skipped / Coolify deploys before new images exist
 

--- a/docker-compose.selfhost.prebuilt.yml
+++ b/docker-compose.selfhost.prebuilt.yml
@@ -11,10 +11,47 @@
 # deploy webhook AFTER images are pushed (see COOLIFY_SELFHOST.md).
 
 configs:
-  # Use compose configs (not bind mounts). Coolify remaps ./host paths to empty
-  # persistent dirs, which broke db-init (/init/01-roles.sql missing).
+  # Inline content (not file:). Coolify runs compose via a helper container;
+  # file:/bind paths under /artifacts are invisible to the host Docker daemon.
+  # Keep in sync with server/postgres/init/01-roles.sql
   retroscope_roles_sql:
-    file: ./server/postgres/init/01-roles.sql
+    content: |
+      -- Minimal roles so PostgREST can start in Phase 1.
+      -- Full schema + RLS bootstrap lands in Phase 3.
+      
+      DO $$
+      BEGIN
+        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'anon') THEN
+          CREATE ROLE anon NOLOGIN;
+        END IF;
+        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticated') THEN
+          CREATE ROLE authenticated NOLOGIN;
+        END IF;
+        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'service_role') THEN
+          CREATE ROLE service_role NOLOGIN BYPASSRLS;
+        END IF;
+        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticator') THEN
+          CREATE ROLE authenticator NOINHERIT LOGIN PASSWORD 'retroscope_authenticator_pass';
+        END IF;
+        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'retroscope_app') THEN
+          CREATE ROLE retroscope_app LOGIN PASSWORD 'retroscope_app_pass';
+        END IF;
+      END
+      $$;
+      
+      GRANT anon TO authenticator;
+      GRANT authenticated TO authenticator;
+      GRANT service_role TO authenticator;
+      GRANT authenticated TO retroscope_app;
+      GRANT anon TO retroscope_app;
+      
+      GRANT USAGE ON SCHEMA public TO anon, authenticated, service_role, retroscope_app, authenticator;
+      GRANT ALL ON SCHEMA public TO retroscope_app;
+      
+      ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO anon;
+      ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO authenticated;
+      ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO service_role;
+      ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO retroscope_app;
 
 services:
   postgres:
@@ -29,7 +66,6 @@ services:
     configs:
       - source: retroscope_roles_sql
         target: /docker-entrypoint-initdb.d/01-roles.sql
-        mode: 0444
     expose:
       - '5432'
     healthcheck:
@@ -57,7 +93,6 @@ services:
     configs:
       - source: retroscope_roles_sql
         target: /init/01-roles.sql
-        mode: 0444
     command: ['psql', '-v', 'ON_ERROR_STOP=1', '-f', '/init/01-roles.sql']
     depends_on:
       postgres:

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -8,9 +8,47 @@
 # COMPOSE_PARALLEL_LIMIT=1 and Concurrent builds = 1.
 
 configs:
-  # Prefer compose configs over bind mounts (Coolify remaps ./ binds to empty dirs).
+  # Inline content (not file:). Coolify runs compose via a helper container;
+  # file:/bind paths under /artifacts are invisible to the host Docker daemon.
+  # Keep in sync with server/postgres/init/01-roles.sql
   retroscope_roles_sql:
-    file: ./server/postgres/init/01-roles.sql
+    content: |
+      -- Minimal roles so PostgREST can start in Phase 1.
+      -- Full schema + RLS bootstrap lands in Phase 3.
+      
+      DO $$
+      BEGIN
+        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'anon') THEN
+          CREATE ROLE anon NOLOGIN;
+        END IF;
+        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticated') THEN
+          CREATE ROLE authenticated NOLOGIN;
+        END IF;
+        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'service_role') THEN
+          CREATE ROLE service_role NOLOGIN BYPASSRLS;
+        END IF;
+        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticator') THEN
+          CREATE ROLE authenticator NOINHERIT LOGIN PASSWORD 'retroscope_authenticator_pass';
+        END IF;
+        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'retroscope_app') THEN
+          CREATE ROLE retroscope_app LOGIN PASSWORD 'retroscope_app_pass';
+        END IF;
+      END
+      $$;
+      
+      GRANT anon TO authenticator;
+      GRANT authenticated TO authenticator;
+      GRANT service_role TO authenticator;
+      GRANT authenticated TO retroscope_app;
+      GRANT anon TO retroscope_app;
+      
+      GRANT USAGE ON SCHEMA public TO anon, authenticated, service_role, retroscope_app, authenticator;
+      GRANT ALL ON SCHEMA public TO retroscope_app;
+      
+      ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO anon;
+      ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO authenticated;
+      ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO service_role;
+      ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO retroscope_app;
 
 services:
   postgres:
@@ -25,7 +63,6 @@ services:
     configs:
       - source: retroscope_roles_sql
         target: /docker-entrypoint-initdb.d/01-roles.sql
-        mode: 0444
     expose:
       - '5432'
     healthcheck:
@@ -53,7 +90,6 @@ services:
     configs:
       - source: retroscope_roles_sql
         target: /init/01-roles.sql
-        mode: 0444
     command: ['psql', '-v', 'ON_ERROR_STOP=1', '-f', '/init/01-roles.sql']
     depends_on:
       postgres:

--- a/server/postgres/init/01-roles.sql
+++ b/server/postgres/init/01-roles.sql
@@ -1,5 +1,8 @@
 -- Minimal roles so PostgREST can start in Phase 1.
 -- Full schema + RLS bootstrap lands in Phase 3.
+--
+-- Coolify compose embeds this SQL via configs.content (not file: / bind mounts).
+-- Keep docker-compose.selfhost*.yml `retroscope_roles_sql` in sync when editing.
 
 DO $$
 BEGIN


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Coolify deploy failed with:

```text
invalid mount config for type "bind": bind source path does not exist:
/artifacts/.../server/postgres/init/01-roles.sql
```

Coolify runs `docker compose` inside a **helper container**. `configs.file:` / bind paths under `/artifacts` exist only there — the host Docker daemon cannot see them.

## Fix

Embed `01-roles.sql` as `configs.retroscope_roles_sql.content` (inline) in both selfhost compose files. No host file mount required.

Also drop unsupported `mode:` on config mounts (Coolify warned it ignores uid/gid/mode).

## After merge

Redeploy (or let Actions → Coolify webhook run). `db-init` should apply roles; PostgREST should connect as `authenticator`.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-83](https://linear.app/dungeon-dwellers/issue/DUN-83/coolify-deployments-eating-100percent-cpu)

<div><a href="https://cursor.com/agents/bc-bb3ad57d-69da-446f-b4eb-85ec90fe52c5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb3ad57d-69da-446f-b4eb-85ec90fe52c5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

