### PR TITLE
fix: Stop Compose from breaking db-init dollar quotes

### DIFF
--- a/COOLIFY_SELFHOST.md
+++ b/COOLIFY_SELFHOST.md
@@ -198,6 +198,10 @@ Coolify runs `docker compose` inside a helper container. Host bind mounts and `c
 
 Use a release that defines `configs.retroscope_roles_sql` with **inline `content:`** (not `file:`).
 
+### `db-init`: `syntax error at or near "$"` / `DO $`
+
+Docker Compose treats `$$` as an escaped `$`, so PL/pgSQL `DO $$ ... $$` becomes `DO $ ... $` and fails. Roles SQL uses psql `\gexec` instead (no dollar-quoting). Keep the SQL free of `$` characters when embedding in compose.
+
 ### `deploy-coolify` skipped / Coolify deploys before new images exist
 
 Using a **GitHub App** does not set `COOLIFY_WEBHOOK` by itself. The App notifies Coolify of git changes; the Actions job needs the separate **Deploy Webhook** URL.

--- a/docker-compose.selfhost.prebuilt.yml
+++ b/docker-compose.selfhost.prebuilt.yml
@@ -11,33 +11,44 @@
 # deploy webhook AFTER images are pushed (see COOLIFY_SELFHOST.md).
 
 configs:
-  # Inline content (not file:). Coolify runs compose via a helper container;
-  # file:/bind paths under /artifacts are invisible to the host Docker daemon.
-  # Keep in sync with server/postgres/init/01-roles.sql
+  # Inline content (not file:). Coolify helper /artifacts binds are invisible to
+  # the host Docker daemon. Keep in sync with server/postgres/init/01-roles.sql
+  # (SQL must stay free of `$` — Compose interpolates them).
   retroscope_roles_sql:
     content: |
       -- Minimal roles so PostgREST can start in Phase 1.
       -- Full schema + RLS bootstrap lands in Phase 3.
+      --
+      -- Use psql \gexec instead of PL/pgSQL DO blocks. Docker Compose interpolates
+      -- dollar signs in compose YAML, which corrupted dollar-quoted DO bodies under
+      -- Coolify. \gexec runs each SELECT result as SQL (psql only — used by db-init).
+      --
+      -- Coolify compose embeds this via configs.content — keep compose in sync.
       
-      DO $$
-      BEGIN
-        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'anon') THEN
-          CREATE ROLE anon NOLOGIN;
-        END IF;
-        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticated') THEN
-          CREATE ROLE authenticated NOLOGIN;
-        END IF;
-        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'service_role') THEN
-          CREATE ROLE service_role NOLOGIN BYPASSRLS;
-        END IF;
-        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticator') THEN
-          CREATE ROLE authenticator NOINHERIT LOGIN PASSWORD 'retroscope_authenticator_pass';
-        END IF;
-        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'retroscope_app') THEN
-          CREATE ROLE retroscope_app LOGIN PASSWORD 'retroscope_app_pass';
-        END IF;
-      END
-      $$;
+      SELECT format('CREATE ROLE %I NOLOGIN', rolname)
+      FROM (VALUES ('anon'), ('authenticated')) AS t(rolname)
+      WHERE NOT EXISTS (SELECT FROM pg_roles r WHERE r.rolname = t.rolname)
+      \gexec
+      
+      SELECT format('CREATE ROLE %I NOLOGIN BYPASSRLS', 'service_role')
+      WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'service_role')
+      \gexec
+      
+      SELECT format(
+        'CREATE ROLE %I NOINHERIT LOGIN PASSWORD %L',
+        'authenticator',
+        'retroscope_authenticator_pass'
+      )
+      WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticator')
+      \gexec
+      
+      SELECT format(
+        'CREATE ROLE %I LOGIN PASSWORD %L',
+        'retroscope_app',
+        'retroscope_app_pass'
+      )
+      WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'retroscope_app')
+      \gexec
       
       GRANT anon TO authenticator;
       GRANT authenticated TO authenticator;
@@ -52,7 +63,6 @@ configs:
       ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO authenticated;
       ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO service_role;
       ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO retroscope_app;
-
 services:
   postgres:
     image: postgres:16-alpine

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -8,33 +8,44 @@
 # COMPOSE_PARALLEL_LIMIT=1 and Concurrent builds = 1.
 
 configs:
-  # Inline content (not file:). Coolify runs compose via a helper container;
-  # file:/bind paths under /artifacts are invisible to the host Docker daemon.
-  # Keep in sync with server/postgres/init/01-roles.sql
+  # Inline content (not file:). Coolify helper /artifacts binds are invisible to
+  # the host Docker daemon. Keep in sync with server/postgres/init/01-roles.sql
+  # (SQL must stay free of `$` — Compose interpolates them).
   retroscope_roles_sql:
     content: |
       -- Minimal roles so PostgREST can start in Phase 1.
       -- Full schema + RLS bootstrap lands in Phase 3.
+      --
+      -- Use psql \gexec instead of PL/pgSQL DO blocks. Docker Compose interpolates
+      -- dollar signs in compose YAML, which corrupted dollar-quoted DO bodies under
+      -- Coolify. \gexec runs each SELECT result as SQL (psql only — used by db-init).
+      --
+      -- Coolify compose embeds this via configs.content — keep compose in sync.
       
-      DO $$
-      BEGIN
-        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'anon') THEN
-          CREATE ROLE anon NOLOGIN;
-        END IF;
-        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticated') THEN
-          CREATE ROLE authenticated NOLOGIN;
-        END IF;
-        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'service_role') THEN
-          CREATE ROLE service_role NOLOGIN BYPASSRLS;
-        END IF;
-        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticator') THEN
-          CREATE ROLE authenticator NOINHERIT LOGIN PASSWORD 'retroscope_authenticator_pass';
-        END IF;
-        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'retroscope_app') THEN
-          CREATE ROLE retroscope_app LOGIN PASSWORD 'retroscope_app_pass';
-        END IF;
-      END
-      $$;
+      SELECT format('CREATE ROLE %I NOLOGIN', rolname)
+      FROM (VALUES ('anon'), ('authenticated')) AS t(rolname)
+      WHERE NOT EXISTS (SELECT FROM pg_roles r WHERE r.rolname = t.rolname)
+      \gexec
+      
+      SELECT format('CREATE ROLE %I NOLOGIN BYPASSRLS', 'service_role')
+      WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'service_role')
+      \gexec
+      
+      SELECT format(
+        'CREATE ROLE %I NOINHERIT LOGIN PASSWORD %L',
+        'authenticator',
+        'retroscope_authenticator_pass'
+      )
+      WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticator')
+      \gexec
+      
+      SELECT format(
+        'CREATE ROLE %I LOGIN PASSWORD %L',
+        'retroscope_app',
+        'retroscope_app_pass'
+      )
+      WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'retroscope_app')
+      \gexec
       
       GRANT anon TO authenticator;
       GRANT authenticated TO authenticator;
@@ -49,7 +60,6 @@ configs:
       ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO authenticated;
       ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO service_role;
       ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO retroscope_app;
-
 services:
   postgres:
     image: postgres:16-alpine

--- a/server/postgres/init/01-roles.sql
+++ b/server/postgres/init/01-roles.sql
@@ -1,28 +1,36 @@
 -- Minimal roles so PostgREST can start in Phase 1.
 -- Full schema + RLS bootstrap lands in Phase 3.
 --
--- Coolify compose embeds this SQL via configs.content (not file: / bind mounts).
--- Keep docker-compose.selfhost*.yml `retroscope_roles_sql` in sync when editing.
+-- Use psql \gexec instead of PL/pgSQL DO blocks. Docker Compose interpolates
+-- dollar signs in compose YAML, which corrupted dollar-quoted DO bodies under
+-- Coolify. \gexec runs each SELECT result as SQL (psql only — used by db-init).
+--
+-- Coolify compose embeds this via configs.content — keep compose in sync.
 
-DO $$
-BEGIN
-  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'anon') THEN
-    CREATE ROLE anon NOLOGIN;
-  END IF;
-  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticated') THEN
-    CREATE ROLE authenticated NOLOGIN;
-  END IF;
-  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'service_role') THEN
-    CREATE ROLE service_role NOLOGIN BYPASSRLS;
-  END IF;
-  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticator') THEN
-    CREATE ROLE authenticator NOINHERIT LOGIN PASSWORD 'retroscope_authenticator_pass';
-  END IF;
-  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'retroscope_app') THEN
-    CREATE ROLE retroscope_app LOGIN PASSWORD 'retroscope_app_pass';
-  END IF;
-END
-$$;
+SELECT format('CREATE ROLE %I NOLOGIN', rolname)
+FROM (VALUES ('anon'), ('authenticated')) AS t(rolname)
+WHERE NOT EXISTS (SELECT FROM pg_roles r WHERE r.rolname = t.rolname)
+\gexec
+
+SELECT format('CREATE ROLE %I NOLOGIN BYPASSRLS', 'service_role')
+WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'service_role')
+\gexec
+
+SELECT format(
+  'CREATE ROLE %I NOINHERIT LOGIN PASSWORD %L',
+  'authenticator',
+  'retroscope_authenticator_pass'
+)
+WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticator')
+\gexec
+
+SELECT format(
+  'CREATE ROLE %I LOGIN PASSWORD %L',
+  'retroscope_app',
+  'retroscope_app_pass'
+)
+WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'retroscope_app')
+\gexec
 
 GRANT anon TO authenticator;
 GRANT authenticated TO authenticator;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`db-init` failed with:

```text
psql:/init/01-roles.sql:7: ERROR:  syntax error at or near "$"
LINE 1: DO $
```

Docker Compose interpolates `$$` → `$` in compose YAML, so `DO $$ ... $$` became `DO $ ... $`.

## Fix

Rewrite `server/postgres/init/01-roles.sql` to use psql `\gexec` + `format(...)` (no PL/pgSQL / no `$`), and refresh the inline `configs.content` copies in both selfhost compose files.

## After merge

Redeploy; `db-init` should create `authenticator` / `retroscope_app` without syntax errors.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-83](https://linear.app/dungeon-dwellers/issue/DUN-83/coolify-deployments-eating-100percent-cpu)

<div><a href="https://cursor.com/agents/bc-bb3ad57d-69da-446f-b4eb-85ec90fe52c5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb3ad57d-69da-446f-b4eb-85ec90fe52c5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

