### PR TITLE
fix(account): stop blank profile picture exports on crop (#92)

### DIFF
--- a/src/components/account/AccountDetails.tsx
+++ b/src/components/account/AccountDetails.tsx
@@ -5,6 +5,7 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { User } from 'lucide-react';
 import { Profile } from '@/hooks/useAuth';
 import { AvatarUploader } from '@/components/account/AvatarUploader';
+import { withAvatarCacheBust } from '@/components/account/avatarCrop';
 import { supabase } from '@/integrations/supabase/client';
 
 interface AccountDetailsProps {
@@ -63,10 +64,12 @@ export const AccountDetails = ({ user, profile, editing, onSetEditing, onUpdateP
                             onCropped={async (blob) => {
                                 // Use profile.id (impersonated user) instead of user.id (admin)
                                 const fileName = `${profile?.id || user.id}.png`;
-                                // Upload to supabase storage bucket 'avatars'
-                                await supabase.storage.from('avatars').upload(fileName, blob, { upsert: true, contentType: 'image/png' });
+                                const { error: uploadError } = await supabase.storage
+                                    .from('avatars')
+                                    .upload(fileName, blob, { upsert: true, contentType: 'image/png' });
+                                if (uploadError) throw uploadError;
                                 const { data } = supabase.storage.from('avatars').getPublicUrl(fileName);
-                                const publicUrl = data.publicUrl;
+                                const publicUrl = withAvatarCacheBust(data.publicUrl);
                                 // Set hidden input so existing form submit keeps working
                                 const hidden = document.getElementById('avatarUrl') as HTMLInputElement | null;
                                 if (hidden) hidden.value = publicUrl;

--- a/src/components/account/AvatarUploader.tsx
+++ b/src/components/account/AvatarUploader.tsx
@@ -2,18 +2,27 @@ import React, { useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Upload } from 'lucide-react';
+import {
+  AVATAR_CIRCLE_DIAMETER,
+  AVATAR_CIRCLE_MARGIN,
+  AVATAR_VIEWPORT_SIZE,
+  getCoverTransform,
+  renderAvatarCropToCanvas,
+} from '@/components/account/avatarCrop';
 
 interface AvatarUploaderProps {
   initialUrl?: string | null;
   onCropped: (blob: Blob) => Promise<void> | void;
 }
 
-export const AvatarUploader: React.FC<AvatarUploaderProps> = ({ initialUrl, onCropped }) => {
+export const AvatarUploader: React.FC<AvatarUploaderProps> = ({ onCropped }) => {
   const [open, setOpen] = useState(false);
   const [fileUrl, setFileUrl] = useState<string | null>(null);
   const [image, setImage] = useState<HTMLImageElement | null>(null);
   const [scale, setScale] = useState(1);
   const [offset, setOffset] = useState({ x: 0, y: 0 });
+  const [saving, setSaving] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const isDraggingRef = useRef(false);
   const dragStartRef = useRef({ x: 0, y: 0 });
@@ -22,23 +31,39 @@ export const AvatarUploader: React.FC<AvatarUploaderProps> = ({ initialUrl, onCr
   const [fileName, setFileName] = useState<string | null>(null);
 
   useEffect(() => {
-    return () => { if (fileUrl) URL.revokeObjectURL(fileUrl); };
+    return () => {
+      if (fileUrl) URL.revokeObjectURL(fileUrl);
+    };
   }, [fileUrl]);
 
   const onFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const f = e.target.files?.[0];
     if (!f) return;
+    setLoadError(null);
     setFileName(f.name);
+    if (fileUrl) URL.revokeObjectURL(fileUrl);
     const url = URL.createObjectURL(f);
     setFileUrl(url);
     const img = new Image();
     img.onload = () => {
+      if (img.naturalWidth <= 0 || img.naturalHeight <= 0) {
+        setLoadError('Could not read that image. Try a different PNG or JPEG.');
+        setImage(null);
+        return;
+      }
+      const cover = getCoverTransform(img.naturalWidth, img.naturalHeight);
       setImage(img);
-      setScale(1);
-      setOffset({ x: 0, y: 0 });
+      setScale(cover.scale);
+      setOffset(cover.offset);
       setOpen(true);
     };
+    img.onerror = () => {
+      setLoadError('Failed to load that image. Try a different file.');
+      setImage(null);
+    };
     img.src = url;
+    // Allow re-selecting the same file
+    e.target.value = '';
   };
 
   const handleMouseDown = (e: React.MouseEvent) => {
@@ -52,49 +77,60 @@ export const AvatarUploader: React.FC<AvatarUploaderProps> = ({ initialUrl, onCr
     const dy = e.clientY - dragStartRef.current.y;
     setOffset({ x: offsetStartRef.current.x + dx, y: offsetStartRef.current.y + dy });
   };
-  const handleMouseUp = () => { isDraggingRef.current = false; };
+  const handleMouseUp = () => {
+    isDraggingRef.current = false;
+  };
 
   const exportCropped = async () => {
-    if (!image || !containerRef.current) return;
-    const viewportSize = 320; // full preview area
-    const circleDiameter = 256; // visible circle
-    const circleMargin = (viewportSize - circleDiameter) / 2;
-    const canvas = document.createElement('canvas');
-    canvas.width = 256;
-    canvas.height = 256;
-    const ctx = canvas.getContext('2d');
-    if (!ctx) return;
-
-    // Compute source crop rect in image coordinates
-    // Image is rendered with top-left at offset (x,y) and scaled by `scale` inside a square viewport of size viewportSize
-    // The visible circle is inset by circleMargin on each side, so crop from that region
-    const sx = (-offset.x + circleMargin) / scale;
-    const sy = (-offset.y + circleMargin) / scale;
-    const sSize = circleDiameter / scale;
-
-    ctx.clearRect(0, 0, 256, 256);
-    ctx.drawImage(image, sx, sy, sSize, sSize, 0, 0, 256, 256);
-    // Export PNG
-    canvas.toBlob(async (blob) => {
-      if (blob) {
-        await onCropped(blob);
-        setOpen(false);
+    if (!image || !containerRef.current || saving) return;
+    setSaving(true);
+    try {
+      const canvas = renderAvatarCropToCanvas(image, { scale, offset });
+      const blob = await new Promise<Blob | null>((resolve) => {
+        canvas.toBlob((b) => resolve(b), 'image/png');
+      });
+      if (!blob || blob.size < 32) {
+        throw new Error('Cropped image was empty. Adjust zoom/position and try again.');
       }
-    }, 'image/png');
+      await onCropped(blob);
+      setOpen(false);
+    } catch (err) {
+      setLoadError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
   };
+
+  const minScale = image
+    ? Math.max(
+        AVATAR_CIRCLE_DIAMETER / image.naturalWidth,
+        AVATAR_CIRCLE_DIAMETER / image.naturalHeight
+      ) * 0.5
+    : 0.5;
+  const maxScale = Math.max(minScale * 6, 3);
 
   return (
     <div className="space-y-2">
       <div className="flex items-center gap-3">
         <input ref={inputRef} type="file" accept="image/*" onChange={onFileChange} className="hidden" />
-        <Button variant="outline" size="sm" onClick={() => inputRef.current?.click()} className="inline-flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => inputRef.current?.click()}
+          className="inline-flex items-center gap-2"
+        >
           <Upload className="h-4 w-4" />
           {fileName ? 'Change Image' : 'Choose Image'}
         </Button>
         {fileName && (
-          <span className="text-xs text-gray-500 dark:text-gray-400 truncate max-w-[200px]" title={fileName}>{fileName}</span>
+          <span className="text-xs text-gray-500 dark:text-gray-400 truncate max-w-[200px]" title={fileName}>
+            {fileName}
+          </span>
         )}
       </div>
+      {loadError && !open && (
+        <p className="text-sm text-destructive">{loadError}</p>
+      )}
 
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent className="max-w-lg">
@@ -107,18 +143,17 @@ export const AvatarUploader: React.FC<AvatarUploaderProps> = ({ initialUrl, onCr
             onMouseMove={handleMouseMove}
             onMouseUp={handleMouseUp}
             onMouseLeave={handleMouseUp}
-            className="relative mx-auto" 
-            style={{ width: 320, height: 320, cursor: 'grab' }}
+            className="relative mx-auto overflow-hidden bg-white"
+            style={{ width: AVATAR_VIEWPORT_SIZE, height: AVATAR_VIEWPORT_SIZE, cursor: 'grab' }}
           >
-            {/* Image layer */}
             {image && (
               <div
                 style={{
                   position: 'absolute',
                   left: 0,
                   top: 0,
-                  width: 320,
-                  height: 320,
+                  width: AVATAR_VIEWPORT_SIZE,
+                  height: AVATAR_VIEWPORT_SIZE,
                   backgroundImage: `url(${image.src})`,
                   backgroundSize: `${image.naturalWidth * scale}px ${image.naturalHeight * scale}px`,
                   backgroundPosition: `${offset.x}px ${offset.y}px`,
@@ -126,31 +161,43 @@ export const AvatarUploader: React.FC<AvatarUploaderProps> = ({ initialUrl, onCr
                 }}
               />
             )}
-            {/* Circular overlay */}
             <div
               className="pointer-events-none absolute rounded-full"
               style={{
-                left: 32,
-                top: 32,
-                width: 256,
-                height: 256,
+                left: AVATAR_CIRCLE_MARGIN,
+                top: AVATAR_CIRCLE_MARGIN,
+                width: AVATAR_CIRCLE_DIAMETER,
+                height: AVATAR_CIRCLE_DIAMETER,
                 boxShadow: '0 0 0 9999px rgba(0,0,0,0.5)',
-                borderRadius: '9999px'
+                borderRadius: '9999px',
               }}
             />
           </div>
           <div className="flex items-center gap-3 pt-3">
             <label className="text-sm text-gray-600 dark:text-gray-300">Zoom</label>
-            <input type="range" min={0.5} max={3} step={0.01} value={scale} onChange={(e) => setScale(parseFloat(e.target.value))} className="w-full" />
+            <input
+              type="range"
+              min={minScale}
+              max={maxScale}
+              step={0.01}
+              value={scale}
+              onChange={(e) => setScale(parseFloat(e.target.value))}
+              className="w-full"
+            />
           </div>
+          {loadError && (
+            <p className="text-sm text-destructive">{loadError}</p>
+          )}
           <div className="flex justify-end gap-2 pt-2">
-            <Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
-            <Button onClick={exportCropped}>Save</Button>
+            <Button variant="outline" onClick={() => setOpen(false)} disabled={saving}>
+              Cancel
+            </Button>
+            <Button onClick={exportCropped} disabled={!image || saving}>
+              {saving ? 'Saving…' : 'Save'}
+            </Button>
           </div>
         </DialogContent>
       </Dialog>
     </div>
   );
 };
-
-

--- a/src/components/account/avatarCrop.test.ts
+++ b/src/components/account/avatarCrop.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AVATAR_CIRCLE_DIAMETER,
+  AVATAR_VIEWPORT_SIZE,
+  getCoverTransform,
+  withAvatarCacheBust,
+} from '@/components/account/avatarCrop';
+
+describe('getCoverTransform', () => {
+  it('scales a small square image up to cover the crop circle', () => {
+    const { scale, offset } = getCoverTransform(48, 48);
+    expect(scale).toBeCloseTo(AVATAR_CIRCLE_DIAMETER / 48);
+    const scaled = 48 * scale;
+    expect(offset.x).toBeCloseTo(AVATAR_VIEWPORT_SIZE / 2 - scaled / 2);
+    expect(offset.y).toBeCloseTo(AVATAR_VIEWPORT_SIZE / 2 - scaled / 2);
+    // Image must fully cover the circle bounding box
+    expect(scaled).toBeGreaterThanOrEqual(AVATAR_CIRCLE_DIAMETER);
+  });
+
+  it('covers the circle for a wide landscape image', () => {
+    const { scale, offset } = getCoverTransform(1000, 500);
+    expect(scale).toBeCloseTo(AVATAR_CIRCLE_DIAMETER / 500);
+    expect(1000 * scale).toBeGreaterThanOrEqual(AVATAR_CIRCLE_DIAMETER);
+    expect(500 * scale).toBeGreaterThanOrEqual(AVATAR_CIRCLE_DIAMETER);
+    expect(offset.y).toBeCloseTo((AVATAR_VIEWPORT_SIZE - 500 * scale) / 2);
+  });
+
+  it('covers the circle for a tall portrait image', () => {
+    const { scale, offset } = getCoverTransform(500, 1000);
+    expect(scale).toBeCloseTo(AVATAR_CIRCLE_DIAMETER / 500);
+    expect(offset.x).toBeCloseTo((AVATAR_VIEWPORT_SIZE - 500 * scale) / 2);
+  });
+
+  it('returns a safe default for invalid dimensions', () => {
+    expect(getCoverTransform(0, 100)).toEqual({ scale: 1, offset: { x: 0, y: 0 } });
+    expect(getCoverTransform(-1, -1)).toEqual({ scale: 1, offset: { x: 0, y: 0 } });
+  });
+});
+
+describe('withAvatarCacheBust', () => {
+  it('appends a v query param without dropping existing params', () => {
+    const url = withAvatarCacheBust(
+      'https://example.com/storage/v1/object/public/avatars/u.png?token=abc',
+      12345
+    );
+    expect(url).toContain('v=12345');
+    expect(url).toContain('token=abc');
+  });
+});

--- a/src/components/account/avatarCrop.ts
+++ b/src/components/account/avatarCrop.ts
@@ -1,0 +1,109 @@
+/** Viewport and crop circle geometry shared by AvatarUploader preview + export. */
+export const AVATAR_VIEWPORT_SIZE = 320;
+export const AVATAR_CIRCLE_DIAMETER = 256;
+export const AVATAR_CIRCLE_MARGIN =
+  (AVATAR_VIEWPORT_SIZE - AVATAR_CIRCLE_DIAMETER) / 2;
+export const AVATAR_OUTPUT_SIZE = 256;
+
+export type AvatarCropTransform = {
+  scale: number;
+  offset: { x: number; y: number };
+};
+
+/**
+ * Scale + center the image so it fully covers the circular crop region
+ * (CSS object-fit: cover against the circle's bounding box).
+ */
+export function getCoverTransform(
+  naturalWidth: number,
+  naturalHeight: number,
+  circleDiameter: number = AVATAR_CIRCLE_DIAMETER,
+  viewportSize: number = AVATAR_VIEWPORT_SIZE
+): AvatarCropTransform {
+  if (naturalWidth <= 0 || naturalHeight <= 0) {
+    return { scale: 1, offset: { x: 0, y: 0 } };
+  }
+
+  const scale = Math.max(circleDiameter / naturalWidth, circleDiameter / naturalHeight);
+  const scaledW = naturalWidth * scale;
+  const scaledH = naturalHeight * scale;
+  const center = viewportSize / 2;
+
+  return {
+    scale,
+    offset: {
+      x: center - scaledW / 2,
+      y: center - scaledH / 2,
+    },
+  };
+}
+
+/**
+ * Draw the image into an output canvas the same way the preview positions it,
+ * then copy the circular crop region. Avoids blank exports when the source
+ * rectangle would fall outside a small image (the old sx/sy path).
+ */
+export function renderAvatarCropToCanvas(
+  image: CanvasImageSource & { naturalWidth: number; naturalHeight: number },
+  transform: AvatarCropTransform,
+  options?: {
+    viewportSize?: number;
+    circleMargin?: number;
+    circleDiameter?: number;
+    outputSize?: number;
+  }
+): HTMLCanvasElement {
+  const viewportSize = options?.viewportSize ?? AVATAR_VIEWPORT_SIZE;
+  const circleMargin = options?.circleMargin ?? AVATAR_CIRCLE_MARGIN;
+  const circleDiameter = options?.circleDiameter ?? AVATAR_CIRCLE_DIAMETER;
+  const outputSize = options?.outputSize ?? AVATAR_OUTPUT_SIZE;
+  const { scale, offset } = transform;
+
+  const viewport = document.createElement('canvas');
+  viewport.width = viewportSize;
+  viewport.height = viewportSize;
+  const vctx = viewport.getContext('2d');
+  if (!vctx) {
+    throw new Error('Could not create canvas context for avatar crop');
+  }
+
+  // Opaque backdrop so transparent source pixels don't yield an "empty" avatar.
+  vctx.fillStyle = '#ffffff';
+  vctx.fillRect(0, 0, viewportSize, viewportSize);
+  vctx.drawImage(
+    image,
+    offset.x,
+    offset.y,
+    image.naturalWidth * scale,
+    image.naturalHeight * scale
+  );
+
+  const output = document.createElement('canvas');
+  output.width = outputSize;
+  output.height = outputSize;
+  const octx = output.getContext('2d');
+  if (!octx) {
+    throw new Error('Could not create canvas context for avatar export');
+  }
+
+  octx.drawImage(
+    viewport,
+    circleMargin,
+    circleMargin,
+    circleDiameter,
+    circleDiameter,
+    0,
+    0,
+    outputSize,
+    outputSize
+  );
+
+  return output;
+}
+
+/** Append a cache-buster so re-uploads to the same storage path refresh in browsers. */
+export function withAvatarCacheBust(publicUrl: string, version: number = Date.now()): string {
+  const url = new URL(publicUrl);
+  url.searchParams.set('v', String(version));
+  return url.toString();
+}

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -22,6 +22,7 @@ import {
 import { currentEnvironment } from '@/config/environment';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { AvatarUploader } from '@/components/account/AvatarUploader';
+import { withAvatarCacheBust } from '@/components/account/avatarCrop';
 import { useFeatureFlags } from '@/contexts/FeatureFlagContext';
 import { FEATURE_SUBSCRIPTIONS_ENABLED } from '@/constants/featureFlags';
 
@@ -222,9 +223,14 @@ const Account = () => {
                             } else {
                               // Normal case: update own avatar
                               const fileName = `${user.id}.png`;
-                              await getDb().storage.from('avatars').upload(fileName, blob, { upsert: true, contentType: 'image/png' });
+                              const { error: uploadError } = await getDb()
+                                .storage.from('avatars')
+                                .upload(fileName, blob, { upsert: true, contentType: 'image/png' });
+                              if (uploadError) throw uploadError;
                               const { data } = getDb().storage.from('avatars').getPublicUrl(fileName);
-                              await updateProfile({ avatar_url: data.publicUrl });
+                              // Cache-bust so re-uploads to the same path refresh in <img> / CDN caches
+                              const publicUrl = withAvatarCacheBust(data.publicUrl);
+                              await updateProfile({ avatar_url: publicUrl });
                               toast({ title: 'Profile picture updated' });
                             }
                           } catch (e: any) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes GitHub issue **#92** ([bug] Uploading profile picture fails) — highest-priority open bug without an existing PR.

The original `invalid input syntax for type uuid: "shared"` failure was addressed earlier by a tenant UUID migration, but profile picture upload still failed in practice: the cropper initialized at `scale=1` / `offset=0`, so small images only covered a corner of the crop circle and canvas export wrote a **transparent 256×256 PNG**. Upload/DB update succeeded, but the avatar looked empty and appeared not to persist.

## Changes
- Cover-fit the selected image into the circular crop region on load
- Export via a viewport canvas that matches the CSS preview (avoids out-of-bounds `drawImage` source rects)
- Reject empty cropped blobs before upload
- Check Supabase storage upload errors instead of ignoring them
- Cache-bust public avatar URLs so re-uploads refresh in browsers
- Unit tests for cover-fit math and cache-bust helper

## Test plan
- [x] `npx vitest run src/components/account/avatarCrop.test.ts`
- [x] Manual on `localhost:8081`: upload 96×96 PNG → crop shows cover-fit image → Save → avatar visible in profile + header → persists after hard refresh

### Walkthrough
<a href="https://cursor.com/agents/bc-14dfe8ec-71b1-4c44-8b7f-e5162555de12/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Favatar_upload_crop_and_persist.mp4"><img src="https://cursor.com/artifacts/c/art-b86aa67b-393a-41a9-a08a-e61c58e76c7e" alt="avatar_upload_crop_and_persist.mp4" /></a>
![Cropper cover-fit](https://cursor.com/artifacts/c/art-cfc7f503-13c7-4387-b887-352a43cf5acb)
![Upload success with avatar](https://cursor.com/artifacts/c/art-4202774c-a4f0-4715-ae1c-47511fad6555)
![Avatar after refresh](https://cursor.com/artifacts/c/art-56a25689-ce10-492f-b789-67a668cab5d4)

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-88](https://linear.app/dungeon-dwellers/issue/DUN-88/find-and-fix-one-issue)

<div><a href="https://cursor.com/agents/bc-14dfe8ec-71b1-4c44-8b7f-e5162555de12?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14dfe8ec-71b1-4c44-8b7f-e5162555de12&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

