### PR TITLE
feat(self-host): Phase 4 Docker-volume storage + P0 edge ports (DUN-79)

### DIFF
--- a/COOLIFY_SELFHOST.md
+++ b/COOLIFY_SELFHOST.md
@@ -1,6 +1,6 @@
-# Coolify Self-Host Deployment (Phase 1–2)
+# Coolify Self-Host Deployment (Phase 1–4)
 
-Lean stack for Retroscope on a shared Coolify VPS: **Postgres + PostgREST + Node API + Nginx FE**. Phase 2 adds local `/auth/v1/*` (Google + password) on the API.
+Lean stack for Retroscope on a shared Coolify VPS: **Postgres + PostgREST + Node API + Nginx FE**. Phase 2 adds local `/auth/v1/*` (Google + password). Phase 3 adds PostgREST data. Phase 4 adds Docker-volume storage + P0 edge ports.
 
 | Compose file | When to use |
 |--------------|-------------|
@@ -91,7 +91,7 @@ VITE_SUPABASE_URL=https://YOUR_PROJECT.supabase.co
 VITE_SUPABASE_PUBLISHABLE_KEY=eyJhbGc...
 ```
 
-When the admin Backend toggle is **Hosted Supabase**, auth + data stay on Supabase. When set to **Self-hosted**, the FE auth facade talks to Node `/auth/v1/*` and table CRUD / RPCs go to local PostgREST via Node `/rest/v1/*` (PostgREST itself stays Coolify-internal). Realtime channels still use hosted Supabase until Phase 5. Keep Supabase Vite vars set through dual-path cutover.
+When the admin Backend toggle is **Hosted Supabase**, auth + data stay on Supabase. When set to **Self-hosted**, the FE auth facade talks to Node `/auth/v1/*`, table CRUD / RPCs go to local PostgREST via Node `/rest/v1/*`, uploads use `/storage/v1/object/*` on the `retroscope_uploads` volume, and P0 edge functions hit `/functions/v1/*`. Realtime channels still use hosted Supabase until Phase 5. Stripe billing functions stay on hosted Supabase (`keep_on_supabase`). Keep Supabase Vite vars set through dual-path cutover.
 
 ### Runtime secrets (`api` / `postgres` / `postgrest`)
 
@@ -169,6 +169,23 @@ After restore, confirm:
 - `GET /readyz` → postgres + postgrest green
 - With a self-hosted access JWT: `GET /rest/v1/profiles?select=id&limit=1` (via API domain)
 
+### Storage copy (Phase 4)
+
+Copy hosted Supabase Storage objects into the Coolify `retroscope_uploads` volume (mounted at `/data/uploads` on `api`):
+
+```bash
+SUPABASE_URL='https://YOUR_PROJECT.supabase.co' \
+SUPABASE_SERVICE_ROLE_KEY='…' \
+UPLOADS_DIR=/data/uploads \
+  ./scripts/selfhost/copy-storage-from-supabase.sh
+
+# After API FQDN is final, rewrite public URLs stored in Postgres:
+DATABASE_URL='postgresql://…' \
+SUPABASE_URL='https://YOUR_PROJECT.supabase.co' \
+PUBLIC_API_BASE_URL='https://retro-api.example.com' \
+  ./scripts/selfhost/rewrite-storage-urls.sh
+```
+
 ## Deploy steps
 
 1. Publish images via GitHub Actions (**Coolify images** workflow) after setting `VITE_*` repo vars/secrets.
@@ -192,6 +209,8 @@ After restore, confirm:
 | `GET /readyz` | Postgres + PostgREST readiness (503 if either fails) |
 | `GET|POST|PATCH|DELETE /rest/v1/*` | PostgREST proxy (JWT forwarded; internal PostgREST only) |
 | `GET /api/admin/backend-status` | Bearer-token stub status for the admin UI |
+| `POST/GET/DELETE /storage/v1/object/*` | Docker-volume uploads (avatars, chat images, retro-audio) |
+| `POST /functions/v1/*` | P0 admin/invite ports; Stripe stays on Supabase |
 
 ## Resource budget (starting point)
 

--- a/documentation/plans/self-host-coverage-tracker.md
+++ b/documentation/plans/self-host-coverage-tracker.md
@@ -115,7 +115,7 @@ Storage bucket string hits via `.from` (not PostgREST tables): `avatars` (4), `r
 | Background profile fields | src/contexts/BackgroundContext.tsx | PostgREST | profiles | PostgREST | Covered | getDb() |
 | App config reads/writes | src/contexts/FeatureFlagContext.tsx, admin/*, Billing | PostgREST | app_config | PostgREST | Not started | Includes future backend_provider |
 | Feature flags | src/contexts/FeatureFlagContext.tsx | PostgREST + Realtime | feature_flags, overrides | PostgREST + WS | Not started | channel feature-flags-realtime |
-| Admin feature flag UI | src/components/admin/FeatureFlagManager.tsx | PostgREST + Edge | flags + admin-search-users / admin-team-members | PostgREST + Node | Not started | |
+| Admin feature flag UI | src/components/admin/FeatureFlagManager.tsx | PostgREST + Edge | flags + admin-search-users / admin-team-members | PostgREST + Node | Covered | getDb(); P0 functions on Node |
 | Tier limits | src/components/admin/TierLimitsManager.tsx | PostgREST | app_config, feature_flags | PostgREST | Not started | |
 | TTS URL config | src/components/admin/TtsUrlManager.tsx | PostgREST | app_config | PostgREST | Not started | |
 | GitHub issue settings | src/components/admin/GithubIssueSettings.tsx | PostgREST | app_config | PostgREST | Not started | |
@@ -130,10 +130,10 @@ Storage bucket string hits via `.from` (not PostgREST tables): `avatars` (4), `r
 | Team data context | src/contexts/TeamDataContext.tsx | PostgREST | members, boards, action items, comments | PostgREST | Covered | getDb() |
 | Invite links | src/hooks/useInviteLinks.ts | PostgREST | team_invitations | PostgREST | Covered | getDb() |
 | Accept team invite | src/hooks/useInvitationAccept.ts | RPC | accept_team_invitation | Postgres RPC / Node | Covered | rpc via /rest/v1/rpc |
-| Send team invite email/notify | useTeamMembers / TeamMembersList | Edge | send-invitation-email, notify-team-invite | Node P0 | Not started | |
+| Send team invite email/notify | useTeamMembers / TeamMembersList | Edge | send-invitation-email, notify-team-invite | Node P0 | Covered | `/functions/v1/*` |
 | Favorite teams | src/pages/Teams.tsx | PostgREST | user_favorite_teams | PostgREST | Not started | |
 | Subscription limits | src/hooks/useSubscriptionLimits.ts | PostgREST + Edge | app_config, members, boards, check-subscription | Mixed | Not started | |
-| Admin manage members | src/components/admin/AdminManageTeamMembers.tsx | Edge | admin-team-members | Node P0 | Not started | |
+| Admin manage members | src/components/admin/AdminManageTeamMembers.tsx | Edge | admin-team-members | Node P0 | Covered | |
 
 ### Organizations
 
@@ -169,7 +169,7 @@ Storage bucket string hits via `.from` (not PostgREST tables): `avatars` (4), `r
 | Poker session | src/hooks/usePokerSession.ts | PostgREST + Realtime + Edge | sessions, rounds, members, delete-session-data, admin-send-notification | PostgREST + WS + Node | Covered | CRUD via getDb(); realtime/edge still hosted |
 | Poker history / rounds | src/hooks/usePokerSessionHistory.ts | PostgREST + Realtime | poker_session_rounds, sessions | PostgREST + WS | Covered | getDb(); realtime still hosted |
 | Poker table context | src/components/Neotro/PokerTableComponent/context.tsx | PostgREST + Edge | rounds, admin-send-notification | PostgREST + Node | Not started | Many round updates |
-| Poker chat | src/hooks/usePokerSessionChat.ts | PostgREST + Storage + Realtime | chat, reactions, poker-session-chat-images | PostgREST + volume + WS | Covered | CRUD via getDb(); storage/realtime still hosted |
+| Poker chat | src/hooks/usePokerSessionChat.ts | PostgREST + Storage + Realtime | chat, reactions, poker-session-chat-images | PostgREST + volume + WS | Covered | CRUD + storage via getDb(); realtime still hosted |
 | Poker helpers | src/lib/supabase/poker.ts, pokerSessionCloneSettings.ts | PostgREST | chat, sessions | PostgREST | Covered | getDb() |
 | Team poker list | src/components/team/TeamPokerSessions.tsx | PostgREST + Realtime | poker_sessions / rounds | PostgREST + WS | Not started | |
 | Poker config | src/components/Neotro/PokerConfig.tsx | PostgREST | team_members, profiles | PostgREST | Not started | |
@@ -211,7 +211,7 @@ Storage bucket string hits via `.from` (not PostgREST tables): `avatars` (4), `r
 | Feature | File (path) | Call Type | Resource | Self-host target | Status | Notes |
 |---|---|---|---|---|---|---|
 | Avatars | Account.tsx, AccountDetails.tsx | Storage | avatars | Docker volume via Node | Not started | upload + public URL |
-| Poker chat images | src/hooks/usePokerSessionChat.ts | Storage | poker-session-chat-images | Docker volume via Node | Not started | |
+| Poker chat images | src/hooks/usePokerSessionChat.ts | Storage | poker-session-chat-images | Docker volume via Node | Covered | Phase 4 storageClient |
 | Retro timer audio | src/components/retro/RetroTimer.tsx | Storage | retro-audio | Docker volume via Node | Not started | |
 | TTS cache | edge functions (not FE-direct) | Storage | tts-audio-cache | Docker volume if/when ported | Not started | Edge-only today |
 
@@ -236,7 +236,7 @@ Storage bucket string hits via `.from` (not PostgREST tables): `avatars` (4), `r
 | Backend toggle | (new) Admin Backend page | Config | app_config.backend_provider | Node + FE facade | Not started | Admin-only |
 | Data client facade | (new) src/lib/backend/* | Facade | all of the above | getDataClient() | Covered | Phase 3: getDb() + selfhosted restClient |
 | PostgREST data path | selfhosted restClient | PostgREST | local tables + RLS | Coolify-internal PostgREST | Covered | Node `/rest/v1` proxy; PostgREST internal |
-| Object storage volumes | Coolify compose | Ops | named Docker volumes | retroscope_uploads (+ buckets) | Not started | Locked storage choice |
+| Object storage volumes | Coolify compose | Ops | named Docker volumes | retroscope_uploads (+ buckets) | Covered | Serve/sign via Node; copy script shipped |
 | Coolify deploy | docker-compose.selfhost.yml | Ops | web/api/postgres/postgrest | Coolify resource | Covered | Phase 1–3 compose + db-init RLS helpers |
 
 ---

--- a/documentation/plans/self-host-node-postgres-migration-plan.md
+++ b/documentation/plans/self-host-node-postgres-migration-plan.md
@@ -219,7 +219,7 @@ Prioritize by “blocks leaving Supabase”:
 | P1 | `delete-session-data`, `cleanup-poker-sessions` | Node jobs / cron |
 | P2 | Jira suite (~15) | Node `/api/jira/*` using existing team credentials |
 | P2 | Slack suite | Node `/api/slack/*` |
-| P3 | Stripe (`check-subscription`, checkout, portal, admin-manage) | Keep on Supabase until billing needed self-hosted, or port with Stripe SDK |
+| P3 | Stripe (`check-subscription`, checkout, portal, admin-manage) | **Decision (Phase 4):** keep on hosted Supabase until billing must be self-hosted; Node returns `501` + `decision: keep_on_supabase` for these names |
 | P3 | OpenAI / TTS | Node; can keep pointing at existing Coqui `tts-server` compose service |
 
 Shared secrets move to VPS env / Docker secrets: `JWT_SECRET`, `GOOGLE_CLIENT_*`, `STRIPE_*`, `OPENAI_API_KEY`, Slack tokens, SMTP, service role equivalent.
@@ -388,9 +388,10 @@ ALLOW_ORIGINS=https://retro.example.com
 
 ### Phase 4 — Storage + critical edge ports
 
-- Avatars + poker chat images.
-- Admin + invite email functions.
-- Jira/Slack only if you use them daily.
+- Avatars + poker chat images + retro-audio served from `retroscope_uploads` via Node `/storage/v1/object/*`.
+- P0 admin + invite email/notify functions on Node `/functions/v1/*`.
+- Stripe stays on Supabase (`keep_on_supabase`).
+- Jira/Slack deferred unless actively used daily.
 
 ### Phase 5 — Realtime
 

--- a/scripts/selfhost/copy-storage-from-supabase.sh
+++ b/scripts/selfhost/copy-storage-from-supabase.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Copy objects from hosted Supabase Storage into the local retroscope_uploads volume (DUN-79).
+#
+# Required env:
+#   SUPABASE_URL              e.g. https://xxxx.supabase.co
+#   SUPABASE_SERVICE_ROLE_KEY service role key (list + download)
+#   UPLOADS_DIR               target volume mount (default: /data/uploads)
+#
+# Optional:
+#   STORAGE_BUCKETS           comma-separated (default: avatars,poker-session-chat-images,retro-audio,tts-audio-cache)
+#   PUBLIC_API_BASE_URL       if set, rewrite public Supabase storage URLs in public.profiles.avatar_url
+#   DATABASE_URL              required when rewriting avatar URLs
+#   DRY_RUN=1                 list only
+#
+# Example:
+#   SUPABASE_URL=… SUPABASE_SERVICE_ROLE_KEY=… UPLOADS_DIR=./tmp/uploads \
+#     ./scripts/selfhost/copy-storage-from-supabase.sh
+
+set -euo pipefail
+
+UPLOADS_DIR="${UPLOADS_DIR:-/data/uploads}"
+STORAGE_BUCKETS="${STORAGE_BUCKETS:-avatars,poker-session-chat-images,retro-audio,tts-audio-cache}"
+DRY_RUN="${DRY_RUN:-0}"
+LIMIT="${LIMIT:-1000}"
+
+if [[ -z "${SUPABASE_URL:-}" || -z "${SUPABASE_SERVICE_ROLE_KEY:-}" ]]; then
+  echo "SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required" >&2
+  exit 1
+fi
+
+SUPABASE_URL="${SUPABASE_URL%/}"
+AUTH_HEADER="Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}"
+APIKEY_HEADER="apikey: ${SUPABASE_SERVICE_ROLE_KEY}"
+
+mkdir -p "$UPLOADS_DIR"
+
+copy_bucket() {
+  local bucket="$1"
+  local offset=0
+  local copied=0
+  mkdir -p "${UPLOADS_DIR}/${bucket}"
+
+  echo "==> Listing objects in bucket: ${bucket}"
+  while true; do
+    local page
+    page="$(curl -fsS \
+      -H "$AUTH_HEADER" \
+      -H "$APIKEY_HEADER" \
+      "${SUPABASE_URL}/storage/v1/object/list/${bucket}" \
+      -H 'Content-Type: application/json' \
+      -d "{\"prefix\":\"\",\"limit\":${LIMIT},\"offset\":${offset}}")"
+
+    local names
+    names="$(python3 -c 'import json,sys; data=json.load(sys.stdin); print("\n".join(item.get("name","") for item in data if item.get("name")))' <<<"$page")"
+    if [[ -z "$names" ]]; then
+      break
+    fi
+
+    local count=0
+    while IFS= read -r name; do
+      [[ -z "$name" ]] && continue
+      # Skip "folder" placeholder objects ending with /
+      [[ "$name" == */ ]] && continue
+      count=$((count + 1))
+      local dest="${UPLOADS_DIR}/${bucket}/${name}"
+      mkdir -p "$(dirname "$dest")"
+      if [[ "$DRY_RUN" == "1" ]]; then
+        echo "  DRY_RUN would copy ${bucket}/${name}"
+      else
+        curl -fsS \
+          -H "$AUTH_HEADER" \
+          -H "$APIKEY_HEADER" \
+          "${SUPABASE_URL}/storage/v1/object/authenticated/${bucket}/${name}" \
+          -o "$dest" \
+          || curl -fsS \
+            -H "$AUTH_HEADER" \
+            -H "$APIKEY_HEADER" \
+            "${SUPABASE_URL}/storage/v1/object/public/${bucket}/${name}" \
+            -o "$dest"
+        echo "  copied ${bucket}/${name}"
+      fi
+      copied=$((copied + 1))
+    done <<<"$names"
+
+    if [[ "$count" -lt "$LIMIT" ]]; then
+      break
+    fi
+    offset=$((offset + LIMIT))
+  done
+
+  echo "==> ${bucket}: ${copied} object(s)"
+}
+
+IFS=',' read -r -a BUCKETS <<<"$STORAGE_BUCKETS"
+for bucket in "${BUCKETS[@]}"; do
+  bucket="$(echo "$bucket" | xargs)"
+  [[ -z "$bucket" ]] && continue
+  copy_bucket "$bucket"
+done
+
+if [[ -n "${PUBLIC_API_BASE_URL:-}" && -n "${DATABASE_URL:-}" && "$DRY_RUN" != "1" ]]; then
+  echo "==> Rewriting avatar public URLs → ${PUBLIC_API_BASE_URL%/}/storage/v1/object/public/avatars/…"
+  python3 - <<'PY'
+import os, re, sys
+try:
+    import psycopg2
+except ImportError:
+    print("psycopg2 not installed; skip URL rewrite (pip install psycopg2-binary)", file=sys.stderr)
+    sys.exit(0)
+
+db = os.environ["DATABASE_URL"]
+api = os.environ["PUBLIC_API_BASE_URL"].rstrip("/")
+supabase = os.environ["SUPABASE_URL"].rstrip("/")
+pattern = re.compile(
+    re.escape(supabase) + r"/storage/v1/object/public/avatars/(.+)$"
+)
+conn = psycopg2.connect(db)
+conn.autocommit = True
+cur = conn.cursor()
+cur.execute("SELECT id, avatar_url FROM public.profiles WHERE avatar_url IS NOT NULL")
+rows = cur.fetchall()
+updated = 0
+for user_id, url in rows:
+    if not url:
+        continue
+    m = pattern.match(url)
+    if not m:
+        continue
+    new_url = f"{api}/storage/v1/object/public/avatars/{m.group(1)}"
+    cur.execute("UPDATE public.profiles SET avatar_url = %s WHERE id = %s", (new_url, user_id))
+    updated += 1
+print(f"Updated {updated} profile avatar_url row(s)")
+cur.close()
+conn.close()
+PY
+fi
+
+echo "==> Done. Objects live under ${UPLOADS_DIR}"
+echo "    Mount this path as the Coolify volume retroscope_uploads → /data/uploads on api."

--- a/scripts/selfhost/rewrite-storage-urls.sh
+++ b/scripts/selfhost/rewrite-storage-urls.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Rewrite hosted Supabase public storage URLs in the local DB to the self-hosted API host.
+#
+# Required:
+#   DATABASE_URL
+#   PUBLIC_API_BASE_URL   e.g. https://retro-api.example.com
+#   SUPABASE_URL          old host to replace (e.g. https://xxx.supabase.co)
+#
+# Optional:
+#   DRY_RUN=1
+
+set -euo pipefail
+
+: "${DATABASE_URL:?DATABASE_URL required}"
+: "${PUBLIC_API_BASE_URL:?PUBLIC_API_BASE_URL required}"
+: "${SUPABASE_URL:?SUPABASE_URL required}"
+
+DRY_RUN="${DRY_RUN:-0}"
+API="${PUBLIC_API_BASE_URL%/}"
+OLD="${SUPABASE_URL%/}"
+
+echo "==> Rewriting ${OLD}/storage/v1/object/public/… → ${API}/storage/v1/object/public/…"
+
+if [[ "$DRY_RUN" == "1" ]]; then
+  psql "$DATABASE_URL" -c "
+    SELECT id, avatar_url
+    FROM public.profiles
+    WHERE avatar_url LIKE '${OLD}/storage/v1/object/public/%'
+    LIMIT 20;
+  "
+  exit 0
+fi
+
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<SQL
+UPDATE public.profiles
+SET avatar_url = replace(avatar_url, '${OLD}/storage/v1/object/public/', '${API}/storage/v1/object/public/')
+WHERE avatar_url LIKE '${OLD}/storage/v1/object/public/%';
+
+-- Poker chat image URLs stored in message bodies / image_url columns when present
+DO \$\$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'poker_session_chat_messages'
+      AND column_name = 'image_url'
+  ) THEN
+    EXECUTE format(
+      'UPDATE public.poker_session_chat_messages
+       SET image_url = replace(image_url, %L, %L)
+       WHERE image_url LIKE %L',
+      '${OLD}/storage/v1/object/public/',
+      '${API}/storage/v1/object/public/',
+      '${OLD}/storage/v1/object/public/%'
+    );
+  END IF;
+END
+\$\$;
+SQL
+
+echo "==> URL rewrite complete"

--- a/server/README.md
+++ b/server/README.md
@@ -1,4 +1,4 @@
-# Retroscope API (Phase 3 — local auth + PostgREST proxy)
+# Retroscope API (Phase 4 — storage + P0 edge ports)
 
 Fastify service for the self-hosted Coolify stack.
 
@@ -33,7 +33,38 @@ npm run import-auth-users -- --users users.json --identities identities.json
 | GET | `/auth/v1/.well-known/jwks.json` | Empty JWKS (HS256 shared secret) |
 | GET | `/api/admin/backend-status` | Bearer token required (admin UI) |
 | GET | `/api/storage/buckets` | Lists volume bucket prefixes |
-| GET/PUT | `/api/storage/:bucket/*` | 501 stubs until Phase 4 |
+| POST/PUT | `/storage/v1/object/:bucket/*` | Upload (Bearer; `x-upsert: true` optional) |
+| GET | `/storage/v1/object/public/:bucket/*` | Public object fetch |
+| POST | `/storage/v1/object/sign/:bucket/*` | Create signed URL |
+| GET | `/storage/v1/object/sign/:bucket/*` | Fetch via signed query token |
+| DELETE | `/storage/v1/object/:bucket/*` | Delete object (Bearer) |
+| POST | `/functions/v1/:name` | P0 edge ports (admin + invites); Stripe → 501 keep_on_supabase |
+
+### Ported functions (P0)
+
+- `admin-search-users`
+- `admin-send-notification`
+- `admin-team-members`
+- `get-user-email`
+- `send-invitation-email`
+- `notify-team-invite`
+- `notify-org-invite`
+
+### Explicit Stripe decision
+
+`check-subscription`, `create-checkout`, `customer-portal`, `admin-manage-subscription` remain on hosted Supabase for Phase 4. Node responds with `501` and `decision: "keep_on_supabase"`.
+
+## Storage migration
+
+```bash
+# Copy blobs into the uploads volume
+SUPABASE_URL=… SUPABASE_SERVICE_ROLE_KEY=… UPLOADS_DIR=/data/uploads \
+  ../scripts/selfhost/copy-storage-from-supabase.sh
+
+# Rewrite public URLs in DB after host change
+DATABASE_URL=… SUPABASE_URL=… PUBLIC_API_BASE_URL=https://retro-api.example.com \
+  ../scripts/selfhost/rewrite-storage-urls.sh
+```
 
 ## Auth + RLS schema
 

--- a/server/src/functions/adminPorts.test.ts
+++ b/server/src/functions/adminPorts.test.ts
@@ -1,0 +1,134 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { adminSearchUsers } from '../functions/adminSearchUsers.js';
+import { adminSendNotification } from '../functions/adminSendNotification.js';
+import { adminTeamMembers } from '../functions/adminTeamMembers.js';
+import { sendInvitationEmail } from '../functions/invites.js';
+import type { FunctionContext } from '../functions/helpers.js';
+import type { AppConfig } from '../config.js';
+
+type QueryFn = (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }>;
+
+function mockDb(handler: QueryFn): FunctionContext {
+  return {
+    // Test double — only the string overload is exercised.
+    db: { query: handler as FunctionContext['db']['query'] },
+    claims: {
+      sub: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      role: 'authenticated',
+    },
+    origin: 'https://retro.example.com',
+  };
+}
+
+describe('adminSearchUsers', () => {
+  it('returns empty results for blank query', async () => {
+    const ctx = mockDb(async () => ({ rows: [] }));
+    const result = await adminSearchUsers(ctx, { q: '  ' });
+    assert.deepEqual(result, { status: 200, body: { results: [] } });
+  });
+
+  it('searches profiles and emails', async () => {
+    const ctx = mockDb(async (sql, params) => {
+      if (sql.includes('FROM public.profiles') && sql.includes('ILIKE')) {
+        return { rows: [{ id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb' }] };
+      }
+      if (sql.includes('FROM auth.users') && sql.includes('LIKE')) {
+        return { rows: [{ id: 'cccccccc-cccc-cccc-cccc-cccccccccccc', email: 'qa@example.com' }] };
+      }
+      if (sql.includes('FROM public.profiles') && sql.includes('ANY')) {
+        return {
+          rows: [
+            {
+              id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+              full_name: 'Bob',
+              avatar_url: null,
+              role: 'member',
+            },
+          ],
+        };
+      }
+      if (sql.includes('FROM auth.users') && sql.includes('ANY')) {
+        return { rows: [{ id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', email: 'bob@example.com' }] };
+      }
+      if (sql.includes('team_members')) {
+        return { rows: [{ team_id: 'team-1', team_name: 'Alpha' }] };
+      }
+      throw new Error(`Unexpected SQL: ${sql} ${JSON.stringify(params)}`);
+    });
+
+    const result = await adminSearchUsers(ctx, { q: 'bob' });
+    assert.equal(result.status, 200);
+    const body = result.body as { results: Array<{ id: string; email: string | null; teams: unknown[] }> };
+    assert.equal(body.results.length, 1);
+    assert.equal(body.results[0].email, 'bob@example.com');
+    assert.deepEqual(body.results[0].teams, [{ id: 'team-1', name: 'Alpha' }]);
+  });
+});
+
+describe('adminSendNotification', () => {
+  it('validates payload', async () => {
+    const ctx = mockDb(async () => ({ rows: [] }));
+    const result = await adminSendNotification(ctx, { title: 'x' });
+    assert.equal(result.status, 400);
+  });
+
+  it('inserts notifications for resolved recipients', async () => {
+    let inserted = false;
+    const ctx = mockDb(async (sql) => {
+      if (sql.includes('INSERT INTO public.notifications')) {
+        inserted = true;
+        return { rows: [] };
+      }
+      throw new Error(sql);
+    });
+    const result = await adminSendNotification(ctx, {
+      recipients: [{ userId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb' }],
+      type: 'custom',
+      title: 'Hello',
+      message: 'World',
+    });
+    assert.equal(result.status, 200);
+    assert.equal(inserted, true);
+  });
+});
+
+describe('adminTeamMembers', () => {
+  it('lists teams', async () => {
+    const ctx = mockDb(async () => ({
+      rows: [{ id: 't1', name: 'Alpha', created_at: '2024-01-01' }],
+    }));
+    const result = await adminTeamMembers(ctx, { action: 'list_teams' });
+    assert.equal(result.status, 200);
+    assert.deepEqual((result.body as { teams: unknown[] }).teams[0], {
+      id: 't1',
+      name: 'Alpha',
+      created_at: '2024-01-01',
+    });
+  });
+});
+
+describe('sendInvitationEmail', () => {
+  it('requires fields', async () => {
+    const ctx = mockDb(async () => ({ rows: [] }));
+    const config = {
+      PUBLIC_SITE_URL: 'https://retro.example.com',
+    } as AppConfig;
+    const result = await sendInvitationEmail(ctx, config, { email: 'a@b.com' });
+    assert.equal(result.status, 400);
+  });
+
+  it('sends via mail fallback and returns success', async () => {
+    const ctx = mockDb(async () => ({ rows: [] }));
+    const config = {
+      PUBLIC_SITE_URL: 'https://retro.example.com',
+    } as AppConfig;
+    const result = await sendInvitationEmail(ctx, config, {
+      email: 'invitee@example.com',
+      teamName: 'Alpha',
+      inviterName: 'Justin',
+      token: 'tok-123',
+    });
+    assert.equal(result.status, 200);
+  });
+});

--- a/server/src/functions/adminSearchUsers.ts
+++ b/server/src/functions/adminSearchUsers.ts
@@ -1,0 +1,85 @@
+import type { FunctionContext, FunctionResult } from './helpers.js';
+import { getEmailsByIds, listUsersMatchingEmail } from './helpers.js';
+
+type SearchResult = {
+  id: string;
+  full_name: string | null;
+  avatar_url: string | null;
+  role: string | null;
+  email: string | null;
+  teams: Array<{ id: string; name: string }>;
+};
+
+export async function adminSearchUsers(
+  ctx: FunctionContext,
+  body: { q?: unknown }
+): Promise<FunctionResult> {
+  const query = (body.q ?? '').toString().trim();
+  if (!query) {
+    return { status: 200, body: { results: [] } };
+  }
+
+  const ids = new Set<string>();
+  const uuidRegex = /^[0-9a-fA-F-]{36}$/;
+  if (uuidRegex.test(query)) ids.add(query);
+
+  const profileMatches = await ctx.db.query<{ id: string }>(
+    `SELECT id FROM public.profiles
+     WHERE full_name ILIKE $1
+     LIMIT 50`,
+    [`%${query}%`]
+  );
+  for (const row of profileMatches.rows) ids.add(row.id);
+
+  const emailMatches = await listUsersMatchingEmail(ctx.db, query);
+  for (const row of emailMatches) ids.add(row.id);
+
+  const allIds = Array.from(ids).slice(0, 20);
+  if (allIds.length === 0) {
+    return { status: 200, body: { results: [] } };
+  }
+
+  const profiles = await ctx.db.query<{
+    id: string;
+    full_name: string | null;
+    avatar_url: string | null;
+    role: string | null;
+  }>(
+    `SELECT id, full_name, avatar_url, role
+     FROM public.profiles
+     WHERE id = ANY($1::uuid[])`,
+    [allIds]
+  );
+
+  const emailById = await getEmailsByIds(ctx.db, allIds);
+  for (const row of emailMatches) {
+    if (row.email) emailById.set(row.id, row.email);
+  }
+
+  const results: SearchResult[] = [];
+  for (const p of profiles.rows) {
+    const memberships = await ctx.db.query<{
+      team_id: string;
+      team_name: string | null;
+    }>(
+      `SELECT tm.team_id, t.name AS team_name
+       FROM public.team_members tm
+       LEFT JOIN public.teams t ON t.id = tm.team_id
+       WHERE tm.user_id = $1`,
+      [p.id]
+    );
+    results.push({
+      id: p.id,
+      full_name: p.full_name,
+      avatar_url: p.avatar_url,
+      role: p.role,
+      email: emailById.get(p.id) || null,
+      teams: memberships.rows.map((m) => ({
+        id: m.team_id,
+        name: m.team_name || 'Team',
+      })),
+    });
+  }
+
+  return { status: 200, body: { results } };
+}

--- a/server/src/functions/adminSendNotification.ts
+++ b/server/src/functions/adminSendNotification.ts
@@ -1,0 +1,66 @@
+import type { FunctionContext, FunctionResult } from './helpers.js';
+import { findUserIdByEmail } from './helpers.js';
+
+type Body = {
+  recipients?: Array<{ userId?: string; email?: string }>;
+  type?: string;
+  title?: string;
+  message?: string;
+  url?: string;
+};
+
+export async function adminSendNotification(
+  ctx: FunctionContext,
+  body: Body
+): Promise<FunctionResult> {
+  if (!Array.isArray(body.recipients) || !body.title || !body.type) {
+    return { status: 400, body: { error: 'Invalid payload' } };
+  }
+
+  const ids: string[] = [];
+  const emails = body.recipients
+    .filter((r) => !!r.email)
+    .map((r) => r.email!.toLowerCase());
+  const directIds = body.recipients
+    .filter((r) => !!r.userId)
+    .map((r) => r.userId!) as string[];
+  ids.push(...directIds);
+
+  for (const email of emails) {
+    const id = await findUserIdByEmail(ctx.db, email);
+    if (id) ids.push(id);
+  }
+
+  const uniqueIds = Array.from(new Set(ids));
+  if (uniqueIds.length === 0) {
+    return { status: 200, body: { success: true, info: 'No recipients resolved' } };
+  }
+
+  const rows = uniqueIds.map((id) => ({
+    user_id: id,
+    type: body.type!,
+    title: body.title!,
+    message: body.message ?? null,
+    url: body.url ?? null,
+  }));
+
+  await ctx.db.query(
+    `INSERT INTO public.notifications (user_id, type, title, message, url)
+     SELECT * FROM UNNEST(
+       $1::uuid[],
+       $2::text[],
+       $3::text[],
+       $4::text[],
+       $5::text[]
+     )`,
+    [
+      rows.map((r) => r.user_id),
+      rows.map((r) => r.type),
+      rows.map((r) => r.title),
+      rows.map((r) => r.message),
+      rows.map((r) => r.url),
+    ]
+  );
+
+  return { status: 200, body: { success: true, count: rows.length } };
+}

--- a/server/src/functions/adminTeamMembers.ts
+++ b/server/src/functions/adminTeamMembers.ts
@@ -1,0 +1,144 @@
+import type { FunctionContext, FunctionResult } from './helpers.js';
+import { findUserIdByEmail, getEmailsByIds } from './helpers.js';
+
+type Action = 'list_teams' | 'list_team_members' | 'add_member' | 'remove_member';
+
+export async function adminTeamMembers(
+  ctx: FunctionContext,
+  body: Record<string, unknown>
+): Promise<FunctionResult> {
+  const action = body.action as Action;
+
+  if (action === 'list_teams') {
+    const q = typeof body.query === 'string' ? body.query.trim() : '';
+    const result = q
+      ? await ctx.db.query(
+          `SELECT id, name, created_at FROM public.teams
+           WHERE name ILIKE $1
+           ORDER BY created_at DESC
+           LIMIT 50`,
+          [`%${q}%`]
+        )
+      : await ctx.db.query(
+          `SELECT id, name, created_at FROM public.teams
+           ORDER BY created_at DESC
+           LIMIT 50`
+        );
+    return { status: 200, body: { teams: result.rows } };
+  }
+
+  if (action === 'list_team_members') {
+    const teamId = typeof body.team_id === 'string' ? body.team_id : undefined;
+    if (!teamId) {
+      return { status: 400, body: { error: 'team_id is required' } };
+    }
+
+    const members = await ctx.db.query<{
+      id: string;
+      role: string;
+      user_id: string;
+      full_name: string | null;
+      avatar_url: string | null;
+    }>(
+      `SELECT tm.id, tm.role, tm.user_id, p.full_name, p.avatar_url
+       FROM public.team_members tm
+       LEFT JOIN public.profiles p ON p.id = tm.user_id
+       WHERE tm.team_id = $1
+       ORDER BY tm.id DESC`,
+      [teamId]
+    );
+
+    const emailById = await getEmailsByIds(
+      ctx.db,
+      members.rows.map((m) => m.user_id)
+    );
+
+    const rows = members.rows.map((m) => ({
+      id: m.id,
+      role: m.role,
+      user_id: m.user_id,
+      full_name: m.full_name,
+      avatar_url: m.avatar_url,
+      email: emailById.get(m.user_id) || null,
+    }));
+    return { status: 200, body: { members: rows } };
+  }
+
+  if (action === 'add_member') {
+    const teamId = typeof body.team_id === 'string' ? body.team_id : undefined;
+    const userId = typeof body.user_id === 'string' ? body.user_id : undefined;
+    const email = typeof body.email === 'string' ? body.email : undefined;
+    const role =
+      body.role === 'owner' || body.role === 'admin' || body.role === 'member'
+        ? body.role
+        : 'member';
+
+    if (!teamId) {
+      return { status: 400, body: { error: 'team_id is required' } };
+    }
+
+    let resolvedUserId = userId || '';
+    if (!resolvedUserId && email) {
+      const found = await findUserIdByEmail(ctx.db, email);
+      if (!found) {
+        return { status: 404, body: { error: 'No user found for email' } };
+      }
+      resolvedUserId = found;
+    }
+    if (!resolvedUserId) {
+      return { status: 400, body: { error: 'user_id or email is required' } };
+    }
+
+    const existing = await ctx.db.query<{ id: string }>(
+      `SELECT id FROM public.team_members
+       WHERE team_id = $1 AND user_id = $2
+       LIMIT 1`,
+      [teamId, resolvedUserId]
+    );
+
+    if (existing.rows[0]) {
+      await ctx.db.query(`UPDATE public.team_members SET role = $2 WHERE id = $1`, [
+        existing.rows[0].id,
+        role,
+      ]);
+    } else {
+      await ctx.db.query(
+        `INSERT INTO public.team_members (team_id, user_id, role)
+         VALUES ($1, $2, $3)`,
+        [teamId, resolvedUserId, role]
+      );
+    }
+    return { status: 200, body: { success: true } };
+  }
+
+  if (action === 'remove_member') {
+    const teamId = typeof body.team_id === 'string' ? body.team_id : undefined;
+    const userId = typeof body.user_id === 'string' ? body.user_id : undefined;
+    const memberId = typeof body.member_id === 'string' ? body.member_id : undefined;
+
+    if (!teamId && !memberId) {
+      return {
+        status: 400,
+        body: { error: 'member_id or team_id+user_id required' },
+      };
+    }
+
+    if (memberId) {
+      await ctx.db.query(`DELETE FROM public.team_members WHERE id = $1`, [memberId]);
+    } else {
+      if (!userId) {
+        return {
+          status: 400,
+          body: { error: 'user_id required when using team_id' },
+        };
+      }
+      await ctx.db.query(
+        `DELETE FROM public.team_members WHERE team_id = $1 AND user_id = $2`,
+        [teamId, userId]
+      );
+    }
+    return { status: 200, body: { success: true } };
+  }
+
+  return { status: 400, body: { error: 'Unknown action' } };
+}

--- a/server/src/functions/getUserEmail.ts
+++ b/server/src/functions/getUserEmail.ts
@@ -1,0 +1,22 @@
+import type { FunctionContext, FunctionResult } from './helpers.js';
+
+export async function getUserEmail(
+  ctx: FunctionContext,
+  body: { userId?: unknown }
+): Promise<FunctionResult> {
+  const userId = typeof body.userId === 'string' ? body.userId : '';
+  if (!userId) {
+    return { status: 400, body: { error: 'userId is required' } };
+  }
+
+  const result = await ctx.db.query<{ email: string | null }>(
+    `SELECT email FROM auth.users
+     WHERE id = $1 AND deleted_at IS NULL
+     LIMIT 1`,
+    [userId]
+  );
+  if (!result.rows[0]) {
+    return { status: 404, body: { error: 'User not found' } };
+  }
+  return { status: 200, body: { email: result.rows[0].email } };
+}

--- a/server/src/functions/helpers.ts
+++ b/server/src/functions/helpers.ts
@@ -1,0 +1,73 @@
+import type pg from 'pg';
+import type { AccessTokenClaims } from '../auth/jwt.js';
+
+type Queryable = Pick<pg.Pool, 'query'>;
+
+export async function getProfileRole(
+  db: Queryable,
+  userId: string
+): Promise<string | null> {
+  const result = await db.query<{ role: string | null }>(
+    `SELECT role FROM public.profiles WHERE id = $1 LIMIT 1`,
+    [userId]
+  );
+  return result.rows[0]?.role ?? null;
+}
+
+export async function findUserIdByEmail(
+  db: Queryable,
+  email: string
+): Promise<string | null> {
+  const result = await db.query<{ id: string }>(
+    `SELECT id FROM auth.users
+     WHERE lower(email) = lower($1)
+       AND deleted_at IS NULL
+     LIMIT 1`,
+    [email]
+  );
+  return result.rows[0]?.id ?? null;
+}
+
+export async function listUsersMatchingEmail(
+  db: Queryable,
+  query: string
+): Promise<Array<{ id: string; email: string | null }>> {
+  const result = await db.query<{ id: string; email: string | null }>(
+    `SELECT id, email FROM auth.users
+     WHERE deleted_at IS NULL
+       AND email IS NOT NULL
+       AND lower(email) LIKE lower($1)
+     LIMIT 100`,
+    [`%${query}%`]
+  );
+  return result.rows;
+}
+
+export async function getEmailsByIds(
+  db: Queryable,
+  ids: string[]
+): Promise<Map<string, string | null>> {
+  const map = new Map<string, string | null>();
+  if (ids.length === 0) return map;
+  const result = await db.query<{ id: string; email: string | null }>(
+    `SELECT id, email FROM auth.users
+     WHERE id = ANY($1::uuid[])
+       AND deleted_at IS NULL`,
+    [ids]
+  );
+  for (const row of result.rows) {
+    map.set(row.id, row.email);
+  }
+  return map;
+}
+
+export type FunctionResult = {
+  status: number;
+  body: unknown;
+};
+
+export type FunctionContext = {
+  db: Queryable;
+  claims: AccessTokenClaims;
+  origin: string | null;
+};

--- a/server/src/functions/invites.ts
+++ b/server/src/functions/invites.ts
@@ -1,0 +1,180 @@
+import type { AppConfig } from '../config.js';
+import { sendMail } from '../auth/mail.js';
+import type { FunctionContext, FunctionResult } from './helpers.js';
+import { findUserIdByEmail, getProfileRole } from './helpers.js';
+
+interface InvitationEmailRequest {
+  invitationId?: string;
+  email?: string;
+  teamName?: string;
+  inviterName?: string;
+  token?: string;
+  invitePath?: string;
+}
+
+export async function sendInvitationEmail(
+  ctx: FunctionContext,
+  config: AppConfig,
+  body: InvitationEmailRequest
+): Promise<FunctionResult> {
+  const email = body.email?.trim();
+  const teamName = body.teamName?.trim();
+  const inviterName = body.inviterName?.trim() || 'Someone';
+  const token = body.token?.trim();
+  if (!email || !teamName || !token) {
+    return {
+      status: 400,
+      body: { error: 'email, teamName, and token are required' },
+    };
+  }
+
+  const basePath = body.invitePath || '/invite';
+  const siteBase =
+    config.PUBLIC_SITE_URL?.replace(/\/$/, '') ||
+    ctx.origin ||
+    'https://your-domain.com';
+  const inviteLink = `${siteBase}${basePath}/${token}`;
+
+  await sendMail(config, {
+    to: email,
+    subject: `You're invited to join ${teamName}`,
+    text: `${inviterName} invited you to join "${teamName}". Accept: ${inviteLink}`,
+    html: `
+      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
+        <h1 style="color: #333; text-align: center;">Team Invitation</h1>
+        <div style="background-color: #f8f9fa; padding: 20px; border-radius: 8px; margin: 20px 0;">
+          <p style="font-size: 16px; color: #333;">
+            <strong>${inviterName}</strong> has invited you to join the team <strong>"${teamName}"</strong>.
+          </p>
+          <div style="text-align: center; margin: 30px 0;">
+            <a href="${inviteLink}"
+               style="background-color: #4f46e5; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; font-weight: bold; display: inline-block;">
+              Accept Invitation
+            </a>
+          </div>
+          <p style="font-size: 14px; color: #666;">
+            Or copy this link:<br>
+            <a href="${inviteLink}" style="color: #4f46e5; word-break: break-all;">${inviteLink}</a>
+          </p>
+        </div>
+        <p style="font-size: 12px; color: #999; text-align: center;">
+          This invitation will expire in 7 days.
+        </p>
+      </div>
+    `,
+  });
+
+  return { status: 200, body: { success: true } };
+}
+
+export async function notifyTeamInvite(
+  ctx: FunctionContext,
+  body: { invitationId?: unknown }
+): Promise<FunctionResult> {
+  const invitationId =
+    typeof body.invitationId === 'string' ? body.invitationId : '';
+  if (!invitationId) {
+    return { status: 400, body: { error: 'invitationId is required' } };
+  }
+
+  const invitation = await ctx.db.query<{
+    id: string;
+    team_id: string;
+    email: string;
+    invited_by: string;
+    token: string;
+  }>(
+    `SELECT id, team_id, email, invited_by, token
+     FROM public.team_invitations
+     WHERE id = $1
+     LIMIT 1`,
+    [invitationId]
+  );
+  const inv = invitation.rows[0];
+  if (!inv) {
+    return { status: 404, body: { error: 'Invitation not found' } };
+  }
+
+  const role = await getProfileRole(ctx.db, ctx.claims.sub);
+  if (role !== 'admin' && inv.invited_by !== ctx.claims.sub) {
+    return { status: 403, body: { error: 'Forbidden' } };
+  }
+
+  const targetId = await findUserIdByEmail(ctx.db, inv.email);
+  if (!targetId) {
+    return {
+      status: 200,
+      body: { success: true, info: 'No user with that email; skipping in-app notification' },
+    };
+  }
+
+  await ctx.db.query(
+    `INSERT INTO public.notifications (user_id, type, title, message, url)
+     VALUES ($1, 'team_invite', 'Team invitation', 'You have been invited to join a team.', $2)`,
+    [targetId, `/invite/${inv.token}`]
+  );
+
+  return { status: 200, body: { success: true } };
+}
+
+export async function notifyOrgInvite(
+  ctx: FunctionContext,
+  body: { invitationId?: unknown }
+): Promise<FunctionResult> {
+  const invitationId =
+    typeof body.invitationId === 'string' ? body.invitationId : '';
+  if (!invitationId) {
+    return { status: 400, body: { error: 'invitationId is required' } };
+  }
+
+  const invitation = await ctx.db.query<{
+    id: string;
+    organization_id: string;
+    email: string;
+    invited_by: string;
+    token: string;
+  }>(
+    `SELECT id, organization_id, email, invited_by, token
+     FROM public.organization_invitations
+     WHERE id = $1
+     LIMIT 1`,
+    [invitationId]
+  );
+  const inv = invitation.rows[0];
+  if (!inv) {
+    return { status: 404, body: { error: 'Invitation not found' } };
+  }
+
+  const role = await getProfileRole(ctx.db, ctx.claims.sub);
+  if (role !== 'admin' && inv.invited_by !== ctx.claims.sub) {
+    return { status: 403, body: { error: 'Forbidden' } };
+  }
+
+  const org = await ctx.db.query<{ name: string }>(
+    `SELECT name FROM public.organizations WHERE id = $1 LIMIT 1`,
+    [inv.organization_id]
+  );
+
+  const targetId = await findUserIdByEmail(ctx.db, inv.email);
+  if (!targetId) {
+    return {
+      status: 200,
+      body: {
+        success: true,
+        info: 'No user with that email; skipping in-app notification',
+      },
+    };
+  }
+
+  await ctx.db.query(
+    `INSERT INTO public.notifications (user_id, type, title, message, url)
+     VALUES ($1, 'org_invite', 'Organization invitation', $2, $3)`,
+    [
+      targetId,
+      `You have been invited to join the organization "${org.rows[0]?.name || 'an organization'}".`,
+      `/org-invite/${inv.token}`,
+    ]
+  );
+
+  return { status: 200, body: { success: true } };
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,6 +4,7 @@ import { loadConfig } from './config.js';
 import { closePool } from './lib/db.js';
 import { registerAdminRoutes } from './routes/admin.js';
 import { registerAuthRoutes } from './routes/auth.js';
+import { registerFunctionRoutes } from './routes/functions.js';
 import { registerHealthRoutes } from './routes/health.js';
 import { registerRestProxyRoutes } from './routes/restProxy.js';
 import { registerStorageRoutes } from './routes/storage.js';
@@ -24,12 +25,13 @@ async function main(): Promise<void> {
   await registerHealthRoutes(app, config);
   await registerAdminRoutes(app, config);
   await registerStorageRoutes(app, config);
+  await registerFunctionRoutes(app, config);
   await registerAuthRoutes(app, config);
   await registerRestProxyRoutes(app, config);
 
   app.get('/', async () => ({
     name: 'retroscope-api',
-    phase: 3,
+    phase: 4,
     endpoints: [
       '/healthz',
       '/readyz',
@@ -43,7 +45,13 @@ async function main(): Promise<void> {
       '/auth/v1/recover',
       '/api/admin/backend-status',
       '/api/storage/buckets',
+      '/storage/v1/object/*',
+      '/functions/v1/*',
     ],
+    stripe: {
+      decision: 'keep_on_supabase',
+      note: 'Billing edge functions stay on hosted Supabase until a later cutover',
+    },
   }));
 
   const shutdown = async (signal: string) => {

--- a/server/src/lib/requestAuth.ts
+++ b/server/src/lib/requestAuth.ts
@@ -1,0 +1,61 @@
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import type { AppConfig } from '../config.js';
+import { verifyAccessToken, type AccessTokenClaims } from '../auth/jwt.js';
+import { getPool } from './db.js';
+
+export function extractBearer(authorization: string | undefined): string | null {
+  if (!authorization) return null;
+  const [scheme, token] = authorization.split(' ');
+  if (scheme?.toLowerCase() !== 'bearer' || !token?.trim()) return null;
+  return token.trim();
+}
+
+export async function requireUser(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  config: AppConfig
+): Promise<AccessTokenClaims | null> {
+  const token = extractBearer(request.headers.authorization);
+  if (!token) {
+    await reply.status(401).send({ error: 'Unauthorized' });
+    return null;
+  }
+
+  if (!config.JWT_SECRET) {
+    await reply.status(503).send({ error: 'JWT_SECRET not configured' });
+    return null;
+  }
+
+  try {
+    return await verifyAccessToken(token, config.JWT_SECRET);
+  } catch {
+    await reply.status(401).send({ error: 'Unauthorized' });
+    return null;
+  }
+}
+
+export async function requireAdmin(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  config: AppConfig
+): Promise<AccessTokenClaims | null> {
+  const claims = await requireUser(request, reply, config);
+  if (!claims) return null;
+
+  const pool = getPool(config);
+  if (!pool) {
+    await reply.status(503).send({ error: 'DATABASE_URL not configured' });
+    return null;
+  }
+
+  const result = await pool.query<{ role: string | null }>(
+    `SELECT role FROM public.profiles WHERE id = $1 LIMIT 1`,
+    [claims.sub]
+  );
+  if (result.rows[0]?.role !== 'admin') {
+    await reply.status(403).send({ error: 'Forbidden' });
+    return null;
+  }
+
+  return claims;
+}

--- a/server/src/routes/functions.ts
+++ b/server/src/routes/functions.ts
@@ -1,0 +1,145 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import type { AppConfig } from '../config.js';
+import { getPool } from '../lib/db.js';
+import { requireAdmin, requireUser } from '../lib/requestAuth.js';
+import { adminSearchUsers } from '../functions/adminSearchUsers.js';
+import { adminSendNotification } from '../functions/adminSendNotification.js';
+import { adminTeamMembers } from '../functions/adminTeamMembers.js';
+import { getUserEmail } from '../functions/getUserEmail.js';
+import {
+  notifyOrgInvite,
+  notifyTeamInvite,
+  sendInvitationEmail,
+} from '../functions/invites.js';
+import type { FunctionContext, FunctionResult } from '../functions/helpers.js';
+
+const ADMIN_FUNCTIONS = new Set([
+  'admin-search-users',
+  'admin-send-notification',
+  'admin-team-members',
+  'get-user-email',
+]);
+
+const AUTH_FUNCTIONS = new Set([
+  ...ADMIN_FUNCTIONS,
+  'send-invitation-email',
+  'notify-team-invite',
+  'notify-org-invite',
+]);
+
+async function readJsonBody(request: FastifyRequest): Promise<Record<string, unknown>> {
+  const body = request.body;
+  if (body && typeof body === 'object' && !Array.isArray(body) && !Buffer.isBuffer(body)) {
+    return body as Record<string, unknown>;
+  }
+  return {};
+}
+
+function stripeDeferredBody(name: string): FunctionResult {
+  return {
+    status: 501,
+    body: {
+      error: 'Stripe remains on hosted Supabase for Phase 4',
+      decision: 'keep_on_supabase',
+      function: name,
+      phase: 4,
+    },
+  };
+}
+
+export async function dispatchFunction(
+  name: string,
+  ctx: FunctionContext,
+  config: AppConfig,
+  body: Record<string, unknown>
+): Promise<FunctionResult> {
+  switch (name) {
+    case 'admin-search-users':
+      return adminSearchUsers(ctx, body);
+    case 'admin-send-notification':
+      return adminSendNotification(ctx, body as {
+        recipients?: Array<{ userId?: string; email?: string }>;
+        type?: string;
+        title?: string;
+        message?: string;
+        url?: string;
+      });
+    case 'admin-team-members':
+      return adminTeamMembers(ctx, body);
+    case 'get-user-email':
+      return getUserEmail(ctx, body);
+    case 'send-invitation-email':
+      return sendInvitationEmail(ctx, config, body);
+    case 'notify-team-invite':
+      return notifyTeamInvite(ctx, body);
+    case 'notify-org-invite':
+      return notifyOrgInvite(ctx, body);
+    default:
+      return { status: 501, body: { error: 'Not implemented' } };
+  }
+}
+
+export async function registerFunctionRoutes(
+  app: FastifyInstance,
+  config: AppConfig
+): Promise<void> {
+  app.options('/functions/v1/:name', async (_request, reply) => {
+    return reply.status(204).send();
+  });
+
+  app.post<{ Params: { name: string } }>(
+    '/functions/v1/:name',
+    async (request, reply) => {
+      const name = request.params.name;
+
+      if (
+        name === 'check-subscription' ||
+        name === 'create-checkout' ||
+        name === 'customer-portal' ||
+        name === 'admin-manage-subscription'
+      ) {
+        const deferred = stripeDeferredBody(name);
+        return reply.status(deferred.status).send(deferred.body);
+      }
+
+      if (!AUTH_FUNCTIONS.has(name)) {
+        return reply.status(501).send({
+          error: `Edge function "${name}" is not ported yet`,
+          phase: 4,
+          hint: 'Jira/Slack ports are optional and deferred unless actively used',
+        });
+      }
+
+      const pool = getPool(config);
+      if (!pool) {
+        return reply.status(503).send({ error: 'DATABASE_URL not configured' });
+      }
+
+      let claims;
+      if (ADMIN_FUNCTIONS.has(name)) {
+        claims = await requireAdmin(request, reply, config);
+      } else {
+        claims = await requireUser(request, reply, config);
+      }
+      if (!claims) return;
+
+      const body = await readJsonBody(request);
+      const originHeader = request.headers.origin;
+      const ctx: FunctionContext = {
+        db: pool,
+        claims,
+        origin: typeof originHeader === 'string' ? originHeader : null,
+      };
+
+      try {
+        const result = await dispatchFunction(name, ctx, config, body);
+        return reply.status(result.status).send(result.body);
+      } catch (error) {
+        request.log.error({ err: error, name }, 'Function handler failed');
+        return reply.status(500).send({
+          error: error instanceof Error ? error.message : 'Unexpected error',
+        });
+      }
+    }
+  );
+}

--- a/server/src/routes/storage.test.ts
+++ b/server/src/routes/storage.test.ts
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { after, before, describe, it } from 'node:test';
+import Fastify from 'fastify';
+import { SignJWT } from 'jose';
+import { registerStorageRoutes } from '../routes/storage.js';
+import type { AppConfig } from '../config.js';
+
+const JWT_SECRET = 'phase4-storage-test-secret-32chars!!';
+
+async function mintToken(userId: string): Promise<string> {
+  return new SignJWT({ role: 'authenticated', email: 'qa@example.com' })
+    .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
+    .setSubject(userId)
+    .setAudience('authenticated')
+    .setIssuedAt()
+    .setExpirationTime('1h')
+    .setIssuer('retroscope-auth')
+    .sign(new TextEncoder().encode(JWT_SECRET));
+}
+
+describe('storage routes', () => {
+  let uploadsDir = '';
+  let app: ReturnType<typeof Fastify>;
+  let token = '';
+
+  before(async () => {
+    uploadsDir = await mkdtemp(path.join(os.tmpdir(), 'retroscope-uploads-'));
+    token = await mintToken('11111111-1111-1111-1111-111111111111');
+    const config = {
+      NODE_ENV: 'test',
+      PORT: 3000,
+      HOST: '127.0.0.1',
+      UPLOADS_DIR: uploadsDir,
+      JWT_SECRET,
+      SELF_HOSTED_API_BASE_URL: 'http://127.0.0.1:3000',
+      JWT_ISSUER: 'retroscope-auth',
+      JWT_ACCESS_TTL_SECONDS: 3600,
+      ALLOW_ORIGINS: '*',
+      POSTGREST_URL: 'http://postgrest:3000',
+      SMTP_PORT: 587,
+      allowOrigins: ['*'],
+    } as AppConfig;
+
+    app = Fastify({ bodyLimit: 25 * 1024 * 1024 });
+    await registerStorageRoutes(app, config);
+    await app.ready();
+  });
+
+  after(async () => {
+    await app.close();
+    await rm(uploadsDir, { recursive: true, force: true });
+  });
+
+  it('lists bucket prefixes', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/storage/buckets' });
+    assert.equal(res.statusCode, 200);
+    const body = res.json() as { buckets: Array<{ name: string }> };
+    assert.ok(body.buckets.some((b) => b.name === 'avatars'));
+  });
+
+  it('uploads and serves a public avatar object', async () => {
+    const bytes = Buffer.from('fake-png-bytes');
+    const put = await app.inject({
+      method: 'POST',
+      url: '/storage/v1/object/avatars/qa/avatar.png',
+      headers: {
+        authorization: `Bearer ${token}`,
+        'content-type': 'image/png',
+        'x-upsert': 'true',
+      },
+      payload: bytes,
+    });
+    assert.equal(put.statusCode, 200, put.body);
+
+    const onDisk = await readFile(path.join(uploadsDir, 'avatars', 'qa', 'avatar.png'));
+    assert.deepEqual(onDisk, bytes);
+
+    const get = await app.inject({
+      method: 'GET',
+      url: '/storage/v1/object/public/avatars/qa/avatar.png',
+    });
+    assert.equal(get.statusCode, 200);
+    assert.deepEqual(Buffer.from(get.rawPayload), bytes);
+  });
+
+  it('creates and consumes a signed URL', async () => {
+    await writeFile(path.join(uploadsDir, 'retro-audio', 'clip.mp3'), Buffer.from('audio'));
+    const sign = await app.inject({
+      method: 'POST',
+      url: '/storage/v1/object/sign/retro-audio/clip.mp3',
+      headers: {
+        authorization: `Bearer ${token}`,
+        'content-type': 'application/json',
+      },
+      payload: { expiresIn: 300 },
+    });
+    assert.equal(sign.statusCode, 200, sign.body);
+    const { signedUrl } = sign.json() as { signedUrl: string };
+    const pathAndQuery = signedUrl.replace('http://127.0.0.1:3000', '');
+    const get = await app.inject({ method: 'GET', url: pathAndQuery });
+    assert.equal(get.statusCode, 200);
+    assert.equal(get.body, 'audio');
+  });
+
+  it('rejects unknown buckets', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/storage/v1/object/public/not-a-bucket/x',
+    });
+    assert.equal(res.statusCode, 404);
+  });
+});

--- a/server/src/routes/storage.ts
+++ b/server/src/routes/storage.ts
@@ -1,21 +1,39 @@
-import { mkdir } from 'node:fs/promises';
+import { createReadStream } from 'node:fs';
+import { access, mkdir, unlink, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import type { FastifyInstance } from 'fastify';
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import type { AppConfig } from '../config.js';
+import { requireUser } from '../lib/requestAuth.js';
+import {
+  absoluteObjectPath,
+  isBucketPrefix,
+  normalizeObjectKey,
+  publicObjectUrl,
+} from '../storage/paths.js';
+import { buildSignedUrl, verifyObjectAccess } from '../storage/signing.js';
+import {
+  PUBLIC_STORAGE_BUCKETS,
+  STORAGE_BUCKET_PREFIXES,
+} from './storageBuckets.js';
 
-/** Bucket prefixes under the retroscope_uploads volume (Phase 1 stubs). */
-export const STORAGE_BUCKET_PREFIXES = [
-  'avatars',
-  'poker-session-chat-images',
-  'retro-audio',
-  'tts-audio-cache',
-] as const;
+export { STORAGE_BUCKET_PREFIXES, type StorageBucketPrefix } from './storageBuckets.js';
 
-export type StorageBucketPrefix = (typeof STORAGE_BUCKET_PREFIXES)[number];
-
-function isBucketPrefix(value: string): value is StorageBucketPrefix {
-  return (STORAGE_BUCKET_PREFIXES as readonly string[]).includes(value);
+function parseJsonBody(body: unknown): Record<string, unknown> {
+  if (body && typeof body === 'object' && !Buffer.isBuffer(body) && !Array.isArray(body)) {
+    return body as Record<string, unknown>;
+  }
+  if (Buffer.isBuffer(body) || body instanceof Uint8Array) {
+    const text = Buffer.from(body).toString('utf8').trim();
+    if (!text) return {};
+    const parsed = JSON.parse(text) as unknown;
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  }
+  return {};
 }
+
+const STORAGE_BODY_LIMIT = 25 * 1024 * 1024;
 
 export async function ensureUploadDirs(uploadsDir: string): Promise<void> {
   await mkdir(uploadsDir, { recursive: true });
@@ -24,6 +42,67 @@ export async function ensureUploadDirs(uploadsDir: string): Promise<void> {
   );
 }
 
+function apiPublicBase(config: AppConfig, request: FastifyRequest): string {
+  if (config.SELF_HOSTED_API_BASE_URL) {
+    return config.SELF_HOSTED_API_BASE_URL.replace(/\/$/, '');
+  }
+  const host = request.headers['x-forwarded-host'] || request.headers.host;
+  const proto = (request.headers['x-forwarded-proto'] as string) || 'http';
+  if (host) return `${proto}://${host}`;
+  return `http://${config.HOST}:${config.PORT}`;
+}
+
+function resolveObjectKey(raw: string | undefined): string | null {
+  return normalizeObjectKey(raw || '');
+}
+
+async function sendObjectFile(
+  reply: FastifyReply,
+  filePath: string,
+  contentType?: string
+): Promise<void> {
+  try {
+    await access(filePath);
+  } catch {
+    await reply.status(404).send({ error: 'Object not found' });
+    return;
+  }
+
+  const stream = createReadStream(filePath);
+  if (contentType) {
+    reply.header('Content-Type', contentType);
+  }
+  reply.header('Cache-Control', 'public, max-age=3600');
+  return reply.send(stream);
+}
+
+async function writeObjectFromBody(
+  request: FastifyRequest,
+  filePath: string,
+  upsert: boolean
+): Promise<{ ok: true } | { ok: false; status: number; error: string }> {
+  const body = request.body;
+  if (!Buffer.isBuffer(body) && !(body instanceof Uint8Array)) {
+    return { ok: false, status: 400, error: 'Expected binary body' };
+  }
+
+  await mkdir(path.dirname(filePath), { recursive: true });
+
+  if (!upsert) {
+    try {
+      await access(filePath);
+      return { ok: false, status: 409, error: 'Object already exists' };
+    } catch {
+      // does not exist — ok
+    }
+  }
+
+  await writeFile(filePath, Buffer.from(body));
+  return { ok: true };
+}
+
+type BucketParams = { bucket: string; '*': string };
+
 export async function registerStorageRoutes(app: FastifyInstance, config: AppConfig): Promise<void> {
   await ensureUploadDirs(config.UPLOADS_DIR);
 
@@ -31,41 +110,215 @@ export async function registerStorageRoutes(app: FastifyInstance, config: AppCon
     buckets: STORAGE_BUCKET_PREFIXES.map((name) => ({
       name,
       path: path.posix.join('/data/uploads', name),
+      public: PUBLIC_STORAGE_BUCKETS.has(name),
     })),
   }));
 
-  app.get<{ Params: { bucket: string; '*': string } }>(
-    '/api/storage/:bucket/*',
-    async (request, reply) => {
+  await app.register(async (scoped) => {
+    scoped.addContentTypeParser(
+      '*',
+      { parseAs: 'buffer' },
+      (_request, body, done) => {
+        done(null, body);
+      }
+    );
+
+    const putOrPostObject = async (
+      request: FastifyRequest<{ Params: BucketParams; Querystring: { upsert?: string } }>,
+      reply: FastifyReply
+    ) => {
+      const claims = await requireUser(request, reply, config);
+      if (!claims) return;
+
       const { bucket } = request.params;
       if (!isBucketPrefix(bucket)) {
         return reply.status(404).send({ error: 'Unknown storage bucket' });
       }
 
-      // Phase 1 stub — object serving lands in Phase 4.
-      return reply.status(501).send({
-        error: 'Storage object serving not implemented yet',
-        bucket,
-        objectPath: request.params['*'] || '',
-        phase: 4,
-      });
-    }
-  );
+      const objectKey = resolveObjectKey(request.params['*']);
+      if (!objectKey) {
+        return reply.status(400).send({ error: 'Invalid object path' });
+      }
 
-  app.put<{ Params: { bucket: string; '*': string } }>(
-    '/api/storage/:bucket/*',
-    async (request, reply) => {
+      const upsertHeader = String(request.headers['x-upsert'] ?? '').toLowerCase();
+      const upsert =
+        upsertHeader === 'true' ||
+        request.query.upsert === 'true' ||
+        request.query.upsert === '1';
+
+      const filePath = absoluteObjectPath(config.UPLOADS_DIR, bucket, objectKey);
+      const result = await writeObjectFromBody(request, filePath, upsert);
+      if (!result.ok) {
+        return reply.status(result.status).send({ error: result.error });
+      }
+
+      const base = apiPublicBase(config, request);
+      return reply.status(200).send({
+        Key: `${bucket}/${objectKey}`,
+        Id: objectKey,
+        publicUrl: publicObjectUrl(base, bucket, objectKey),
+      });
+    };
+
+    const getPublicObject = async (
+      request: FastifyRequest<{ Params: BucketParams }>,
+      reply: FastifyReply
+    ) => {
+      const { bucket } = request.params;
+      if (!isBucketPrefix(bucket)) {
+        return reply.status(404).send({ error: 'Unknown storage bucket' });
+      }
+      if (!PUBLIC_STORAGE_BUCKETS.has(bucket)) {
+        return reply.status(403).send({ error: 'Bucket is not public' });
+      }
+
+      const objectKey = resolveObjectKey(request.params['*']);
+      if (!objectKey) {
+        return reply.status(400).send({ error: 'Invalid object path' });
+      }
+
+      const filePath = absoluteObjectPath(config.UPLOADS_DIR, bucket, objectKey);
+      return sendObjectFile(reply, filePath, request.headers.accept?.includes('application/json') ? undefined : undefined);
+    };
+
+    const getSignedObject = async (
+      request: FastifyRequest<{
+        Params: BucketParams;
+        Querystring: { token?: string; expires?: string };
+      }>,
+      reply: FastifyReply
+    ) => {
       const { bucket } = request.params;
       if (!isBucketPrefix(bucket)) {
         return reply.status(404).send({ error: 'Unknown storage bucket' });
       }
 
-      return reply.status(501).send({
-        error: 'Storage uploads not implemented yet',
-        bucket,
-        objectPath: request.params['*'] || '',
-        phase: 4,
+      const objectKey = resolveObjectKey(request.params['*']);
+      if (!objectKey) {
+        return reply.status(400).send({ error: 'Invalid object path' });
+      }
+
+      const token = request.query.token;
+      const expires = Number(request.query.expires);
+      if (!token || !Number.isFinite(expires)) {
+        return reply.status(400).send({ error: 'token and expires query params required' });
+      }
+
+      const secret = config.JWT_SECRET;
+      if (!secret) {
+        return reply.status(503).send({ error: 'JWT_SECRET not configured' });
+      }
+
+      if (!verifyObjectAccess(secret, { bucket, objectKey, expiresAt: expires }, token)) {
+        return reply.status(403).send({ error: 'Invalid or expired signature' });
+      }
+
+      const filePath = absoluteObjectPath(config.UPLOADS_DIR, bucket, objectKey);
+      return sendObjectFile(reply, filePath);
+    };
+
+    const deleteObject = async (
+      request: FastifyRequest<{ Params: BucketParams }>,
+      reply: FastifyReply
+    ) => {
+      const claims = await requireUser(request, reply, config);
+      if (!claims) return;
+
+      const { bucket } = request.params;
+      if (!isBucketPrefix(bucket)) {
+        return reply.status(404).send({ error: 'Unknown storage bucket' });
+      }
+
+      const objectKey = resolveObjectKey(request.params['*']);
+      if (!objectKey) {
+        return reply.status(400).send({ error: 'Invalid object path' });
+      }
+
+      const filePath = absoluteObjectPath(config.UPLOADS_DIR, bucket, objectKey);
+      try {
+        await unlink(filePath);
+      } catch {
+        return reply.status(404).send({ error: 'Object not found' });
+      }
+
+      return reply.status(200).send({ message: 'Deleted' });
+    };
+
+    const createSignedUrlHandler = async (
+      request: FastifyRequest<{ Params: BucketParams }>,
+      reply: FastifyReply
+    ) => {
+      const claims = await requireUser(request, reply, config);
+      if (!claims) return;
+
+      const { bucket } = request.params;
+      if (!isBucketPrefix(bucket)) {
+        return reply.status(404).send({ error: 'Unknown storage bucket' });
+      }
+
+      const objectKey = resolveObjectKey(request.params['*']);
+      if (!objectKey) {
+        return reply.status(400).send({ error: 'Invalid object path' });
+      }
+
+      const secret = config.JWT_SECRET;
+      if (!secret) {
+        return reply.status(503).send({ error: 'JWT_SECRET not configured' });
+      }
+
+      let body: Record<string, unknown> = {};
+      try {
+        body = parseJsonBody(request.body);
+      } catch {
+        return reply.status(400).send({ error: 'Invalid JSON body' });
+      }
+
+      const rawExpires = body.expiresIn;
+      const expiresIn =
+        typeof rawExpires === 'number' && rawExpires > 0
+          ? Math.min(rawExpires, 60 * 60 * 24 * 7)
+          : 3600;
+
+      const base = apiPublicBase(config, request);
+      const signed = buildSignedUrl(base, secret, bucket, objectKey, expiresIn);
+      return reply.send({
+        signedURL: signed.signedUrl,
+        signedUrl: signed.signedUrl,
+        token: signed.token,
+        expiresAt: signed.expiresAt,
       });
-    }
-  );
+    };
+
+    const routeOpts = { bodyLimit: STORAGE_BODY_LIMIT };
+
+    // Supabase-compatible paths
+    scoped.put('/storage/v1/object/:bucket/*', routeOpts, putOrPostObject);
+    scoped.post('/storage/v1/object/:bucket/*', routeOpts, putOrPostObject);
+    scoped.get('/storage/v1/object/public/:bucket/*', getPublicObject);
+    scoped.get('/storage/v1/object/sign/:bucket/*', getSignedObject);
+    scoped.delete('/storage/v1/object/:bucket/*', deleteObject);
+    scoped.post('/storage/v1/object/sign/:bucket/*', routeOpts, createSignedUrlHandler);
+
+    // Phase 1 aliases under /api/storage
+    scoped.put('/api/storage/:bucket/*', routeOpts, putOrPostObject);
+    scoped.post('/api/storage/:bucket/*', routeOpts, putOrPostObject);
+    scoped.get('/api/storage/:bucket/*', async (request, reply) => {
+      const { bucket } = request.params as BucketParams;
+      if (isBucketPrefix(bucket) && PUBLIC_STORAGE_BUCKETS.has(bucket)) {
+        return getPublicObject(request as FastifyRequest<{ Params: BucketParams }>, reply);
+      }
+      const claims = await requireUser(request, reply, config);
+      if (!claims) return;
+      if (!isBucketPrefix(bucket)) {
+        return reply.status(404).send({ error: 'Unknown storage bucket' });
+      }
+      const objectKey = resolveObjectKey((request.params as BucketParams)['*']);
+      if (!objectKey) {
+        return reply.status(400).send({ error: 'Invalid object path' });
+      }
+      const filePath = absoluteObjectPath(config.UPLOADS_DIR, bucket, objectKey);
+      return sendObjectFile(reply, filePath);
+    });
+    scoped.delete('/api/storage/:bucket/*', deleteObject);
+  });
 }

--- a/server/src/routes/storageBuckets.ts
+++ b/server/src/routes/storageBuckets.ts
@@ -1,0 +1,17 @@
+/** Bucket prefixes under the retroscope_uploads volume. */
+export const STORAGE_BUCKET_PREFIXES = [
+  'avatars',
+  'poker-session-chat-images',
+  'retro-audio',
+  'tts-audio-cache',
+] as const;
+
+export type StorageBucketPrefix = (typeof STORAGE_BUCKET_PREFIXES)[number];
+
+/** Buckets that may be fetched without auth (public URLs / FE getPublicUrl). */
+export const PUBLIC_STORAGE_BUCKETS = new Set<StorageBucketPrefix>([
+  'avatars',
+  'poker-session-chat-images',
+  'retro-audio',
+  'tts-audio-cache',
+]);

--- a/server/src/storage/paths.ts
+++ b/server/src/storage/paths.ts
@@ -1,0 +1,36 @@
+import path from 'node:path';
+import { STORAGE_BUCKET_PREFIXES, type StorageBucketPrefix } from '../routes/storageBuckets.js';
+
+export function isBucketPrefix(value: string): value is StorageBucketPrefix {
+  return (STORAGE_BUCKET_PREFIXES as readonly string[]).includes(value);
+}
+
+/** Normalize object key: strip leading slashes, reject traversal. */
+export function normalizeObjectKey(raw: string): string | null {
+  const cleaned = raw.replace(/^\/+/, '').replace(/\\/g, '/');
+  if (!cleaned || cleaned.includes('\0')) return null;
+  const parts = cleaned.split('/').filter((p) => p.length > 0);
+  if (parts.some((p) => p === '.' || p === '..')) return null;
+  return parts.join('/');
+}
+
+export function absoluteObjectPath(
+  uploadsDir: string,
+  bucket: StorageBucketPrefix,
+  objectKey: string
+): string {
+  return path.join(uploadsDir, bucket, objectKey);
+}
+
+export function publicObjectUrl(
+  apiBaseUrl: string,
+  bucket: StorageBucketPrefix,
+  objectKey: string
+): string {
+  const base = apiBaseUrl.replace(/\/$/, '');
+  const encodedKey = objectKey
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+  return `${base}/storage/v1/object/public/${bucket}/${encodedKey}`;
+}

--- a/server/src/storage/signing.test.ts
+++ b/server/src/storage/signing.test.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { normalizeObjectKey, publicObjectUrl } from '../storage/paths.js';
+import { buildSignedUrl, signObjectAccess, verifyObjectAccess } from '../storage/signing.js';
+
+describe('storage paths', () => {
+  it('normalizes object keys and rejects traversal', () => {
+    assert.equal(normalizeObjectKey('/avatars/me.png'), 'avatars/me.png');
+    assert.equal(normalizeObjectKey('a/b/c.png'), 'a/b/c.png');
+    assert.equal(normalizeObjectKey('../secret'), null);
+    assert.equal(normalizeObjectKey('a/../../b'), null);
+    assert.equal(normalizeObjectKey(''), null);
+  });
+
+  it('builds public object URLs', () => {
+    assert.equal(
+      publicObjectUrl('https://api.example.com', 'avatars', 'user/me.png'),
+      'https://api.example.com/storage/v1/object/public/avatars/user/me.png'
+    );
+  });
+});
+
+describe('storage signing', () => {
+  it('signs and verifies object access tokens', () => {
+    const secret = 'test-secret-at-least-32-characters!!';
+    const expiresAt = Math.floor(Date.now() / 1000) + 60;
+    const token = signObjectAccess(secret, {
+      bucket: 'avatars',
+      objectKey: 'me.png',
+      expiresAt,
+    });
+    assert.equal(
+      verifyObjectAccess(
+        secret,
+        { bucket: 'avatars', objectKey: 'me.png', expiresAt },
+        token
+      ),
+      true
+    );
+    assert.equal(
+      verifyObjectAccess(
+        secret,
+        { bucket: 'avatars', objectKey: 'other.png', expiresAt },
+        token
+      ),
+      false
+    );
+  });
+
+  it('rejects expired signatures', () => {
+    const secret = 'test-secret-at-least-32-characters!!';
+    const expiresAt = Math.floor(Date.now() / 1000) - 10;
+    const token = signObjectAccess(secret, {
+      bucket: 'avatars',
+      objectKey: 'me.png',
+      expiresAt,
+    });
+    assert.equal(
+      verifyObjectAccess(
+        secret,
+        { bucket: 'avatars', objectKey: 'me.png', expiresAt },
+        token
+      ),
+      false
+    );
+  });
+
+  it('builds signed URLs with query params', () => {
+    const signed = buildSignedUrl(
+      'https://api.example.com',
+      'test-secret-at-least-32-characters!!',
+      'retro-audio',
+      'clip.mp3',
+      120
+    );
+    assert.match(signed.signedUrl, /^https:\/\/api\.example\.com\/storage\/v1\/object\/sign\/retro-audio\/clip\.mp3\?token=/);
+    assert.ok(signed.expiresAt > Math.floor(Date.now() / 1000));
+  });
+});

--- a/server/src/storage/signing.ts
+++ b/server/src/storage/signing.ts
@@ -1,0 +1,51 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+export interface SignedObjectParams {
+  bucket: string;
+  objectKey: string;
+  expiresAt: number;
+}
+
+function payload(params: SignedObjectParams): string {
+  return `${params.bucket}:${params.objectKey}:${params.expiresAt}`;
+}
+
+export function signObjectAccess(
+  secret: string,
+  params: SignedObjectParams
+): string {
+  return createHmac('sha256', secret).update(payload(params)).digest('hex');
+}
+
+export function verifyObjectAccess(
+  secret: string,
+  params: SignedObjectParams,
+  signature: string
+): boolean {
+  if (!signature || !/^[a-f0-9]{64}$/i.test(signature)) return false;
+  if (Date.now() / 1000 > params.expiresAt) return false;
+  const expected = signObjectAccess(secret, params);
+  try {
+    return timingSafeEqual(Buffer.from(expected), Buffer.from(signature));
+  } catch {
+    return false;
+  }
+}
+
+export function buildSignedUrl(
+  apiBaseUrl: string,
+  secret: string,
+  bucket: string,
+  objectKey: string,
+  expiresInSeconds: number
+): { signedUrl: string; expiresAt: number; token: string } {
+  const expiresAt = Math.floor(Date.now() / 1000) + expiresInSeconds;
+  const token = signObjectAccess(secret, { bucket, objectKey, expiresAt });
+  const base = apiBaseUrl.replace(/\/$/, '');
+  const encodedKey = objectKey
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+  const signedUrl = `${base}/storage/v1/object/sign/${bucket}/${encodedKey}?token=${token}&expires=${expiresAt}`;
+  return { signedUrl, expiresAt, token };
+}

--- a/src/components/Neotro/PokerTableComponent/context.tsx
+++ b/src/components/Neotro/PokerTableComponent/context.tsx
@@ -9,6 +9,7 @@ import {
   type WinningPoints,
 } from '@/hooks/usePokerSession';
 import { supabase } from '@/integrations/supabase/client';
+import { getDb } from '@/lib/backend/getDataClient';
 import {
   usePokerSessionHistory,
   PokerSessionRound,
@@ -1339,7 +1340,7 @@ export const PokerTableProvider: React.FC<PokerTableProviderProps> = ({ children
         const notificationUrl = teamId
           ? `/teams/${teamId}/poker/${pathSlug}`
           : `/poker/${pathSlug}`;
-        await supabase.functions.invoke('admin-send-notification', {
+        await getDb().functions.invoke('admin-send-notification', {
           body: {
             recipients: participantIds.map((id) => ({ userId: id })),
             type: 'poker_session',

--- a/src/components/account/AccountDetails.tsx
+++ b/src/components/account/AccountDetails.tsx
@@ -5,7 +5,7 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { User } from 'lucide-react';
 import { Profile } from '@/hooks/useAuth';
 import { AvatarUploader } from '@/components/account/AvatarUploader';
-import { supabase } from '@/integrations/supabase/client';
+import { getDb } from '@/lib/backend/getDataClient';
 
 interface AccountDetailsProps {
     user: any;
@@ -63,9 +63,9 @@ export const AccountDetails = ({ user, profile, editing, onSetEditing, onUpdateP
                             onCropped={async (blob) => {
                                 // Use profile.id (impersonated user) instead of user.id (admin)
                                 const fileName = `${profile?.id || user.id}.png`;
-                                // Upload to supabase storage bucket 'avatars'
-                                await supabase.storage.from('avatars').upload(fileName, blob, { upsert: true, contentType: 'image/png' });
-                                const { data } = supabase.storage.from('avatars').getPublicUrl(fileName);
+                                // Upload to avatars bucket (hosted Supabase or self-hosted volume)
+                                await getDb().storage.from('avatars').upload(fileName, blob, { upsert: true, contentType: 'image/png' });
+                                const { data } = getDb().storage.from('avatars').getPublicUrl(fileName);
                                 const publicUrl = data.publicUrl;
                                 // Set hidden input so existing form submit keeps working
                                 const hidden = document.getElementById('avatarUrl') as HTMLInputElement | null;

--- a/src/components/admin/AdminManageTeamMembers.tsx
+++ b/src/components/admin/AdminManageTeamMembers.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useToast } from '@/hooks/use-toast';
-import { supabase } from '@/integrations/supabase/client';
+import { getDb } from '@/lib/backend/getDataClient';
 
 type Team = { id: string; name: string };
 type Member = { id: string; user_id: string; full_name: string | null; avatar_url: string | null; email: string | null; role: 'owner'|'admin'|'member' };
@@ -21,13 +21,13 @@ export const AdminManageTeamMembers: React.FC = () => {
   const [loading, setLoading] = useState(false);
 
   const loadTeams = async () => {
-    const { data, error } = await supabase.functions.invoke('admin-team-members', { body: { action: 'list_teams', query: teamQuery } });
+    const { data, error } = await getDb().functions.invoke('admin-team-members', { body: { action: 'list_teams', query: teamQuery } });
     if (error) { toast({ title: 'Failed to load teams', description: error.message, variant: 'destructive' }); return; }
     setTeams((data as any)?.teams || []);
   };
 
   const loadMembers = async (teamId: string) => {
-    const { data, error } = await supabase.functions.invoke('admin-team-members', { body: { action: 'list_team_members', team_id: teamId } });
+    const { data, error } = await getDb().functions.invoke('admin-team-members', { body: { action: 'list_team_members', team_id: teamId } });
     if (error) { toast({ title: 'Failed to load members', description: error.message, variant: 'destructive' }); return; }
     setMembers((data as any)?.members || []);
   };
@@ -41,7 +41,7 @@ export const AdminManageTeamMembers: React.FC = () => {
     try {
       const body: any = { action: 'add_member', team_id: selectedTeamId, role };
       if (/^[0-9a-fA-F-]{36}$/.test(userInput.trim())) body.user_id = userInput.trim(); else body.email = userInput.trim();
-      const { error } = await supabase.functions.invoke('admin-team-members', { body });
+      const { error } = await getDb().functions.invoke('admin-team-members', { body });
       if (error) throw error;
       toast({ title: 'Member added' });
       setUserInput('');
@@ -55,7 +55,7 @@ export const AdminManageTeamMembers: React.FC = () => {
     if (!selectedTeamId) return;
     setLoading(true);
     try {
-      const { error } = await supabase.functions.invoke('admin-team-members', { body: { action: 'remove_member', member_id: member.id } });
+      const { error } = await getDb().functions.invoke('admin-team-members', { body: { action: 'remove_member', member_id: member.id } });
       if (error) throw error;
       toast({ title: 'Member removed' });
       await loadMembers(selectedTeamId);

--- a/src/components/admin/AdminSendNotification.tsx
+++ b/src/components/admin/AdminSendNotification.tsx
@@ -4,7 +4,7 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { useToast } from '@/hooks/use-toast';
-import { supabase } from '@/integrations/supabase/client';
+import { getDb } from '@/lib/backend/getDataClient';
 
 export const AdminSendNotification: React.FC = () => {
   const { toast } = useToast();
@@ -33,7 +33,7 @@ export const AdminSendNotification: React.FC = () => {
         message: message || undefined,
         url: url || undefined,
       };
-      const { error } = await supabase.functions.invoke('admin-send-notification', { body: payload });
+      const { error } = await getDb().functions.invoke('admin-send-notification', { body: payload });
       if (error) throw error;
       toast({ title: 'Sent', description: 'Notifications queued.' });
       setRecipients('');

--- a/src/components/admin/FeatureFlagManager.tsx
+++ b/src/components/admin/FeatureFlagManager.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { supabase } from '@/integrations/supabase/client';
+import { getDb } from '@/lib/backend/getDataClient';
 import { Switch } from '@/components/ui/switch';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
@@ -87,7 +87,7 @@ export const FeatureFlagManager: React.FC = () => {
       const labelMap: Record<string, string> = {};
       const lookups = await Promise.allSettled(
         uniqueUserIds.map(async (userId) => {
-          const { data, error } = await supabase.functions.invoke('admin-search-users', { body: { q: userId } });
+          const { data, error } = await getDb().functions.invoke('admin-search-users', { body: { q: userId } });
           if (error) throw error;
           const match = ((data as { results?: UserSearchResult[] } | null)?.results || []).find((row) => row.id === userId);
           if (!match) return { userId, label: '(unknown user)' };
@@ -106,7 +106,7 @@ export const FeatureFlagManager: React.FC = () => {
     }
 
     if (uniqueTeamIds.length > 0) {
-      const { data } = await supabase
+      const { data } = await getDb()
         .from('teams')
         .select('id,name')
         .in('id', uniqueTeamIds);
@@ -122,8 +122,8 @@ export const FeatureFlagManager: React.FC = () => {
 
   const refreshOverrides = async () => {
     const [userRes, teamRes] = await Promise.all([
-      supabase.from('feature_flag_user_overrides').select('id, flag_name, user_id, state'),
-      supabase.from('feature_flag_team_overrides').select('id, flag_name, team_id, state'),
+      getDb().from('feature_flag_user_overrides').select('id, flag_name, user_id, state'),
+      getDb().from('feature_flag_team_overrides').select('id, flag_name, team_id, state'),
     ]);
 
     if (userRes.error) {
@@ -144,7 +144,7 @@ export const FeatureFlagManager: React.FC = () => {
 
   const loadData = async () => {
     setLoading(true);
-    const { data: flagsData, error: flagsError } = await supabase.from('feature_flags').select('*');
+    const { data: flagsData, error: flagsError } = await getDb().from('feature_flags').select('*');
     if (flagsError) {
       console.error('Error fetching feature flags:', flagsError);
       toast({ title: 'Error fetching flags', variant: 'destructive' });
@@ -169,7 +169,7 @@ export const FeatureFlagManager: React.FC = () => {
         return;
       }
       setSearchingUsers(true);
-      const { data, error } = await supabase.functions.invoke('admin-search-users', { body: { q: query } });
+      const { data, error } = await getDb().functions.invoke('admin-search-users', { body: { q: query } });
       if (error) {
         toast({ title: 'User search failed', description: error.message, variant: 'destructive' });
         setUserSearchResults([]);
@@ -192,7 +192,7 @@ export const FeatureFlagManager: React.FC = () => {
         return;
       }
       setSearchingTeams(true);
-      const { data, error } = await supabase.functions.invoke('admin-team-members', {
+      const { data, error } = await getDb().functions.invoke('admin-team-members', {
         body: { action: 'list_teams', query },
       });
       if (error) {
@@ -282,7 +282,7 @@ export const FeatureFlagManager: React.FC = () => {
       currentFlags.map((flag) => (flag.flag_name === flagName ? { ...flag, is_enabled: isEnabled } : flag))
     );
 
-    const { error } = await supabase
+    const { error } = await getDb()
       .from('feature_flags')
       .update({ is_enabled: isEnabled })
       .eq('flag_name', flagName);
@@ -304,7 +304,7 @@ export const FeatureFlagManager: React.FC = () => {
       toast({ title: 'Select a user', variant: 'destructive' });
       return;
     }
-    const { error } = await supabase
+    const { error } = await getDb()
       .from('feature_flag_user_overrides')
       .upsert({ flag_name: selectedFlagName, user_id: userId, state: pendingUserState }, { onConflict: 'user_id,flag_name' });
     if (error) {
@@ -328,7 +328,7 @@ export const FeatureFlagManager: React.FC = () => {
       toast({ title: 'Select a team', variant: 'destructive' });
       return;
     }
-    const { error } = await supabase
+    const { error } = await getDb()
       .from('feature_flag_team_overrides')
       .upsert({ flag_name: selectedFlagName, team_id: teamId, state: pendingTeamState }, { onConflict: 'team_id,flag_name' });
     if (error) {
@@ -346,7 +346,7 @@ export const FeatureFlagManager: React.FC = () => {
   };
 
   const clearUserOverride = async (id: string) => {
-    const { error } = await supabase.from('feature_flag_user_overrides').delete().eq('id', id);
+    const { error } = await getDb().from('feature_flag_user_overrides').delete().eq('id', id);
     if (error) {
       toast({ title: 'Failed to clear user override', description: error.message, variant: 'destructive' });
       return;
@@ -357,7 +357,7 @@ export const FeatureFlagManager: React.FC = () => {
   };
 
   const clearTeamOverride = async (id: string) => {
-    const { error } = await supabase.from('feature_flag_team_overrides').delete().eq('id', id);
+    const { error } = await getDb().from('feature_flag_team_overrides').delete().eq('id', id);
     if (error) {
       toast({ title: 'Failed to clear team override', description: error.message, variant: 'destructive' });
       return;

--- a/src/components/admin/ImpersonateUser.tsx
+++ b/src/components/admin/ImpersonateUser.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { supabase } from '@/integrations/supabase/client';
+import { getDb } from '@/lib/backend/getDataClient';
 import { useAuth } from '@/hooks/useAuth';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -31,7 +31,7 @@ export const ImpersonateUser: React.FC = () => {
         return;
       }
       setLoading(true);
-      const { data, error } = await supabase.functions.invoke('admin-search-users', { body: { q: query } });
+      const { data, error } = await getDb().functions.invoke('admin-search-users', { body: { q: query } });
       if (error) {
         toast({ title: 'Search failed', description: error.message, variant: 'destructive' });
       } else {

--- a/src/components/retro/RetroTimer.tsx
+++ b/src/components/retro/RetroTimer.tsx
@@ -6,7 +6,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { Timer, Play, Pause, RotateCcw, Music, VolumeX, Upload, Trash2, AlertTriangle } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/hooks/useAuth';
-import { supabase } from '@/integrations/supabase/client';
+import { getDb } from '@/lib/backend/getDataClient';
 
 interface RetroTimerProps {
   presenceChannel?: any;
@@ -140,7 +140,7 @@ export const RetroTimer: React.FC<RetroTimerProps> = ({
 
   // Default audio file configuration
   const defaultAudioFileName = "retro-music-7c2a52ff-cea8-4a3f-9de9-0f2f744be625-1748877023437.mp3";
-  const defaultAudioUrl = `${supabase.storage.from('retro-audio').getPublicUrl(defaultAudioFileName).data.publicUrl}`;
+  const defaultAudioUrl = `${getDb().storage.from('retro-audio').getPublicUrl(defaultAudioFileName).data.publicUrl}`;
 
   // Initialize with default audio
   useEffect(() => {
@@ -397,13 +397,13 @@ export const RetroTimer: React.FC<RetroTimerProps> = ({
       const fileExt = audioFile.name.split('.').pop();
       const fileName = `retro-music-${user.id}-${Date.now()}.${fileExt}`;
       
-      const { error: uploadError } = await supabase.storage
+      const { error: uploadError } = await getDb().storage
         .from('retro-audio')
         .upload(fileName, audioFile);
 
       if (uploadError) throw uploadError;
 
-      const { data: { publicUrl } } = supabase.storage
+      const { data: { publicUrl } } = getDb().storage
         .from('retro-audio')
         .getPublicUrl(fileName);
 
@@ -446,7 +446,7 @@ export const RetroTimer: React.FC<RetroTimerProps> = ({
       const urlParts = uploadedAudioUrl.split('/');
       const fileName = urlParts[urlParts.length - 1];
       
-      const { error } = await supabase.storage
+      const { error } = await getDb().storage
         .from('retro-audio')
         .remove([fileName]);
 

--- a/src/components/team/TeamMembersList.tsx
+++ b/src/components/team/TeamMembersList.tsx
@@ -10,7 +10,7 @@ import { useTeamData } from '@/contexts/TeamDataContext';
 import { InviteMemberDialog } from './InviteMemberDialog';
 import { InviteLinkDialog } from './InviteLinkDialog';
 import { useIsMobile } from '@/hooks/use-mobile';
-import { supabase } from '@/integrations/supabase/client';
+import { getDb } from '@/lib/backend/getDataClient';
 import { useToast } from '@/hooks/use-toast';
 import { useSubscriptionLimits } from '@/hooks/useSubscriptionLimits';
 
@@ -32,7 +32,7 @@ export const TeamMembersList: React.FC<TeamMembersListProps> = ({ teamId, teamNa
 
   const inviteMember = async (email: string) => {
     try {
-      const currentUser = (await supabase.auth.getUser()).data.user;
+      const currentUser = (await getDb().auth.getUser()).data.user;
       if (!currentUser) throw new Error('User not authenticated');
 
       const { allowed, current, max, tier: currentTier } = await checkMemberLimit(teamId);
@@ -46,21 +46,21 @@ export const TeamMembersList: React.FC<TeamMembersListProps> = ({ teamId, teamNa
       }
 
       // Get current user's profile for the inviter name
-      const { data: profile } = await supabase
+      const { data: profile } = await getDb()
         .from('profiles')
         .select('full_name')
         .eq('id', currentUser.id)
         .single();
 
       // Get team name
-      const { data: team } = await supabase
+      const { data: team } = await getDb()
         .from('teams')
         .select('name')
         .eq('id', teamId)
         .single();
 
       // Create the invitation record
-      const { data: invitation, error } = await supabase
+      const { data: invitation, error } = await getDb()
         .from('team_invitations')
         .insert([{
           team_id: teamId,
@@ -74,7 +74,7 @@ export const TeamMembersList: React.FC<TeamMembersListProps> = ({ teamId, teamNa
       if (error) throw error;
 
       // Send the email via edge function
-      const { error: emailError } = await supabase.functions.invoke('send-invitation-email', {
+      const { error: emailError } = await getDb().functions.invoke('send-invitation-email', {
         body: {
           invitationId: invitation.id,
           email: email,
@@ -85,7 +85,7 @@ export const TeamMembersList: React.FC<TeamMembersListProps> = ({ teamId, teamNa
       });
 
       // Emit in-app notification if the email belongs to an existing account
-      const { error: notifError } = await supabase.functions.invoke('notify-team-invite', {
+      const { error: notifError } = await getDb().functions.invoke('notify-team-invite', {
         body: { invitationId: invitation.id }
       });
 
@@ -120,7 +120,7 @@ export const TeamMembersList: React.FC<TeamMembersListProps> = ({ teamId, teamNa
 
   const removeMember = async (memberId: string) => {
     try {
-      const { error } = await supabase
+      const { error } = await getDb()
         .from('team_members')
         .delete()
         .eq('id', memberId);
@@ -145,7 +145,7 @@ export const TeamMembersList: React.FC<TeamMembersListProps> = ({ teamId, teamNa
 
   const updateMemberRole = async (memberId: string, newRole: 'owner' | 'admin' | 'member') => {
     try {
-      const { error } = await supabase
+      const { error } = await getDb()
         .from('team_members')
         .update({ role: newRole })
         .eq('id', memberId);
@@ -170,7 +170,7 @@ export const TeamMembersList: React.FC<TeamMembersListProps> = ({ teamId, teamNa
 
   const cancelInvitation = async (invitationId: string) => {
     try {
-      const { error } = await supabase
+      const { error } = await getDb()
         .from('team_invitations')
         .delete()
         .eq('id', invitationId);

--- a/src/lib/backend/getDataClient.ts
+++ b/src/lib/backend/getDataClient.ts
@@ -99,8 +99,9 @@ export function getDb(): DataClient {
 /**
  * Facade for choosing hosted Supabase vs self-hosted clients.
  *
- * Phase 3: when mode is selfhosted, `.from()` / `.rpc()` hit local PostgREST
- * via Node `/rest/v1`. Realtime/functions/storage still use hosted temporarily.
+ * Phase 4: when mode is selfhosted, `.from()` / `.rpc()` hit local PostgREST
+ * via Node `/rest/v1`, `.storage` hits Docker volume routes, and P0
+ * `.functions` hit Node `/functions/v1/*`. Realtime still hosted until Phase 5.
  */
 export async function getDataClient(): Promise<ResolvedBackendClient> {
   const config = cachedConfig ?? (await fetchBackendProviderConfig());

--- a/src/lib/backend/selfhosted/dataClient.ts
+++ b/src/lib/backend/selfhosted/dataClient.ts
@@ -1,15 +1,24 @@
 import { supabase } from '@/integrations/supabase/client';
 import { getAuthClient, getCachedAuthBackendMode } from '@/lib/auth/client';
 import {
+  createFunctionsClient,
+  type SelfHostedFunctionsClient,
+} from '@/lib/backend/selfhosted/functionsClient';
+import {
   createRestClient,
   type SelfHostedRestClient,
 } from '@/lib/backend/selfhosted/restClient';
+import {
+  createStorageClient,
+  type SelfHostedStorageClient,
+} from '@/lib/backend/selfhosted/storageClient';
 
 /**
- * Hybrid self-hosted data client (Phase 3):
+ * Hybrid self-hosted data client (Phase 4):
  * - `.from()` / `.rpc()` → local PostgREST via Node `/rest/v1`
- * - `.channel()` / `.functions` / `.storage` → hosted Supabase temporarily
- *   (realtime + edge ports land in later phases; auth is already local)
+ * - `.storage` → Node Docker volume (`/storage/v1/object/*`)
+ * - `.functions` → Node P0 ports (`/functions/v1/*`); Stripe/Jira/Slack may 501
+ * - `.channel()` → hosted Supabase temporarily (Phase 5 realtime)
  * - `.auth` → FE auth facade (Node `/auth/v1` when mode is selfhosted)
  */
 export type SelfHostedDataClient = SelfHostedRestClient & {
@@ -17,8 +26,8 @@ export type SelfHostedDataClient = SelfHostedRestClient & {
   channel: typeof supabase.channel;
   removeChannel: typeof supabase.removeChannel;
   getChannels: typeof supabase.getChannels;
-  functions: typeof supabase.functions;
-  storage: typeof supabase.storage;
+  functions: SelfHostedFunctionsClient;
+  storage: SelfHostedStorageClient;
   realtime: typeof supabase.realtime;
 };
 
@@ -33,6 +42,8 @@ async function resolveAccessToken(): Promise<string | null> {
 
 export function createSelfHostedDataClient(apiBaseUrl: string): SelfHostedDataClient {
   const rest = createRestClient(apiBaseUrl, resolveAccessToken);
+  const storage = createStorageClient(apiBaseUrl, resolveAccessToken);
+  const functions = createFunctionsClient(apiBaseUrl, resolveAccessToken);
 
   return {
     from: rest.from,
@@ -45,8 +56,8 @@ export function createSelfHostedDataClient(apiBaseUrl: string): SelfHostedDataCl
       supabase.removeChannel(...args),
     getChannels: (...args: Parameters<typeof supabase.getChannels>) =>
       supabase.getChannels(...args),
-    functions: supabase.functions,
-    storage: supabase.storage,
+    functions,
+    storage,
     realtime: supabase.realtime,
   };
 }

--- a/src/lib/backend/selfhosted/functionsClient.ts
+++ b/src/lib/backend/selfhosted/functionsClient.ts
@@ -1,0 +1,94 @@
+/**
+ * Supabase Functions-compatible client for self-hosted Node ports (DUN-79).
+ * Talks to Node `/functions/v1/:name`.
+ */
+
+export type AccessTokenProvider = () => string | null | Promise<string | null>;
+
+export interface FunctionsError {
+  message: string;
+  context?: Response;
+}
+
+export interface FunctionsResponse<T = unknown> {
+  data: T | null;
+  error: FunctionsError | null;
+}
+
+export interface InvokeOptions {
+  body?: unknown;
+  headers?: Record<string, string>;
+  method?: 'POST' | 'GET';
+}
+
+export class SelfHostedFunctionsClient {
+  constructor(
+    private readonly apiBaseUrl: string,
+    private readonly getAccessToken: AccessTokenProvider
+  ) {}
+
+  async invoke<T = unknown>(
+    functionName: string,
+    options?: InvokeOptions
+  ): Promise<FunctionsResponse<T>> {
+    try {
+      const token = await this.getAccessToken();
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        ...(options?.headers || {}),
+      };
+      if (token) headers.Authorization = `Bearer ${token}`;
+
+      const base = this.apiBaseUrl.replace(/\/$/, '');
+      const response = await fetch(`${base}/functions/v1/${functionName}`, {
+        method: options?.method || 'POST',
+        headers,
+        body:
+          options?.method === 'GET'
+            ? undefined
+            : JSON.stringify(options?.body ?? {}),
+      });
+
+      const text = await response.text();
+      let parsed: unknown = null;
+      if (text) {
+        try {
+          parsed = JSON.parse(text);
+        } catch {
+          parsed = text;
+        }
+      }
+
+      if (!response.ok) {
+        const message =
+          parsed &&
+          typeof parsed === 'object' &&
+          parsed !== null &&
+          'error' in parsed
+            ? String((parsed as { error: unknown }).error)
+            : text || `Function ${functionName} failed (${response.status})`;
+        return {
+          data: null,
+          error: { message, context: response },
+        };
+      }
+
+      return { data: parsed as T, error: null };
+    } catch (error) {
+      return {
+        data: null,
+        error: {
+          message:
+            error instanceof Error ? error.message : `Function ${functionName} failed`,
+        },
+      };
+    }
+  }
+}
+
+export function createFunctionsClient(
+  apiBaseUrl: string,
+  getAccessToken: AccessTokenProvider
+): SelfHostedFunctionsClient {
+  return new SelfHostedFunctionsClient(apiBaseUrl, getAccessToken);
+}

--- a/src/lib/backend/selfhosted/storageClient.ts
+++ b/src/lib/backend/selfhosted/storageClient.ts
@@ -1,0 +1,212 @@
+/**
+ * Supabase Storage-compatible client for self-hosted Docker volume uploads (DUN-79).
+ * Talks to Node `/storage/v1/object/*`.
+ */
+
+export type AccessTokenProvider = () => string | null | Promise<string | null>;
+
+export interface StorageError {
+  message: string;
+  statusCode?: string;
+}
+
+export interface StorageResponse<T> {
+  data: T | null;
+  error: StorageError | null;
+}
+
+export interface UploadOptions {
+  cacheControl?: string;
+  contentType?: string;
+  upsert?: boolean;
+}
+
+function joinUrl(base: string, ...parts: string[]): string {
+  const root = base.replace(/\/$/, '');
+  const path = parts
+    .map((p) => p.replace(/^\/+|\/+$/g, ''))
+    .filter(Boolean)
+    .map((segment) =>
+      segment
+        .split('/')
+        .map((s) => encodeURIComponent(s))
+        .join('/')
+    )
+    .join('/');
+  return `${root}/${path}`;
+}
+
+export class StorageBucketClient {
+  constructor(
+    private readonly apiBaseUrl: string,
+    private readonly bucket: string,
+    private readonly getAccessToken: AccessTokenProvider
+  ) {}
+
+  getPublicUrl(path: string): { data: { publicUrl: string } } {
+    const publicUrl = joinUrl(
+      this.apiBaseUrl,
+      'storage/v1/object/public',
+      this.bucket,
+      path
+    );
+    return { data: { publicUrl } };
+  }
+
+  async upload(
+    path: string,
+    fileBody: Blob | File | ArrayBuffer | ArrayBufferView | Buffer | string,
+    options?: UploadOptions
+  ): Promise<StorageResponse<{ path: string; fullPath: string }>> {
+    try {
+      const token = await this.getAccessToken();
+      const headers: Record<string, string> = {
+        'x-upsert': options?.upsert ? 'true' : 'false',
+      };
+      if (token) headers.Authorization = `Bearer ${token}`;
+
+      let body: BodyInit;
+      if (typeof fileBody === 'string') {
+        body = fileBody;
+        headers['Content-Type'] = options?.contentType || 'text/plain';
+      } else if (fileBody instanceof Blob) {
+        body = fileBody;
+        headers['Content-Type'] =
+          options?.contentType || fileBody.type || 'application/octet-stream';
+      } else if (ArrayBuffer.isView(fileBody)) {
+        body = fileBody as unknown as BlobPart as BodyInit;
+        headers['Content-Type'] = options?.contentType || 'application/octet-stream';
+      } else {
+        body = fileBody as BodyInit;
+        headers['Content-Type'] = options?.contentType || 'application/octet-stream';
+      }
+
+      const url = joinUrl(
+        this.apiBaseUrl,
+        'storage/v1/object',
+        this.bucket,
+        path
+      );
+      const response = await fetch(url, { method: 'POST', headers, body });
+      if (!response.ok) {
+        const text = await response.text();
+        let message = text;
+        try {
+          const json = JSON.parse(text) as { error?: string };
+          message = json.error || text;
+        } catch {
+          // keep text
+        }
+        return {
+          data: null,
+          error: { message, statusCode: String(response.status) },
+        };
+      }
+
+      return {
+        data: { path, fullPath: `${this.bucket}/${path}` },
+        error: null,
+      };
+    } catch (error) {
+      return {
+        data: null,
+        error: {
+          message: error instanceof Error ? error.message : 'Upload failed',
+        },
+      };
+    }
+  }
+
+  async remove(paths: string[]): Promise<StorageResponse<string[]>> {
+    try {
+      const token = await this.getAccessToken();
+      const removed: string[] = [];
+      for (const path of paths) {
+        const headers: Record<string, string> = {};
+        if (token) headers.Authorization = `Bearer ${token}`;
+        const url = joinUrl(
+          this.apiBaseUrl,
+          'storage/v1/object',
+          this.bucket,
+          path
+        );
+        const response = await fetch(url, { method: 'DELETE', headers });
+        if (!response.ok && response.status !== 404) {
+          const text = await response.text();
+          return {
+            data: null,
+            error: { message: text || 'Delete failed', statusCode: String(response.status) },
+          };
+        }
+        removed.push(path);
+      }
+      return { data: removed, error: null };
+    } catch (error) {
+      return {
+        data: null,
+        error: {
+          message: error instanceof Error ? error.message : 'Delete failed',
+        },
+      };
+    }
+  }
+
+  async createSignedUrl(
+    path: string,
+    expiresIn: number
+  ): Promise<StorageResponse<{ signedUrl: string }>> {
+    try {
+      const token = await this.getAccessToken();
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+      };
+      if (token) headers.Authorization = `Bearer ${token}`;
+      const url = joinUrl(
+        this.apiBaseUrl,
+        'storage/v1/object/sign',
+        this.bucket,
+        path
+      );
+      const response = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ expiresIn }),
+      });
+      if (!response.ok) {
+        const text = await response.text();
+        return {
+          data: null,
+          error: { message: text || 'Sign failed', statusCode: String(response.status) },
+        };
+      }
+      const json = (await response.json()) as { signedUrl?: string; signedURL?: string };
+      const signedUrl = json.signedUrl || json.signedURL || '';
+      return { data: { signedUrl }, error: null };
+    } catch (error) {
+      return {
+        data: null,
+        error: {
+          message: error instanceof Error ? error.message : 'Sign failed',
+        },
+      };
+    }
+  }
+}
+
+export class SelfHostedStorageClient {
+  constructor(
+    private readonly apiBaseUrl: string,
+    private readonly getAccessToken: AccessTokenProvider
+  ) {}
+
+  from(bucket: string): StorageBucketClient {
+    return new StorageBucketClient(this.apiBaseUrl, bucket, this.getAccessToken);
+  }
+}
+
+export function createStorageClient(
+  apiBaseUrl: string,
+  getAccessToken: AccessTokenProvider
+): SelfHostedStorageClient {
+  return new SelfHostedStorageClient(apiBaseUrl, getAccessToken);
+}

--- a/tasks/tasks-self-host-node-postgres.md
+++ b/tasks/tasks-self-host-node-postgres.md
@@ -57,11 +57,11 @@ Status values: Not started | In progress | Blocked | In review | Done
 
 | # | Task Name | Task Description | Status | Blocked By | Notes |
 |---|---|---|---|---|---|
-| 4.1 | Storage backend on volume | Serve/sign uploads from `retroscope_uploads` bucket prefixes | Not started | 1.8 | Docker volumes locked |
-| 4.2 | Copy existing objects | Migrate blobs from Supabase Storage into volume; fix public URLs if host changes | Not started | 4.1, 3.2 | |
-| 4.3 | Admin/notify edge ports | search users, send notification, team members, invites email | Not started | 2.2, 3.3 | |
-| 4.4 | Jira/Slack ports (if used) | Move only integrations you rely on | Not started | 3.3 | Can defer |
-| 4.5 | Stripe decision | Keep on Supabase temporarily or port | Not started | - | Explicit product choice |
+| 4.1 | Storage backend on volume | Serve/sign uploads from `retroscope_uploads` bucket prefixes | Done | 1.8 | `/storage/v1/object/*` + FE `storageClient` |
+| 4.2 | Copy existing objects | Migrate blobs from Supabase Storage into volume; fix public URLs if host changes | Done | 4.1, 3.2 | `scripts/selfhost/copy-storage-from-supabase.sh` + `rewrite-storage-urls.sh` |
+| 4.3 | Admin/notify edge ports | search users, send notification, team members, invites email | Done | 2.2, 3.3 | Node `/functions/v1/*` P0 ports |
+| 4.4 | Jira/Slack ports (if used) | Move only integrations you rely on | Deferred | 3.3 | Not actively required for cutover; stay on Supabase |
+| 4.5 | Stripe decision | Keep on Supabase temporarily or port | Done | - | **Keep on Supabase** until billing cutover |
 
 ### Phase 5 — Realtime
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **DUN-79 / Self-host Phase 4**: replace Supabase Storage with Docker-volume uploads and port critical admin/notify edge functions to Node.

### Storage
- Full serve/upload/delete/sign on `retroscope_uploads` prefixes (`avatars`, `poker-session-chat-images`, `retro-audio`, `tts-audio-cache`)
- Supabase-compatible paths: `/storage/v1/object/*` (+ `/api/storage/*` aliases)
- FE `storageClient` wired into self-hosted `getDb().storage`
- Migration scripts: `scripts/selfhost/copy-storage-from-supabase.sh`, `rewrite-storage-urls.sh`

### P0 edge ports (`/functions/v1/*`)
- `admin-search-users`, `admin-send-notification`, `admin-team-members`, `get-user-email`
- `send-invitation-email`, `notify-team-invite`, `notify-org-invite`
- FE `functionsClient` + admin/invite call sites switched to `getDb()`

### Explicit decisions
- **Stripe:** keep on hosted Supabase for now (`501` + `decision: keep_on_supabase`)
- **Jira/Slack:** deferred (optional; not required for cutover)

### Tests
- 24 unit tests passing (storage routes/signing + admin/invite ports + existing auth/rest unit tests)
- Live API demo confirmed upload → public fetch, Stripe keep_on_supabase, Jira deferred 501

### Walkthrough artifacts
- Unit test log and storage API demo JSON captured in the agent run artifacts directory.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-79](https://linear.app/dungeon-dwellers/issue/DUN-79/self-host-phase-4-docker-volume-storage-critical-edge-ports)

<div><a href="https://cursor.com/agents/bc-b116f88b-32d5-4525-b548-49821aa465ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b116f88b-32d5-4525-b548-49821aa465ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

