### PR TITLE
feat(admin): Supabase → self-host migrate tool on Backend page

### DIFF
--- a/COOLIFY_SELFHOST.md
+++ b/COOLIFY_SELFHOST.md
@@ -127,6 +127,13 @@ EMAIL_FROM=Retroscope <noreply@yourdomain.com>
 # SMTP_PORT=587
 # SMTP_USER=...
 # SMTP_PASS=...
+
+# Phase 4 — Admin "Copy from Supabase" tool (optional; enable when ready to sync)
+# Session-mode URI from Supabase → Project Settings → Database
+MIGRATE_SOURCE_DATABASE_URL=postgresql://postgres.…@db.…supabase.co:5432/postgres
+# Needed only if you also copy Storage objects from the Admin panel
+SUPABASE_URL=https://YOUR_PROJECT.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=eyJhbGc...
 ```
 
 > Default DB role passwords in `server/postgres/init/01-roles.sql` are for bootstrap only. Change them (and matching `DATABASE_URL` / `PGRST_DB_URI`) before any real data restore.
@@ -171,7 +178,9 @@ After restore, confirm:
 
 ### Storage copy (Phase 4)
 
-Copy hosted Supabase Storage objects into the Coolify `retroscope_uploads` volume (mounted at `/data/uploads` on `api`):
+**Option A — Admin UI:** open **Admin → Backend → Copy from Supabase** (requires the env vars above). Prefer dry-run first.
+
+**Option B — CLI:** copy hosted Supabase Storage objects into the Coolify `retroscope_uploads` volume (mounted at `/data/uploads` on `api`):
 
 ```bash
 SUPABASE_URL='https://YOUR_PROJECT.supabase.co' \
@@ -208,7 +217,8 @@ PUBLIC_API_BASE_URL='https://retro-api.example.com' \
 | `GET /healthz` | Process liveness |
 | `GET /readyz` | Postgres + PostgREST readiness (503 if either fails) |
 | `GET|POST|PATCH|DELETE /rest/v1/*` | PostgREST proxy (JWT forwarded; internal PostgREST only) |
-| `GET /api/admin/backend-status` | Bearer-token stub status for the admin UI |
+| GET | `/api/admin/backend-status` | Bearer-token stub status for the admin UI |
+| GET/POST | `/api/admin/migrate-from-supabase` | Admin-only Supabase → self-host data/storage copy |
 | `POST/GET/DELETE /storage/v1/object/*` | Docker-volume uploads (avatars, chat images, retro-audio) |
 | `POST /functions/v1/*` | P0 admin/invite ports; Stripe stays on Supabase |
 

--- a/docker-compose.selfhost.prebuilt.yml
+++ b/docker-compose.selfhost.prebuilt.yml
@@ -383,6 +383,9 @@ services:
       SMTP_PORT: ${SMTP_PORT:-587}
       SMTP_USER: ${SMTP_USER:-}
       SMTP_PASS: ${SMTP_PASS:-}
+      MIGRATE_SOURCE_DATABASE_URL: ${MIGRATE_SOURCE_DATABASE_URL:-}
+      SUPABASE_URL: ${SUPABASE_URL:-}
+      SUPABASE_SERVICE_ROLE_KEY: ${SUPABASE_SERVICE_ROLE_KEY:-}
     volumes:
       - retroscope_uploads:/data/uploads
     depends_on:

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -385,6 +385,9 @@ services:
       SMTP_PORT: ${SMTP_PORT:-587}
       SMTP_USER: ${SMTP_USER:-}
       SMTP_PASS: ${SMTP_PASS:-}
+      MIGRATE_SOURCE_DATABASE_URL: ${MIGRATE_SOURCE_DATABASE_URL:-}
+      SUPABASE_URL: ${SUPABASE_URL:-}
+      SUPABASE_SERVICE_ROLE_KEY: ${SUPABASE_SERVICE_ROLE_KEY:-}
     volumes:
       - retroscope_uploads:/data/uploads
     depends_on:

--- a/server/README.md
+++ b/server/README.md
@@ -32,6 +32,7 @@ npm run import-auth-users -- --users users.json --identities identities.json
 | POST | `/auth/v1/verify` | Confirm recovery code + new password |
 | GET | `/auth/v1/.well-known/jwks.json` | Empty JWKS (HS256 shared secret) |
 | GET | `/api/admin/backend-status` | Bearer token required (admin UI) |
+| GET/POST | `/api/admin/migrate-from-supabase` | Admin-only copy from hosted Supabase DB/storage |
 | GET | `/api/storage/buckets` | Lists volume bucket prefixes |
 | POST/PUT | `/storage/v1/object/:bucket/*` | Upload (Bearer; `x-upsert: true` optional) |
 | GET | `/storage/v1/object/public/:bucket/*` | Public object fetch |

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -22,6 +22,11 @@ const envSchema = z.object({
   SMTP_PORT: z.coerce.number().int().positive().default(587),
   SMTP_USER: z.string().optional(),
   SMTP_PASS: z.string().optional(),
+  /** Hosted Supabase Postgres URI used by admin migrate tool (never expose to FE). */
+  MIGRATE_SOURCE_DATABASE_URL: z.string().optional(),
+  /** Hosted Supabase project URL for storage object copy. */
+  SUPABASE_URL: z.string().optional(),
+  SUPABASE_SERVICE_ROLE_KEY: z.string().optional(),
 });
 
 export type AppConfig = z.infer<typeof envSchema> & {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -44,6 +44,7 @@ async function main(): Promise<void> {
       '/auth/v1/callback',
       '/auth/v1/recover',
       '/api/admin/backend-status',
+      '/api/admin/migrate-from-supabase',
       '/api/storage/buckets',
       '/storage/v1/object/*',
       '/functions/v1/*',

--- a/server/src/migrate/fromSupabase.test.ts
+++ b/server/src/migrate/fromSupabase.test.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  MIGRATE_CONFIRMATION_PHRASE,
+  MigrateError,
+  getMigrateCapability,
+  migrateFromSupabase,
+} from './fromSupabase.js';
+import type { AppConfig } from '../config.js';
+
+describe('migrateFromSupabase guards', () => {
+  it('exposes confirmation phrase', () => {
+    assert.equal(MIGRATE_CONFIRMATION_PHRASE, 'COPY FROM SUPABASE');
+  });
+
+  it('reports capability flags without secrets', () => {
+    const capability = getMigrateCapability({
+      MIGRATE_SOURCE_DATABASE_URL: 'postgresql://source',
+      DATABASE_URL: 'postgresql://target',
+      SUPABASE_URL: 'https://example.supabase.co',
+      SUPABASE_SERVICE_ROLE_KEY: 'service',
+    } as AppConfig);
+    assert.deepEqual(capability, {
+      dataConfigured: true,
+      storageConfigured: true,
+      targetConfigured: true,
+    });
+  });
+
+  it('rejects wrong confirmation phrase', async () => {
+    await assert.rejects(
+      () =>
+        migrateFromSupabase({} as AppConfig, {
+          confirmation: 'please copy',
+          dryRun: true,
+        }),
+      (error: unknown) =>
+        error instanceof MigrateError && error.statusCode === 400
+    );
+  });
+
+  it('rejects when nothing is selected', async () => {
+    await assert.rejects(
+      () =>
+        migrateFromSupabase({} as AppConfig, {
+          confirmation: MIGRATE_CONFIRMATION_PHRASE,
+          includeAuth: false,
+          includePublic: false,
+          includeStorage: false,
+        }),
+      (error: unknown) =>
+        error instanceof MigrateError && /at least one/i.test(error.message)
+    );
+  });
+
+  it('requires source DB URL for data copy', async () => {
+    await assert.rejects(
+      () =>
+        migrateFromSupabase(
+          { DATABASE_URL: 'postgresql://target' } as AppConfig,
+          {
+            confirmation: MIGRATE_CONFIRMATION_PHRASE,
+            dryRun: true,
+            includeAuth: true,
+            includePublic: false,
+            includeStorage: false,
+          }
+        ),
+      (error: unknown) =>
+        error instanceof MigrateError && error.statusCode === 503
+    );
+  });
+});

--- a/server/src/migrate/fromSupabase.ts
+++ b/server/src/migrate/fromSupabase.ts
@@ -1,0 +1,628 @@
+import pg from 'pg';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { AppConfig } from '../config.js';
+import { STORAGE_BUCKET_PREFIXES } from '../routes/storageBuckets.js';
+import { absoluteObjectPath } from '../storage/paths.js';
+
+const { Pool } = pg;
+
+export const MIGRATE_CONFIRMATION_PHRASE = 'COPY FROM SUPABASE';
+
+export type MigrateRequest = {
+  confirmation: string;
+  dryRun?: boolean;
+  includeAuth?: boolean;
+  includePublic?: boolean;
+  includeStorage?: boolean;
+  truncateFirst?: boolean;
+  rewriteStorageUrls?: boolean;
+};
+
+export type TableCopyStat = {
+  schema: string;
+  table: string;
+  rows: number;
+  action: 'copied' | 'would_copy' | 'skipped';
+  reason?: string;
+};
+
+export type StorageCopyStat = {
+  bucket: string;
+  objects: number;
+  errors: number;
+  action: 'copied' | 'would_copy' | 'skipped';
+  reason?: string;
+};
+
+export type MigrateReport = {
+  dryRun: boolean;
+  includeAuth: boolean;
+  includePublic: boolean;
+  includeStorage: boolean;
+  truncateFirst: boolean;
+  tables: TableCopyStat[];
+  storage: StorageCopyStat[];
+  urlRewrite?: { updated: number };
+  warnings: string[];
+  durationMs: number;
+};
+
+let migrateInFlight = false;
+
+const AUTH_TABLES = ['users', 'identities'] as const;
+const SKIP_PUBLIC_TABLES = new Set([
+  // Spatial / extension junk if present
+  'spatial_ref_sys',
+]);
+
+function assertConfirmation(confirmation: string): void {
+  if (confirmation.trim() !== MIGRATE_CONFIRMATION_PHRASE) {
+    throw new MigrateError(
+      `Confirmation must be exactly "${MIGRATE_CONFIRMATION_PHRASE}"`,
+      400
+    );
+  }
+}
+
+export class MigrateError extends Error {
+  constructor(
+    message: string,
+    readonly statusCode: number = 400
+  ) {
+    super(message);
+    this.name = 'MigrateError';
+  }
+}
+
+export function getMigrateCapability(config: AppConfig): {
+  dataConfigured: boolean;
+  storageConfigured: boolean;
+  targetConfigured: boolean;
+} {
+  return {
+    dataConfigured: Boolean(config.MIGRATE_SOURCE_DATABASE_URL),
+    storageConfigured: Boolean(
+      config.SUPABASE_URL && config.SUPABASE_SERVICE_ROLE_KEY
+    ),
+    targetConfigured: Boolean(config.DATABASE_URL),
+  };
+}
+
+function sameDatabaseTarget(sourceUrl: string, targetUrl: string): boolean {
+  try {
+    const a = new URL(sourceUrl);
+    const b = new URL(targetUrl);
+    return (
+      a.hostname === b.hostname &&
+      a.port === b.port &&
+      a.pathname === b.pathname
+    );
+  } catch {
+    return sourceUrl === targetUrl;
+  }
+}
+
+async function listBaseTables(
+  client: pg.PoolClient,
+  schema: string
+): Promise<string[]> {
+  const result = await client.query<{ table_name: string }>(
+    `SELECT table_name
+     FROM information_schema.tables
+     WHERE table_schema = $1
+       AND table_type = 'BASE TABLE'
+     ORDER BY table_name`,
+    [schema]
+  );
+  return result.rows.map((r) => r.table_name);
+}
+
+async function listCopyableColumns(
+  client: pg.PoolClient,
+  schema: string,
+  table: string
+): Promise<string[]> {
+  const result = await client.query<{ column_name: string }>(
+    `SELECT column_name
+     FROM information_schema.columns
+     WHERE table_schema = $1
+       AND table_name = $2
+       AND is_generated <> 'ALWAYS'
+     ORDER BY ordinal_position`,
+    [schema, table]
+  );
+  return result.rows.map((r) => r.column_name);
+}
+
+async function tableExists(
+  client: pg.PoolClient,
+  schema: string,
+  table: string
+): Promise<boolean> {
+  const result = await client.query(
+    `SELECT 1
+     FROM information_schema.tables
+     WHERE table_schema = $1
+       AND table_name = $2
+       AND table_type = 'BASE TABLE'
+     LIMIT 1`,
+    [schema, table]
+  );
+  return result.rowCount === 1;
+}
+
+async function countRows(
+  client: pg.PoolClient,
+  schema: string,
+  table: string
+): Promise<number> {
+  const result = await client.query<{ count: string }>(
+    `SELECT count(*)::text AS count FROM ${quoteIdent(schema)}.${quoteIdent(table)}`
+  );
+  return Number(result.rows[0]?.count ?? 0);
+}
+
+function quoteIdent(ident: string): string {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(ident)) {
+    throw new MigrateError(`Invalid identifier: ${ident}`, 400);
+  }
+  return `"${ident}"`;
+}
+
+async function copyTable(
+  source: pg.PoolClient,
+  target: pg.PoolClient,
+  schema: string,
+  table: string,
+  truncateFirst: boolean,
+  dryRun: boolean
+): Promise<TableCopyStat> {
+  const sourceCols = await listCopyableColumns(source, schema, table);
+  const targetCols = await listCopyableColumns(target, schema, table);
+  const columns = sourceCols.filter((c) => targetCols.includes(c));
+  if (columns.length === 0) {
+    return {
+      schema,
+      table,
+      rows: 0,
+      action: 'skipped',
+      reason: 'No overlapping columns',
+    };
+  }
+
+  const sourceCount = await countRows(source, schema, table);
+  if (dryRun) {
+    return {
+      schema,
+      table,
+      rows: sourceCount,
+      action: 'would_copy',
+    };
+  }
+
+  const colList = columns.map(quoteIdent).join(', ');
+  const qualified = `${quoteIdent(schema)}.${quoteIdent(table)}`;
+
+  if (truncateFirst) {
+    await target.query(`TRUNCATE TABLE ${qualified} CASCADE`);
+  }
+
+  const batchSize = 500;
+  let copied = 0;
+  let lastCtid: string | null = null;
+
+  while (true) {
+    const page: pg.QueryResult<Record<string, unknown>> = lastCtid
+      ? await source.query<Record<string, unknown>>(
+          `SELECT ctid::text AS __ctid, ${colList}
+           FROM ${qualified}
+           WHERE ctid > $1::tid
+           ORDER BY ctid
+           LIMIT $2`,
+          [lastCtid, batchSize]
+        )
+      : await source.query<Record<string, unknown>>(
+          `SELECT ctid::text AS __ctid, ${colList}
+           FROM ${qualified}
+           ORDER BY ctid
+           LIMIT $1`,
+          [batchSize]
+        );
+    if (page.rows.length === 0) break;
+
+    for (const row of page.rows) {
+      lastCtid = String(row.__ctid);
+      const values = columns.map((c) => row[c]);
+      const placeholders = values.map((_, i) => `$${i + 1}`).join(', ');
+      if (truncateFirst) {
+        await target.query(
+          `INSERT INTO ${qualified} (${colList}) VALUES (${placeholders})`,
+          values
+        );
+      } else {
+        await target.query(
+          `INSERT INTO ${qualified} (${colList}) VALUES (${placeholders})
+           ON CONFLICT DO NOTHING`,
+          values
+        );
+      }
+      copied += 1;
+    }
+
+    if (page.rows.length < batchSize) break;
+  }
+
+  return { schema, table, rows: copied, action: 'copied' };
+}
+
+async function copySchemaTables(params: {
+  source: pg.PoolClient;
+  target: pg.PoolClient;
+  schema: string;
+  tables: string[];
+  truncateFirst: boolean;
+  dryRun: boolean;
+  warnings: string[];
+}): Promise<TableCopyStat[]> {
+  const stats: TableCopyStat[] = [];
+  for (const table of params.tables) {
+    if (params.schema === 'public' && SKIP_PUBLIC_TABLES.has(table)) {
+      stats.push({
+        schema: params.schema,
+        table,
+        rows: 0,
+        action: 'skipped',
+        reason: 'Skipped system/extension table',
+      });
+      continue;
+    }
+
+    const existsOnTarget = await tableExists(params.target, params.schema, table);
+    if (!existsOnTarget) {
+      stats.push({
+        schema: params.schema,
+        table,
+        rows: 0,
+        action: 'skipped',
+        reason: 'Table missing on target (restore schema first)',
+      });
+      params.warnings.push(
+        `${params.schema}.${table} exists on source but not target — run schema restore first`
+      );
+      continue;
+    }
+
+    try {
+      const stat = await copyTable(
+        params.source,
+        params.target,
+        params.schema,
+        table,
+        params.truncateFirst,
+        params.dryRun
+      );
+      stats.push(stat);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      params.warnings.push(`${params.schema}.${table}: ${message}`);
+      stats.push({
+        schema: params.schema,
+        table,
+        rows: 0,
+        action: 'skipped',
+        reason: message,
+      });
+    }
+  }
+  return stats;
+}
+
+async function listStorageObjects(
+  supabaseUrl: string,
+  serviceKey: string,
+  bucket: string
+): Promise<string[]> {
+  const names: string[] = [];
+  const limit = 1000;
+  let offset = 0;
+  while (true) {
+    const response = await fetch(
+      `${supabaseUrl.replace(/\/$/, '')}/storage/v1/object/list/${bucket}`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${serviceKey}`,
+          apikey: serviceKey,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ prefix: '', limit, offset }),
+      }
+    );
+    if (!response.ok) {
+      const text = await response.text();
+      throw new MigrateError(
+        `Storage list failed for ${bucket}: ${response.status} ${text}`,
+        502
+      );
+    }
+    const page = (await response.json()) as Array<{ name?: string }>;
+    if (!Array.isArray(page) || page.length === 0) break;
+    for (const item of page) {
+      if (item.name && !item.name.endsWith('/')) names.push(item.name);
+    }
+    if (page.length < limit) break;
+    offset += limit;
+  }
+  return names;
+}
+
+async function downloadStorageObject(
+  supabaseUrl: string,
+  serviceKey: string,
+  bucket: string,
+  objectKey: string
+): Promise<Buffer> {
+  const base = supabaseUrl.replace(/\/$/, '');
+  const headers = {
+    Authorization: `Bearer ${serviceKey}`,
+    apikey: serviceKey,
+  };
+  const urls = [
+    `${base}/storage/v1/object/authenticated/${bucket}/${objectKey}`,
+    `${base}/storage/v1/object/public/${bucket}/${objectKey}`,
+  ];
+  let lastError = 'download failed';
+  for (const url of urls) {
+    const response = await fetch(url, { headers });
+    if (response.ok) {
+      return Buffer.from(await response.arrayBuffer());
+    }
+    lastError = `${response.status} ${await response.text()}`;
+  }
+  throw new Error(lastError);
+}
+
+async function copyStorage(params: {
+  config: AppConfig;
+  dryRun: boolean;
+  warnings: string[];
+}): Promise<StorageCopyStat[]> {
+  const supabaseUrl = params.config.SUPABASE_URL;
+  const serviceKey = params.config.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceKey) {
+    return STORAGE_BUCKET_PREFIXES.map((bucket) => ({
+      bucket,
+      objects: 0,
+      errors: 0,
+      action: 'skipped' as const,
+      reason: 'SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY not configured',
+    }));
+  }
+
+  const stats: StorageCopyStat[] = [];
+  for (const bucket of STORAGE_BUCKET_PREFIXES) {
+    try {
+      const objects = await listStorageObjects(supabaseUrl, serviceKey, bucket);
+      if (params.dryRun) {
+        stats.push({
+          bucket,
+          objects: objects.length,
+          errors: 0,
+          action: 'would_copy',
+        });
+        continue;
+      }
+
+      let copied = 0;
+      let errors = 0;
+      for (const objectKey of objects) {
+        try {
+          const bytes = await downloadStorageObject(
+            supabaseUrl,
+            serviceKey,
+            bucket,
+            objectKey
+          );
+          const dest = absoluteObjectPath(params.config.UPLOADS_DIR, bucket, objectKey);
+          await mkdir(path.dirname(dest), { recursive: true });
+          await writeFile(dest, bytes);
+          copied += 1;
+        } catch (error) {
+          errors += 1;
+          params.warnings.push(
+            `storage ${bucket}/${objectKey}: ${
+              error instanceof Error ? error.message : String(error)
+            }`
+          );
+        }
+      }
+      stats.push({ bucket, objects: copied, errors, action: 'copied' });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      params.warnings.push(`storage ${bucket}: ${message}`);
+      stats.push({
+        bucket,
+        objects: 0,
+        errors: 1,
+        action: 'skipped',
+        reason: message,
+      });
+    }
+  }
+  return stats;
+}
+
+async function rewriteAvatarUrls(
+  target: pg.PoolClient,
+  config: AppConfig
+): Promise<number> {
+  const supabaseUrl = config.SUPABASE_URL?.replace(/\/$/, '');
+  const apiBase = config.SELF_HOSTED_API_BASE_URL?.replace(/\/$/, '');
+  if (!supabaseUrl || !apiBase) return 0;
+
+  const result = await target.query(
+    `UPDATE public.profiles
+     SET avatar_url = replace(
+       avatar_url,
+       $1,
+       $2
+     )
+     WHERE avatar_url LIKE $3
+     RETURNING id`,
+    [
+      `${supabaseUrl}/storage/v1/object/public/`,
+      `${apiBase}/storage/v1/object/public/`,
+      `${supabaseUrl}/storage/v1/object/public/%`,
+    ]
+  );
+  return result.rowCount ?? 0;
+}
+
+export async function migrateFromSupabase(
+  config: AppConfig,
+  request: MigrateRequest
+): Promise<MigrateReport> {
+  assertConfirmation(request.confirmation);
+
+  if (migrateInFlight) {
+    throw new MigrateError('A migration is already running', 409);
+  }
+
+  const dryRun = Boolean(request.dryRun);
+  const includeAuth = request.includeAuth !== false;
+  const includePublic = request.includePublic !== false;
+  const includeStorage = Boolean(request.includeStorage);
+  const truncateFirst = Boolean(request.truncateFirst);
+  const rewriteStorageUrls = Boolean(request.rewriteStorageUrls);
+
+  if (!includeAuth && !includePublic && !includeStorage) {
+    throw new MigrateError('Select at least one of auth, public data, or storage', 400);
+  }
+
+  if ((includeAuth || includePublic) && !config.MIGRATE_SOURCE_DATABASE_URL) {
+    throw new MigrateError(
+      'MIGRATE_SOURCE_DATABASE_URL is not configured on the API',
+      503
+    );
+  }
+  if ((includeAuth || includePublic) && !config.DATABASE_URL) {
+    throw new MigrateError('DATABASE_URL is not configured on the API', 503);
+  }
+  if (
+    includeStorage &&
+    (!config.SUPABASE_URL || !config.SUPABASE_SERVICE_ROLE_KEY)
+  ) {
+    throw new MigrateError(
+      'SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required for storage copy',
+      503
+    );
+  }
+
+  if (
+    config.MIGRATE_SOURCE_DATABASE_URL &&
+    config.DATABASE_URL &&
+    sameDatabaseTarget(config.MIGRATE_SOURCE_DATABASE_URL, config.DATABASE_URL)
+  ) {
+    throw new MigrateError(
+      'Source and target DATABASE_URL appear to be the same database',
+      400
+    );
+  }
+
+  migrateInFlight = true;
+  const started = Date.now();
+  const warnings: string[] = [];
+  const tables: TableCopyStat[] = [];
+  let storage: StorageCopyStat[] = [];
+  let urlRewrite: { updated: number } | undefined;
+
+  let sourcePool: pg.Pool | null = null;
+  let targetPool: pg.Pool | null = null;
+
+  try {
+    if (includeAuth || includePublic) {
+      sourcePool = new Pool({
+        connectionString: config.MIGRATE_SOURCE_DATABASE_URL,
+        max: 2,
+        connectionTimeoutMillis: 10_000,
+      });
+      targetPool = new Pool({
+        connectionString: config.DATABASE_URL,
+        max: 2,
+        connectionTimeoutMillis: 10_000,
+      });
+
+      const source = await sourcePool.connect();
+      const target = await targetPool.connect();
+      try {
+        if (!dryRun) {
+          await target.query(`SET session_replication_role = replica`);
+        }
+
+        if (includeAuth) {
+          const available: string[] = [];
+          for (const table of AUTH_TABLES) {
+            if (await tableExists(source, 'auth', table)) available.push(table);
+          }
+          const authStats = await copySchemaTables({
+            source,
+            target,
+            schema: 'auth',
+            tables: available,
+            truncateFirst,
+            dryRun,
+            warnings,
+          });
+          tables.push(...authStats);
+        }
+
+        if (includePublic) {
+          const publicTables = await listBaseTables(source, 'public');
+          const publicStats = await copySchemaTables({
+            source,
+            target,
+            schema: 'public',
+            tables: publicTables,
+            truncateFirst,
+            dryRun,
+            warnings,
+          });
+          tables.push(...publicStats);
+        }
+
+        if (!dryRun && rewriteStorageUrls) {
+          urlRewrite = { updated: await rewriteAvatarUrls(target, config) };
+        }
+
+        if (!dryRun) {
+          await target.query(`SET session_replication_role = DEFAULT`);
+        }
+      } finally {
+        source.release();
+        target.release();
+      }
+    }
+
+    if (includeStorage) {
+      storage = await copyStorage({ config, dryRun, warnings });
+    }
+
+    return {
+      dryRun,
+      includeAuth,
+      includePublic,
+      includeStorage,
+      truncateFirst,
+      tables,
+      storage,
+      urlRewrite,
+      warnings,
+      durationMs: Date.now() - started,
+    };
+  } finally {
+    migrateInFlight = false;
+    await sourcePool?.end().catch(() => undefined);
+    await targetPool?.end().catch(() => undefined);
+  }
+}

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -1,15 +1,15 @@
 import type { FastifyInstance } from 'fastify';
 import type { AppConfig } from '../config.js';
-import { verifyAccessToken } from '../auth/jwt.js';
 import { checkPostgres } from '../lib/db.js';
 import { checkPostgrest } from '../lib/postgrest.js';
-
-function extractBearer(authorization: string | undefined): string | null {
-  if (!authorization) return null;
-  const [scheme, token] = authorization.split(' ');
-  if (scheme?.toLowerCase() !== 'bearer' || !token?.trim()) return null;
-  return token.trim();
-}
+import { extractBearer, requireAdmin } from '../lib/requestAuth.js';
+import { verifyAccessToken } from '../auth/jwt.js';
+import {
+  getMigrateCapability,
+  MigrateError,
+  migrateFromSupabase,
+  MIGRATE_CONFIRMATION_PHRASE,
+} from '../migrate/fromSupabase.js';
 
 export async function registerAdminRoutes(app: FastifyInstance, config: AppConfig): Promise<void> {
   app.get('/api/admin/backend-status', async (request, reply) => {
@@ -25,7 +25,6 @@ export async function registerAdminRoutes(app: FastifyInstance, config: AppConfi
         await verifyAccessToken(token, config.JWT_SECRET);
       } catch {
         // Dual-path: admin UI may still send a hosted Supabase access token.
-        // Accept any non-empty Bearer until Phase 3 fully cuts over data/auth.
       }
     }
 
@@ -33,6 +32,7 @@ export async function registerAdminRoutes(app: FastifyInstance, config: AppConfi
       checkPostgres(config),
       checkPostgrest(config),
     ]);
+    const migrate = getMigrateCapability(config);
 
     return {
       modeHint: 'selfhosted',
@@ -43,6 +43,7 @@ export async function registerAdminRoutes(app: FastifyInstance, config: AppConfi
           config.GOOGLE_CLIENT_SECRET &&
           config.OAUTH_GOOGLE_REDIRECT_URI
       ),
+      migrate,
       checks: {
         api: { ok: true },
         auth: {
@@ -58,5 +59,65 @@ export async function registerAdminRoutes(app: FastifyInstance, config: AppConfi
       },
       timestamp: new Date().toISOString(),
     };
+  });
+
+  app.get('/api/admin/migrate-from-supabase', async (request, reply) => {
+    const claims = await requireAdmin(request, reply, config);
+    if (!claims) return;
+
+    return {
+      confirmationPhrase: MIGRATE_CONFIRMATION_PHRASE,
+      capability: getMigrateCapability(config),
+      defaults: {
+        dryRun: true,
+        includeAuth: true,
+        includePublic: true,
+        includeStorage: false,
+        truncateFirst: false,
+        rewriteStorageUrls: true,
+      },
+      notes: [
+        'Copies from MIGRATE_SOURCE_DATABASE_URL into local DATABASE_URL.',
+        'Schema must already exist on the target (Phase 3 restore / init SQL).',
+        'Storage copy needs SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY.',
+        'Use dry-run first. truncateFirst replaces overlapping table data.',
+      ],
+    };
+  });
+
+  app.post('/api/admin/migrate-from-supabase', async (request, reply) => {
+    const claims = await requireAdmin(request, reply, config);
+    if (!claims) return;
+
+    const body = (request.body ?? {}) as {
+      confirmation?: string;
+      dryRun?: boolean;
+      includeAuth?: boolean;
+      includePublic?: boolean;
+      includeStorage?: boolean;
+      truncateFirst?: boolean;
+      rewriteStorageUrls?: boolean;
+    };
+
+    try {
+      const report = await migrateFromSupabase(config, {
+        confirmation: String(body.confirmation ?? ''),
+        dryRun: body.dryRun,
+        includeAuth: body.includeAuth,
+        includePublic: body.includePublic,
+        includeStorage: body.includeStorage,
+        truncateFirst: body.truncateFirst,
+        rewriteStorageUrls: body.rewriteStorageUrls,
+      });
+      return reply.send(report);
+    } catch (error) {
+      if (error instanceof MigrateError) {
+        return reply.status(error.statusCode).send({ error: error.message });
+      }
+      request.log.error({ err: error }, 'migrate-from-supabase failed');
+      return reply.status(500).send({
+        error: error instanceof Error ? error.message : 'Migration failed',
+      });
+    }
   });
 }

--- a/src/components/admin/SupabaseMigratePanel.tsx
+++ b/src/components/admin/SupabaseMigratePanel.tsx
@@ -1,0 +1,379 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { useToast } from '@/hooks/use-toast';
+import { useAuth } from '@/hooks/useAuth';
+import { getViteApiBaseUrl } from '@/lib/backend/config';
+import { Loader2 } from 'lucide-react';
+
+type MigrateCapability = {
+  dataConfigured: boolean;
+  storageConfigured: boolean;
+  targetConfigured: boolean;
+};
+
+type MigrateMeta = {
+  confirmationPhrase: string;
+  capability: MigrateCapability;
+  notes: string[];
+};
+
+type MigrateReport = {
+  dryRun: boolean;
+  includeAuth: boolean;
+  includePublic: boolean;
+  includeStorage: boolean;
+  truncateFirst: boolean;
+  tables: Array<{
+    schema: string;
+    table: string;
+    rows: number;
+    action: string;
+    reason?: string;
+  }>;
+  storage: Array<{
+    bucket: string;
+    objects: number;
+    errors: number;
+    action: string;
+    reason?: string;
+  }>;
+  urlRewrite?: { updated: number };
+  warnings: string[];
+  durationMs: number;
+};
+
+function CapabilityBadge({ label, ok }: { label: string; ok: boolean }) {
+  return <Badge variant={ok ? 'default' : 'secondary'}>{label}: {ok ? 'ready' : 'not set'}</Badge>;
+}
+
+export const SupabaseMigratePanel: React.FC = () => {
+  const { session } = useAuth();
+  const { toast } = useToast();
+  const [loading, setLoading] = useState(true);
+  const [running, setRunning] = useState(false);
+  const [meta, setMeta] = useState<MigrateMeta | null>(null);
+  const [confirmation, setConfirmation] = useState('');
+  const [dryRun, setDryRun] = useState(true);
+  const [includeAuth, setIncludeAuth] = useState(true);
+  const [includePublic, setIncludePublic] = useState(true);
+  const [includeStorage, setIncludeStorage] = useState(false);
+  const [truncateFirst, setTruncateFirst] = useState(false);
+  const [rewriteStorageUrls, setRewriteStorageUrls] = useState(true);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [report, setReport] = useState<MigrateReport | null>(null);
+
+  const apiBase = (getViteApiBaseUrl() || '').replace(/\/$/, '');
+
+  const loadMeta = useCallback(async () => {
+    if (!apiBase || !session?.access_token) {
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      const response = await fetch(`${apiBase}/api/admin/migrate-from-supabase`, {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        throw new Error(
+          (body as { error?: string }).error ||
+            `Failed to load migrate tool (${response.status})`
+        );
+      }
+      const json = (await response.json()) as MigrateMeta;
+      setMeta(json);
+    } catch (error) {
+      toast({
+        title: 'Migrate tool unavailable',
+        description: error instanceof Error ? error.message : String(error),
+        variant: 'destructive',
+      });
+      setMeta(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [apiBase, session?.access_token, toast]);
+
+  useEffect(() => {
+    void loadMeta();
+  }, [loadMeta]);
+
+  const runMigrate = async () => {
+    if (!apiBase || !session?.access_token || !meta) return;
+    setRunning(true);
+    try {
+      const response = await fetch(`${apiBase}/api/admin/migrate-from-supabase`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${session.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          confirmation,
+          dryRun,
+          includeAuth,
+          includePublic,
+          includeStorage,
+          truncateFirst,
+          rewriteStorageUrls,
+        }),
+      });
+      const body = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(
+          (body as { error?: string }).error || `Migrate failed (${response.status})`
+        );
+      }
+      const next = body as MigrateReport;
+      setReport(next);
+      toast({
+        title: next.dryRun ? 'Dry run complete' : 'Migration complete',
+        description: `${next.tables.length} table(s), ${next.storage.length} bucket(s), ${next.durationMs}ms`,
+      });
+      setConfirmOpen(false);
+    } catch (error) {
+      toast({
+        title: 'Migration failed',
+        description: error instanceof Error ? error.message : String(error),
+        variant: 'destructive',
+      });
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <Card>
+        <CardContent className="flex items-center gap-2 py-8">
+          <Loader2 className="h-5 w-5 animate-spin" />
+          Loading Supabase → self-host migrate tool…
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!apiBase) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Copy from Supabase</CardTitle>
+          <CardDescription>
+            Set the self-hosted API base URL (Vite `VITE_API_BASE_URL` or Backend page field) to use
+            this tool.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  const phrase = meta?.confirmationPhrase || 'COPY FROM SUPABASE';
+  const canSubmit =
+    confirmation.trim() === phrase &&
+    (includeAuth || includePublic || includeStorage) &&
+    !running;
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle>Copy from Supabase</CardTitle>
+          <CardDescription>
+            Admin-only. Pulls hosted Supabase Postgres data (and optionally Storage objects) into
+            this self-hosted stack. Requires Coolify env{' '}
+            <code className="text-xs">MIGRATE_SOURCE_DATABASE_URL</code>
+            {includeStorage ? (
+              <>
+                {' '}
+                plus <code className="text-xs">SUPABASE_URL</code> /{' '}
+                <code className="text-xs">SUPABASE_SERVICE_ROLE_KEY</code>
+              </>
+            ) : null}
+            . Schema must already exist on the target.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="flex flex-wrap gap-2">
+            <CapabilityBadge label="Source DB" ok={Boolean(meta?.capability.dataConfigured)} />
+            <CapabilityBadge label="Target DB" ok={Boolean(meta?.capability.targetConfigured)} />
+            <CapabilityBadge
+              label="Storage API"
+              ok={Boolean(meta?.capability.storageConfigured)}
+            />
+            <Button type="button" variant="outline" size="sm" onClick={() => void loadMeta()}>
+              Refresh
+            </Button>
+          </div>
+
+          {meta?.notes?.length ? (
+            <ul className="list-disc space-y-1 pl-5 text-sm text-muted-foreground">
+              {meta.notes.map((note) => (
+                <li key={note}>{note}</li>
+              ))}
+            </ul>
+          ) : null}
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            <label className="flex items-center gap-2 text-sm">
+              <Checkbox checked={dryRun} onCheckedChange={(v) => setDryRun(v === true)} />
+              Dry run (count only, no writes)
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <Checkbox
+                checked={includeAuth}
+                onCheckedChange={(v) => setIncludeAuth(v === true)}
+              />
+              Copy auth.users + auth.identities
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <Checkbox
+                checked={includePublic}
+                onCheckedChange={(v) => setIncludePublic(v === true)}
+              />
+              Copy public schema tables
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <Checkbox
+                checked={includeStorage}
+                onCheckedChange={(v) => setIncludeStorage(v === true)}
+              />
+              Copy storage objects into volume
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <Checkbox
+                checked={truncateFirst}
+                onCheckedChange={(v) => setTruncateFirst(v === true)}
+                disabled={dryRun}
+              />
+              Truncate target tables first (destructive)
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <Checkbox
+                checked={rewriteStorageUrls}
+                onCheckedChange={(v) => setRewriteStorageUrls(v === true)}
+                disabled={dryRun}
+              />
+              Rewrite profile avatar URLs to self-hosted API
+            </label>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="migrate-confirm">
+              Type <span className="font-mono">{phrase}</span> to enable
+            </Label>
+            <Input
+              id="migrate-confirm"
+              value={confirmation}
+              onChange={(event) => setConfirmation(event.target.value)}
+              placeholder={phrase}
+              autoComplete="off"
+            />
+          </div>
+
+          <Button type="button" onClick={() => setConfirmOpen(true)} disabled={!canSubmit}>
+            {running ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+            {dryRun ? 'Run dry-run' : 'Start copy'}
+          </Button>
+
+          {report ? (
+            <div className="space-y-3 rounded-md border p-4 text-sm">
+              <div className="flex flex-wrap gap-2">
+                <Badge variant="outline">{report.dryRun ? 'dry-run' : 'applied'}</Badge>
+                <Badge variant="outline">{report.durationMs}ms</Badge>
+                {report.urlRewrite ? (
+                  <Badge variant="outline">
+                    avatar URLs rewritten: {report.urlRewrite.updated}
+                  </Badge>
+                ) : null}
+              </div>
+              <div>
+                <p className="mb-1 font-medium">Tables</p>
+                <div className="max-h-48 overflow-auto font-mono text-xs">
+                  {report.tables.map((row) => (
+                    <div key={`${row.schema}.${row.table}`}>
+                      {row.schema}.{row.table}: {row.action} ({row.rows}
+                      {row.reason ? ` — ${row.reason}` : ''})
+                    </div>
+                  ))}
+                </div>
+              </div>
+              {report.storage.length > 0 ? (
+                <div>
+                  <p className="mb-1 font-medium">Storage</p>
+                  <div className="font-mono text-xs">
+                    {report.storage.map((row) => (
+                      <div key={row.bucket}>
+                        {row.bucket}: {row.action} ({row.objects} objects
+                        {row.errors ? `, ${row.errors} errors` : ''}
+                        {row.reason ? ` — ${row.reason}` : ''})
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+              {report.warnings.length > 0 ? (
+                <div>
+                  <p className="mb-1 font-medium text-destructive">Warnings</p>
+                  <ul className="max-h-32 list-disc overflow-auto pl-5 text-xs text-muted-foreground">
+                    {report.warnings.map((warning) => (
+                      <li key={warning}>{warning}</li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {dryRun ? 'Run migration dry-run?' : 'Copy data from Supabase now?'}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {dryRun
+                ? 'No rows will be written. This only counts what would be copied.'
+                : truncateFirst
+                  ? 'This will TRUNCATE selected target tables, then insert from Supabase. Irreversible without a backup.'
+                  : 'This will insert rows from Supabase (ON CONFLICT DO NOTHING). Existing rows are kept.'}
+              {' '}
+              Auth: {includeAuth ? 'yes' : 'no'}; public: {includePublic ? 'yes' : 'no'}; storage:{' '}
+              {includeStorage ? 'yes' : 'no'}.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={running}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(event) => {
+                event.preventDefault();
+                void runMigrate();
+              }}
+              disabled={running}
+            >
+              {running ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+              Confirm
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+};

--- a/src/pages/admin/AdminBackendPage.tsx
+++ b/src/pages/admin/AdminBackendPage.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { BackendProviderToggle } from '@/components/admin/BackendProviderToggle';
+import { SupabaseMigratePanel } from '@/components/admin/SupabaseMigratePanel';
 
 const AdminBackendPage: React.FC = () => {
   return (
@@ -9,6 +10,7 @@ const AdminBackendPage: React.FC = () => {
         this page.
       </p>
       <BackendProviderToggle />
+      <SupabaseMigratePanel />
     </div>
   );
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an **admin-only “Copy from Supabase”** panel on **Admin → Backend** so you can pull hosted Supabase data into self-hosted Postgres (and optionally Storage objects into `retroscope_uploads`) without SSH/CLI.

### API
- `GET /api/admin/migrate-from-supabase` — capability + confirmation phrase
- `POST /api/admin/migrate-from-supabase` — run copy (admin JWT required)

### Options
- Dry-run (default)
- Copy `auth.users` + `auth.identities`
- Copy `public` schema tables
- Optional storage object copy
- Optional truncate-first (destructive)
- Optional avatar URL rewrite to self-hosted API
- Confirmation phrase: `COPY FROM SUPABASE`

### Coolify env required
```bash
MIGRATE_SOURCE_DATABASE_URL=postgresql://…@db.…supabase.co:5432/postgres
# storage only:
SUPABASE_URL=https://YOUR_PROJECT.supabase.co
SUPABASE_SERVICE_ROLE_KEY=…
```

### Notes
- Target schema must already exist (Phase 3 restore / init SQL).
- Prefer dry-run first; take a volume/DB backup before truncate-first.
- Compose files pass through the new env vars.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-79](https://linear.app/dungeon-dwellers/issue/DUN-79/self-host-phase-4-docker-volume-storage-critical-edge-ports)

<div><a href="https://cursor.com/agents/bc-b116f88b-32d5-4525-b548-49821aa465ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b116f88b-32d5-4525-b548-49821aa465ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

