### PR TITLE
fix(admin): migrate 401 — accept hosted Supabase admin sessions

### DIFF
--- a/COOLIFY_SELFHOST.md
+++ b/COOLIFY_SELFHOST.md
@@ -131,9 +131,11 @@ EMAIL_FROM=Retroscope <noreply@yourdomain.com>
 # Phase 4 — Admin "Copy from Supabase" tool (optional; enable when ready to sync)
 # Session-mode URI from Supabase → Project Settings → Database
 MIGRATE_SOURCE_DATABASE_URL=postgresql://postgres.…@db.…supabase.co:5432/postgres
-# Needed only if you also copy Storage objects from the Admin panel
+# Needed for storage copy AND for dual-path migrate auth (hosted admin session → API)
 SUPABASE_URL=https://YOUR_PROJECT.supabase.co
 SUPABASE_SERVICE_ROLE_KEY=eyJhbGc...
+# Optional fallback for validating hosted user JWTs
+# SUPABASE_ANON_KEY=eyJhbGc...
 ```
 
 > Default DB role passwords in `server/postgres/init/01-roles.sql` are for bootstrap only. Change them (and matching `DATABASE_URL` / `PGRST_DB_URI`) before any real data restore.

--- a/docker-compose.selfhost.prebuilt.yml
+++ b/docker-compose.selfhost.prebuilt.yml
@@ -386,6 +386,7 @@ services:
       MIGRATE_SOURCE_DATABASE_URL: ${MIGRATE_SOURCE_DATABASE_URL:-}
       SUPABASE_URL: ${SUPABASE_URL:-}
       SUPABASE_SERVICE_ROLE_KEY: ${SUPABASE_SERVICE_ROLE_KEY:-}
+      SUPABASE_ANON_KEY: ${SUPABASE_ANON_KEY:-}
     volumes:
       - retroscope_uploads:/data/uploads
     depends_on:

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -388,6 +388,7 @@ services:
       MIGRATE_SOURCE_DATABASE_URL: ${MIGRATE_SOURCE_DATABASE_URL:-}
       SUPABASE_URL: ${SUPABASE_URL:-}
       SUPABASE_SERVICE_ROLE_KEY: ${SUPABASE_SERVICE_ROLE_KEY:-}
+      SUPABASE_ANON_KEY: ${SUPABASE_ANON_KEY:-}
     volumes:
       - retroscope_uploads:/data/uploads
     depends_on:

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -24,9 +24,11 @@ const envSchema = z.object({
   SMTP_PASS: z.string().optional(),
   /** Hosted Supabase Postgres URI used by admin migrate tool (never expose to FE). */
   MIGRATE_SOURCE_DATABASE_URL: z.string().optional(),
-  /** Hosted Supabase project URL for storage object copy. */
+  /** Hosted Supabase project URL for storage object copy / dual-path admin auth. */
   SUPABASE_URL: z.string().optional(),
   SUPABASE_SERVICE_ROLE_KEY: z.string().optional(),
+  /** Optional; used to validate hosted user JWTs if service role is unavailable. */
+  SUPABASE_ANON_KEY: z.string().optional(),
 });
 
 export type AppConfig = z.infer<typeof envSchema> & {

--- a/server/src/lib/migrateAuth.test.ts
+++ b/server/src/lib/migrateAuth.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import Fastify from 'fastify';
+import { SignJWT } from 'jose';
+import { requireAdminForMigrate } from './migrateAuth.js';
+import type { AppConfig } from '../config.js';
+
+const LOCAL_SECRET = 'local-jwt-secret-at-least-32-characters!!';
+
+async function mintLocalToken(userId: string): Promise<string> {
+  return new SignJWT({ role: 'authenticated', email: 'admin@example.com' })
+    .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
+    .setSubject(userId)
+    .setAudience('authenticated')
+    .setIssuedAt()
+    .setExpirationTime('1h')
+    .setIssuer('retroscope-auth')
+    .sign(new TextEncoder().encode(LOCAL_SECRET));
+}
+
+describe('requireAdminForMigrate', () => {
+  it('returns 401 with hint when Authorization is missing', async () => {
+    const app = Fastify();
+    app.get('/t', async (request, reply) => {
+      const claims = await requireAdminForMigrate(request, reply, {} as AppConfig);
+      if (!claims) return reply;
+      return { ok: true };
+    });
+    await app.ready();
+    const res = await app.inject({ method: 'GET', url: '/t' });
+    assert.equal(res.statusCode, 401);
+    assert.match(res.json().hint || '', /Missing Bearer/i);
+    await app.close();
+  });
+
+  it('returns 401 with dual-path hint when local JWT fails and no Supabase URL', async () => {
+    const app = Fastify();
+    const config = {
+      JWT_SECRET: LOCAL_SECRET,
+    } as AppConfig;
+    app.get('/t', async (request, reply) => {
+      const claims = await requireAdminForMigrate(request, reply, config);
+      if (!claims) return reply;
+      return { ok: true };
+    });
+    await app.ready();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/t',
+      headers: { authorization: 'Bearer not-a-valid-jwt' },
+    });
+    assert.equal(res.statusCode, 401);
+    assert.match(res.json().hint || '', /hosted Supabase/i);
+    await app.close();
+  });
+
+  it('accepts a valid local JWT then 403s when no admin profile sources exist', async () => {
+    const app = Fastify();
+    const userId = '11111111-1111-1111-1111-111111111111';
+    const config = {
+      JWT_SECRET: LOCAL_SECRET,
+      // no DATABASE_URL / migrate source → admin check fails closed
+    } as AppConfig;
+    app.get('/t', async (request, reply) => {
+      const claims = await requireAdminForMigrate(request, reply, config);
+      if (!claims) return reply;
+      return { ok: true, sub: claims.sub };
+    });
+    await app.ready();
+    const token = await mintLocalToken(userId);
+    const res = await app.inject({
+      method: 'GET',
+      url: '/t',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    assert.equal(res.statusCode, 403);
+    assert.match(res.json().hint || '', /admin profile/i);
+    await app.close();
+  });
+});

--- a/server/src/lib/migrateAuth.ts
+++ b/server/src/lib/migrateAuth.ts
@@ -1,0 +1,220 @@
+import pg from 'pg';
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import type { AppConfig } from '../config.js';
+import { verifyAccessToken, type AccessTokenClaims } from '../auth/jwt.js';
+import { extractBearer } from './requestAuth.js';
+import { getPool } from './db.js';
+
+const { Pool } = pg;
+
+/**
+ * Resolve the caller for migrate endpoints during dual-path cutover:
+ * 1) Verify local self-hosted JWT (JWT_SECRET)
+ * 2) Else validate the Bearer token against hosted Supabase Auth (/auth/v1/user)
+ * 3) Require profiles.role = admin on local DB, else on MIGRATE_SOURCE_DATABASE_URL
+ */
+export async function requireAdminForMigrate(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  config: AppConfig
+): Promise<AccessTokenClaims | null> {
+  const token = extractBearer(request.headers.authorization);
+  if (!token) {
+    await reply.status(401).send({
+      error: 'Unauthorized',
+      hint: 'Missing Bearer token. Sign in and retry.',
+    });
+    return null;
+  }
+
+  let userId: string | null = null;
+  let email: string | undefined;
+  let authSource: 'local_jwt' | 'hosted_supabase' | null = null;
+
+  if (config.JWT_SECRET) {
+    try {
+      const claims = await verifyAccessToken(token, config.JWT_SECRET);
+      userId = claims.sub;
+      email = typeof claims.email === 'string' ? claims.email : undefined;
+      authSource = 'local_jwt';
+    } catch {
+      // Dual-path: browser may still hold a hosted Supabase access token.
+    }
+  }
+
+  if (!userId) {
+    const hosted = await resolveHostedSupabaseUser(config, token);
+    if (hosted) {
+      userId = hosted.id;
+      email = hosted.email;
+      authSource = 'hosted_supabase';
+    }
+  }
+
+  if (!userId) {
+    await reply.status(401).send({
+      error: 'Unauthorized',
+      hint:
+        'Access token was not accepted as a local JWT or a hosted Supabase session. ' +
+        'Set SUPABASE_URL (+ SUPABASE_SERVICE_ROLE_KEY) on the API so hosted admin sessions can call migrate, ' +
+        'or sign in via self-hosted auth with a matching JWT_SECRET.',
+      authSource: null,
+    });
+    return null;
+  }
+
+  const adminCheck = await isAdminUser(config, userId);
+  if (!adminCheck.ok) {
+    await reply.status(403).send({
+      error: 'Forbidden',
+      hint: adminCheck.hint,
+      userId,
+      authSource,
+    });
+    return null;
+  }
+
+  return {
+    sub: userId,
+    role: 'authenticated',
+    email,
+  };
+}
+
+async function resolveHostedSupabaseUser(
+  config: AppConfig,
+  accessToken: string
+): Promise<{ id: string; email?: string } | null> {
+  const supabaseUrl = config.SUPABASE_URL?.replace(/\/$/, '');
+  const apiKey = config.SUPABASE_SERVICE_ROLE_KEY || config.SUPABASE_ANON_KEY;
+  if (!supabaseUrl || !apiKey) {
+    return null;
+  }
+
+  try {
+    const response = await fetch(`${supabaseUrl}/auth/v1/user`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        apikey: apiKey,
+      },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!response.ok) {
+      return null;
+    }
+    const body = (await response.json()) as { id?: string; email?: string };
+    if (!body.id || typeof body.id !== 'string') {
+      return null;
+    }
+    return { id: body.id, email: body.email };
+  } catch {
+    return null;
+  }
+}
+
+async function readAdminRole(
+  connectionString: string,
+  userId: string
+): Promise<string | null> {
+  const pool = new Pool({
+    connectionString,
+    max: 1,
+    connectionTimeoutMillis: 8_000,
+  });
+  try {
+    const result = await pool.query<{ role: string | null }>(
+      `SELECT role FROM public.profiles WHERE id = $1 LIMIT 1`,
+      [userId]
+    );
+    return result.rows[0]?.role ?? null;
+  } finally {
+    await pool.end().catch(() => undefined);
+  }
+}
+
+async function isAdminUser(
+  config: AppConfig,
+  userId: string
+): Promise<{ ok: boolean; hint?: string }> {
+  // 1) Local target DB
+  const local = getPool(config);
+  if (local) {
+    try {
+      const result = await local.query<{ role: string | null }>(
+        `SELECT role FROM public.profiles WHERE id = $1 LIMIT 1`,
+        [userId]
+      );
+      if (result.rows[0]?.role === 'admin') {
+        return { ok: true };
+      }
+      if (result.rows[0]) {
+        // Local profile exists but is not admin — still allow checking source in case
+        // local data is stale pre-migrate, but prefer explicit admin on either side.
+      }
+    } catch {
+      // profiles may not exist yet on an empty target
+    }
+  }
+
+  // 2) Source Supabase DB (pre-migrate / empty local profiles)
+  if (config.MIGRATE_SOURCE_DATABASE_URL) {
+    try {
+      const role = await readAdminRole(config.MIGRATE_SOURCE_DATABASE_URL, userId);
+      if (role === 'admin') {
+        return { ok: true };
+      }
+      if (role) {
+        return {
+          ok: false,
+          hint: `Your user is "${role}" on the source Supabase profiles table; admin role is required.`,
+        };
+      }
+    } catch (error) {
+      return {
+        ok: false,
+        hint: `Could not read source profiles for admin check: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      };
+    }
+  }
+
+  // 3) Hosted PostgREST via service role
+  if (config.SUPABASE_URL && config.SUPABASE_SERVICE_ROLE_KEY) {
+    try {
+      const url = new URL(
+        `${config.SUPABASE_URL.replace(/\/$/, '')}/rest/v1/profiles`
+      );
+      url.searchParams.set('id', `eq.${userId}`);
+      url.searchParams.set('select', 'role');
+      const response = await fetch(url, {
+        headers: {
+          apikey: config.SUPABASE_SERVICE_ROLE_KEY,
+          Authorization: `Bearer ${config.SUPABASE_SERVICE_ROLE_KEY}`,
+        },
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (response.ok) {
+        const rows = (await response.json()) as Array<{ role?: string }>;
+        if (rows[0]?.role === 'admin') {
+          return { ok: true };
+        }
+        if (rows[0]?.role) {
+          return {
+            ok: false,
+            hint: `Your user is "${rows[0].role}" in hosted Supabase; admin role is required.`,
+          };
+        }
+      }
+    } catch {
+      // fall through
+    }
+  }
+
+  return {
+    ok: false,
+    hint:
+      'No admin profile found locally or on the Supabase source. ' +
+      'Ensure profiles.role = admin for your user, or complete an auth/profile import first.',
+  };
+}

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -2,7 +2,8 @@ import type { FastifyInstance } from 'fastify';
 import type { AppConfig } from '../config.js';
 import { checkPostgres } from '../lib/db.js';
 import { checkPostgrest } from '../lib/postgrest.js';
-import { extractBearer, requireAdmin } from '../lib/requestAuth.js';
+import { extractBearer } from '../lib/requestAuth.js';
+import { requireAdminForMigrate } from '../lib/migrateAuth.js';
 import { verifyAccessToken } from '../auth/jwt.js';
 import {
   getMigrateCapability,
@@ -62,7 +63,7 @@ export async function registerAdminRoutes(app: FastifyInstance, config: AppConfi
   });
 
   app.get('/api/admin/migrate-from-supabase', async (request, reply) => {
-    const claims = await requireAdmin(request, reply, config);
+    const claims = await requireAdminForMigrate(request, reply, config);
     if (!claims) return;
 
     return {
@@ -80,13 +81,14 @@ export async function registerAdminRoutes(app: FastifyInstance, config: AppConfi
         'Copies from MIGRATE_SOURCE_DATABASE_URL into local DATABASE_URL.',
         'Schema must already exist on the target (Phase 3 restore / init SQL).',
         'Storage copy needs SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY.',
+        'Dual-path: hosted Supabase admin sessions are accepted when SUPABASE_URL is set.',
         'Use dry-run first. truncateFirst replaces overlapping table data.',
       ],
     };
   });
 
   app.post('/api/admin/migrate-from-supabase', async (request, reply) => {
-    const claims = await requireAdmin(request, reply, config);
+    const claims = await requireAdminForMigrate(request, reply, config);
     if (!claims) return;
 
     const body = (request.body ?? {}) as {

--- a/src/components/admin/SupabaseMigratePanel.tsx
+++ b/src/components/admin/SupabaseMigratePanel.tsx
@@ -121,9 +121,11 @@ export const SupabaseMigratePanel: React.FC = () => {
       });
       if (!response.ok) {
         const body = await response.json().catch(() => ({}));
+        const errBody = body as { error?: string; hint?: string };
         throw new Error(
-          (body as { error?: string }).error ||
-            `Failed to load migrate tool (${response.status})`
+          [errBody.error || `Failed to load migrate tool (${response.status})`, errBody.hint]
+            .filter(Boolean)
+            .join(' — ')
         );
       }
       const json = (await response.json()) as MigrateMeta;
@@ -184,8 +186,11 @@ export const SupabaseMigratePanel: React.FC = () => {
       });
       const body = await response.json().catch(() => ({}));
       if (!response.ok) {
+        const errBody = body as { error?: string; hint?: string };
         throw new Error(
-          (body as { error?: string }).error || `Migrate failed (${response.status})`
+          [errBody.error || `Migrate failed (${response.status})`, errBody.hint]
+            .filter(Boolean)
+            .join(' — ')
         );
       }
       const next = body as MigrateReport;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`GET/POST /api/admin/migrate-from-supabase` returned **401** even with Coolify migrate env vars set.

## Cause

Those routes used strict `requireAdmin`, which only accepts JWTs signed with the API’s `JWT_SECRET`. During dual-path cutover the Admin UI often still sends a **hosted Supabase** access token, which fails local verification → 401.

The three migrate env vars (`MIGRATE_SOURCE_DATABASE_URL`, `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`) were not used for auth.

## Fix

- New `requireAdminForMigrate`:
  1. Try local `JWT_SECRET` verification
  2. Else validate Bearer via hosted `SUPABASE_URL/auth/v1/user`
  3. Require `profiles.role = admin` on local DB, else source DB / hosted REST
- Clearer `401`/`403` JSON with `hint`
- FE toasts include those hints
- Compose passes optional `SUPABASE_ANON_KEY`

## After merge

Redeploy **api** (and web for toast hints). Ensure Coolify has at least:

```bash
SUPABASE_URL=https://YOUR_PROJECT.supabase.co
SUPABASE_SERVICE_ROLE_KEY=…
MIGRATE_SOURCE_DATABASE_URL=postgresql://…
```

`SUPABASE_URL` is required for hosted-session auth, not only storage.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-79](https://linear.app/dungeon-dwellers/issue/DUN-79/self-host-phase-4-docker-volume-storage-critical-edge-ports)

<div><a href="https://cursor.com/agents/bc-b116f88b-32d5-4525-b548-49821aa465ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b116f88b-32d5-4525-b548-49821aa465ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

