### PR TITLE
fix(migrate): copy nested poker chat storage folders

### DIFF
--- a/scripts/selfhost/copy-storage-from-supabase.sh
+++ b/scripts/selfhost/copy-storage-from-supabase.sh
@@ -21,7 +21,6 @@ set -euo pipefail
 UPLOADS_DIR="${UPLOADS_DIR:-/data/uploads}"
 STORAGE_BUCKETS="${STORAGE_BUCKETS:-avatars,poker-session-chat-images,retro-audio,tts-audio-cache}"
 DRY_RUN="${DRY_RUN:-0}"
-LIMIT="${LIMIT:-1000}"
 
 if [[ -z "${SUPABASE_URL:-}" || -z "${SUPABASE_SERVICE_ROLE_KEY:-}" ]]; then
   echo "SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required" >&2
@@ -29,74 +28,101 @@ if [[ -z "${SUPABASE_URL:-}" || -z "${SUPABASE_SERVICE_ROLE_KEY:-}" ]]; then
 fi
 
 SUPABASE_URL="${SUPABASE_URL%/}"
-AUTH_HEADER="Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}"
-APIKEY_HEADER="apikey: ${SUPABASE_SERVICE_ROLE_KEY}"
+export SUPABASE_URL
+export SUPABASE_SERVICE_ROLE_KEY
+export UPLOADS_DIR
+export DRY_RUN
+export STORAGE_BUCKETS
 
 mkdir -p "$UPLOADS_DIR"
 
-copy_bucket() {
-  local bucket="$1"
-  local offset=0
-  local copied=0
-  mkdir -p "${UPLOADS_DIR}/${bucket}"
+python3 - <<'PY'
+import json, os, pathlib, urllib.error, urllib.request
 
-  echo "==> Listing objects in bucket: ${bucket}"
-  while true; do
-    local page
-    page="$(curl -fsS \
-      -H "$AUTH_HEADER" \
-      -H "$APIKEY_HEADER" \
-      "${SUPABASE_URL}/storage/v1/object/list/${bucket}" \
-      -H 'Content-Type: application/json' \
-      -d "{\"prefix\":\"\",\"limit\":${LIMIT},\"offset\":${offset}}")"
+supabase = os.environ["SUPABASE_URL"].rstrip("/")
+service = os.environ["SUPABASE_SERVICE_ROLE_KEY"]
+uploads = pathlib.Path(os.environ["UPLOADS_DIR"])
+dry_run = os.environ.get("DRY_RUN", "0") == "1"
+buckets = [b.strip() for b in os.environ.get("STORAGE_BUCKETS", "").split(",") if b.strip()]
 
-    local names
-    names="$(python3 -c 'import json,sys; data=json.load(sys.stdin); print("\n".join(item.get("name","") for item in data if item.get("name")))' <<<"$page")"
-    if [[ -z "$names" ]]; then
-      break
-    fi
-
-    local count=0
-    while IFS= read -r name; do
-      [[ -z "$name" ]] && continue
-      # Skip "folder" placeholder objects ending with /
-      [[ "$name" == */ ]] && continue
-      count=$((count + 1))
-      local dest="${UPLOADS_DIR}/${bucket}/${name}"
-      mkdir -p "$(dirname "$dest")"
-      if [[ "$DRY_RUN" == "1" ]]; then
-        echo "  DRY_RUN would copy ${bucket}/${name}"
-      else
-        curl -fsS \
-          -H "$AUTH_HEADER" \
-          -H "$APIKEY_HEADER" \
-          "${SUPABASE_URL}/storage/v1/object/authenticated/${bucket}/${name}" \
-          -o "$dest" \
-          || curl -fsS \
-            -H "$AUTH_HEADER" \
-            -H "$APIKEY_HEADER" \
-            "${SUPABASE_URL}/storage/v1/object/public/${bucket}/${name}" \
-            -o "$dest"
-        echo "  copied ${bucket}/${name}"
-      fi
-      copied=$((copied + 1))
-    done <<<"$names"
-
-    if [[ "$count" -lt "$LIMIT" ]]; then
-      break
-    fi
-    offset=$((offset + LIMIT))
-  done
-
-  echo "==> ${bucket}: ${copied} object(s)"
+headers = {
+    "Authorization": f"Bearer {service}",
+    "apikey": service,
+    "Content-Type": "application/json",
 }
 
-IFS=',' read -r -a BUCKETS <<<"$STORAGE_BUCKETS"
-for bucket in "${BUCKETS[@]}"; do
-  bucket="$(echo "$bucket" | xargs)"
-  [[ -z "$bucket" ]] && continue
-  copy_bucket "$bucket"
-done
+
+def list_prefix(bucket: str, prefix: str, depth: int = 0) -> list[str]:
+    if depth > 20:
+        raise RuntimeError(f"recursion too deep for {bucket}/{prefix}")
+    names: list[str] = []
+    limit = 1000
+    offset = 0
+    while True:
+        req = urllib.request.Request(
+            f"{supabase}/storage/v1/object/list/{bucket}",
+            data=json.dumps({"prefix": prefix, "limit": limit, "offset": offset}).encode(),
+            headers=headers,
+            method="POST",
+        )
+        with urllib.request.urlopen(req) as resp:
+            page = json.load(resp)
+        if not page:
+            break
+        for item in page:
+            name = (item.get("name") or "").lstrip("/")
+            if not name or name == ".emptyFolderPlaceholder":
+                continue
+            full = f"{prefix.rstrip('/')}/{name}" if prefix else name
+            full = full.lstrip("/")
+            is_folder = item.get("id") is None and item.get("metadata") is None
+            if is_folder:
+                child = full if full.endswith("/") else full + "/"
+                names.extend(list_prefix(bucket, child, depth + 1))
+            else:
+                names.append(full)
+        if len(page) < limit:
+            break
+        offset += limit
+    return names
+
+
+def download(bucket: str, key: str) -> bytes:
+    encoded = "/".join(urllib.request.quote(part) for part in key.split("/") if part)
+    for kind in ("authenticated", "public"):
+        url = f"{supabase}/storage/v1/object/{kind}/{bucket}/{encoded}"
+        req = urllib.request.Request(url, headers={"Authorization": f"Bearer {service}", "apikey": service})
+        try:
+            with urllib.request.urlopen(req) as resp:
+                return resp.read()
+        except urllib.error.HTTPError:
+            continue
+    raise RuntimeError(f"download failed for {bucket}/{key}")
+
+
+for bucket in buckets:
+    print(f"==> Listing objects in bucket: {bucket}")
+    keys = list(dict.fromkeys(list_prefix(bucket, "")))
+    copied = 0
+    errors = 0
+    for key in keys:
+        dest = uploads / bucket / key
+        if dry_run:
+            print(f"  DRY_RUN would copy {bucket}/{key}")
+            copied += 1
+            continue
+        try:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(download(bucket, key))
+            print(f"  copied {bucket}/{key}")
+            copied += 1
+        except Exception as exc:
+            print(f"  ERROR {bucket}/{key}: {exc}")
+            errors += 1
+    print(f"==> {bucket}: {copied} object(s), {errors} error(s)")
+
+print(f"==> Done. Objects live under {uploads}")
+PY
 
 if [[ -n "${PUBLIC_API_BASE_URL:-}" && -n "${DATABASE_URL:-}" && "$DRY_RUN" != "1" ]]; then
   echo "==> Rewriting avatar public URLs → ${PUBLIC_API_BASE_URL%/}/storage/v1/object/public/avatars/…"
@@ -135,5 +161,4 @@ conn.close()
 PY
 fi
 
-echo "==> Done. Objects live under ${UPLOADS_DIR}"
 echo "    Mount this path as the Coolify volume retroscope_uploads → /data/uploads on api."

--- a/server/src/migrate/fromSupabase.test.ts
+++ b/server/src/migrate/fromSupabase.test.ts
@@ -1,10 +1,11 @@
 import assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
+import { describe, it, mock } from 'node:test';
 import {
   MIGRATE_CONFIRMATION_PHRASE,
   MigrateError,
   getMigrateCapability,
   migrateFromSupabase,
+  __storageListTestUtils,
 } from './fromSupabase.js';
 import type { AppConfig } from '../config.js';
 
@@ -69,5 +70,77 @@ describe('migrateFromSupabase guards', () => {
       (error: unknown) =>
         error instanceof MigrateError && error.statusCode === 503
     );
+  });
+});
+
+describe('storage list recursion', () => {
+  it('encodes nested object paths', () => {
+    assert.equal(
+      __storageListTestUtils.encodeObjectPath('session/1/pic.png'),
+      'session/1/pic.png'
+    );
+    assert.equal(
+      __storageListTestUtils.encodeObjectPath('a b/c.png'),
+      'a%20b/c.png'
+    );
+  });
+
+  it('treats null id+metadata as folders', () => {
+    assert.equal(
+      __storageListTestUtils.isStorageFolder({ name: 'sess', id: null, metadata: null }),
+      true
+    );
+    assert.equal(
+      __storageListTestUtils.isStorageFolder({
+        name: 'file.png',
+        id: 'abc',
+        metadata: { size: 12 },
+      }),
+      false
+    );
+  });
+
+  it('recurses into Supabase folder placeholders', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock.fn(async (_url, init) => {
+      const body = JSON.parse(String(init?.body ?? '{}')) as { prefix?: string };
+      if (!body.prefix) {
+        return new Response(
+          JSON.stringify([{ name: '17ca-session', id: null, metadata: null }]),
+          { status: 200 }
+        );
+      }
+      if (body.prefix === '17ca-session/') {
+        return new Response(
+          JSON.stringify([{ name: '1', id: null, metadata: null }]),
+          { status: 200 }
+        );
+      }
+      if (body.prefix === '17ca-session/1/') {
+        return new Response(
+          JSON.stringify([
+            {
+              name: 'pic.png',
+              id: 'obj-1',
+              metadata: { size: 10, mimetype: 'image/png' },
+            },
+          ]),
+          { status: 200 }
+        );
+      }
+      return new Response(JSON.stringify([]), { status: 200 });
+    }) as typeof fetch;
+
+    try {
+      const names = await __storageListTestUtils.listStoragePrefix(
+        'https://example.supabase.co',
+        'service',
+        'poker-session-chat-images',
+        ''
+      );
+      assert.deepEqual(names, ['17ca-session/1/pic.png']);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/server/src/migrate/fromSupabase.ts
+++ b/server/src/migrate/fromSupabase.ts
@@ -318,14 +318,43 @@ async function copySchemaTables(params: {
   return stats;
 }
 
-async function listStorageObjects(
+type StorageListItem = {
+  name?: string;
+  id?: string | null;
+  metadata?: Record<string, unknown> | null;
+};
+
+function encodeObjectPath(objectKey: string): string {
+  return objectKey
+    .split('/')
+    .filter((part) => part.length > 0)
+    .map((part) => encodeURIComponent(part))
+    .join('/');
+}
+
+function isStorageFolder(item: StorageListItem): boolean {
+  // Supabase list returns placeholders for prefixes with null id AND metadata.
+  return item.id == null && item.metadata == null;
+}
+
+async function listStoragePrefix(
   supabaseUrl: string,
   serviceKey: string,
-  bucket: string
+  bucket: string,
+  prefix: string,
+  depth = 0
 ): Promise<string[]> {
+  if (depth > 20) {
+    throw new MigrateError(
+      `Storage list recursion too deep for ${bucket}/${prefix}`,
+      502
+    );
+  }
+
   const names: string[] = [];
   const limit = 1000;
   let offset = 0;
+
   while (true) {
     const response = await fetch(
       `${supabaseUrl.replace(/\/$/, '')}/storage/v1/object/list/${bucket}`,
@@ -336,25 +365,67 @@ async function listStorageObjects(
           apikey: serviceKey,
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ prefix: '', limit, offset }),
+        body: JSON.stringify({ prefix, limit, offset }),
       }
     );
     if (!response.ok) {
       const text = await response.text();
       throw new MigrateError(
-        `Storage list failed for ${bucket}: ${response.status} ${text}`,
+        `Storage list failed for ${bucket} (prefix="${prefix}"): ${response.status} ${text}`,
         502
       );
     }
-    const page = (await response.json()) as Array<{ name?: string }>;
+
+    const page = (await response.json()) as StorageListItem[];
     if (!Array.isArray(page) || page.length === 0) break;
+
     for (const item of page) {
-      if (item.name && !item.name.endsWith('/')) names.push(item.name);
+      if (!item.name || item.name === '.emptyFolderPlaceholder') continue;
+      const relative = item.name.replace(/^\/+/, '');
+      const fullPath = prefix ? `${prefix.replace(/\/?$/, '/')}${relative}` : relative;
+
+      if (isStorageFolder(item)) {
+        const childPrefix = fullPath.endsWith('/') ? fullPath : `${fullPath}/`;
+        const nested = await listStoragePrefix(
+          supabaseUrl,
+          serviceKey,
+          bucket,
+          childPrefix,
+          depth + 1
+        );
+        names.push(...nested);
+      } else {
+        names.push(fullPath);
+      }
     }
+
     if (page.length < limit) break;
     offset += limit;
   }
+
   return names;
+}
+
+/** Exported for unit tests */
+export const __storageListTestUtils = {
+  encodeObjectPath,
+  isStorageFolder,
+  listStoragePrefix: (
+    supabaseUrl: string,
+    serviceKey: string,
+    bucket: string,
+    prefix: string
+  ) => listStoragePrefix(supabaseUrl, serviceKey, bucket, prefix),
+};
+
+async function listStorageObjects(
+  supabaseUrl: string,
+  serviceKey: string,
+  bucket: string
+): Promise<string[]> {
+  const names = await listStoragePrefix(supabaseUrl, serviceKey, bucket, '');
+  // De-dupe while preserving order
+  return Array.from(new Set(names));
 }
 
 async function downloadStorageObject(
@@ -368,9 +439,10 @@ async function downloadStorageObject(
     Authorization: `Bearer ${serviceKey}`,
     apikey: serviceKey,
   };
+  const encodedKey = encodeObjectPath(objectKey);
   const urls = [
-    `${base}/storage/v1/object/authenticated/${bucket}/${objectKey}`,
-    `${base}/storage/v1/object/public/${bucket}/${objectKey}`,
+    `${base}/storage/v1/object/authenticated/${bucket}/${encodedKey}`,
+    `${base}/storage/v1/object/public/${bucket}/${encodedKey}`,
   ];
   let lastError = 'download failed';
   for (const url of urls) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What happened in your run

Your storage-only copy mostly succeeded:

| Bucket | Result |
|--------|--------|
| avatars | 10 copied |
| retro-audio | 1 copied |
| tts-audio-cache | 137 copied |
| poker-session-chat-images | **0 copied, 6 errors** |

The 6 `NoSuchKey` warnings were **folder placeholders** (session UUID prefixes), not real files. Poker chat images are nested as `sessionId/round/file`, and the migrator only listed the top level.

You also ran with `includeAuth: false` / `includePublic: false`, so **no Postgres data** was copied in that run — only storage.

## Fix

- Recursively list Supabase storage prefixes (null `id` + `metadata` = folder)
- Encode nested object paths on download
- Same recursion for the CLI `copy-storage-from-supabase.sh`

## After merge

Redeploy **api**, then re-run migrate with storage checked. Expect nested poker chat images to copy instead of `NoSuchKey` on UUID folders.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-79](https://linear.app/dungeon-dwellers/issue/DUN-79/self-host-phase-4-docker-volume-storage-critical-edge-ports)

<div><a href="https://cursor.com/agents/bc-b116f88b-32d5-4525-b548-49821aa465ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b116f88b-32d5-4525-b548-49821aa465ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

