### PR TITLE
fix(api): CORS errors on self-hosted /rest/v1 after 400

### DIFF
--- a/COOLIFY_SELFHOST.md
+++ b/COOLIFY_SELFHOST.md
@@ -111,14 +111,15 @@ POSTGREST_URL=http://postgrest:3000
 PGRST_DB_ANON_ROLE=anon
 
 # CORS + public API URL used in health/status payloads
-ALLOW_ORIGINS=https://retro.example.com
-SELF_HOSTED_API_BASE_URL=https://retro-api.example.com
-PUBLIC_SITE_URL=https://retro.example.com
+# ALLOW_ORIGINS = browser/web origin (FE host), not the API host.
+ALLOW_ORIGINS=https://retroscope.lovelesslabs.net
+SELF_HOSTED_API_BASE_URL=https://retroscope-api.lovelesslabs.net
+PUBLIC_SITE_URL=https://retroscope.lovelesslabs.net
 
 # Phase 2 — Google OAuth (redirect URI must match Coolify API FQDN)
 GOOGLE_CLIENT_ID=...
 GOOGLE_CLIENT_SECRET=...
-OAUTH_GOOGLE_REDIRECT_URI=https://retro-api.example.com/auth/v1/callback
+OAUTH_GOOGLE_REDIRECT_URI=https://retroscope-api.lovelesslabs.net/auth/v1/callback
 
 # Phase 2 — password reset email (Resend preferred; SMTP optional)
 RESEND_API_KEY=...

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -44,6 +44,15 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): AppConfig {
           .map((origin) => origin.trim())
           .filter(Boolean);
 
+  // Always include public site / API URLs when set so Coolify misconfig is less painful.
+  for (const extra of [parsed.PUBLIC_SITE_URL, parsed.SELF_HOSTED_API_BASE_URL]) {
+    if (!extra) continue;
+    const normalized = extra.replace(/\/$/, '');
+    if (normalized && !allowOrigins.includes('*') && !allowOrigins.includes(normalized)) {
+      allowOrigins.push(normalized);
+    }
+  }
+
   return {
     ...parsed,
     allowOrigins,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -18,9 +18,46 @@ async function main(): Promise<void> {
   });
 
   await app.register(cors, {
-    origin: config.allowOrigins.includes('*') ? true : config.allowOrigins,
+    origin: config.allowOrigins.includes('*')
+      ? true
+      : (origin, cb) => {
+          if (!origin) {
+            // Non-browser / same-origin tooling
+            cb(null, true);
+            return;
+          }
+          const allowed = config.allowOrigins.some(
+            (entry) => entry === origin || entry.replace(/\/$/, '') === origin.replace(/\/$/, '')
+          );
+          cb(null, allowed);
+        },
     credentials: true,
+    allowedHeaders: [
+      'Authorization',
+      'Content-Type',
+      'Accept',
+      'Prefer',
+      'Range',
+      'apikey',
+      'x-client-info',
+      'accept-profile',
+      'content-profile',
+      'x-supabase-client-platform',
+      'x-supabase-client-platform-version',
+      'x-supabase-client-runtime',
+      'x-supabase-client-runtime-version',
+    ],
+    exposedHeaders: ['Content-Range', 'Prefer'],
+    methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS', 'HEAD'],
   });
+
+  app.log.info(
+    {
+      allowOrigins: config.allowOrigins,
+      publicSiteUrl: config.PUBLIC_SITE_URL ?? null,
+    },
+    'CORS configured'
+  );
 
   await registerHealthRoutes(app, config);
   await registerAdminRoutes(app, config);

--- a/server/src/routes/restProxy.test.ts
+++ b/server/src/routes/restProxy.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { restPathFromRequest } from './restProxy.js';
+import { restPathFromRequest, shouldForwardUpstreamHeader } from './restProxy.js';
 
 describe('restPathFromRequest', () => {
   it('strips /rest/v1 prefix for tables', () => {
@@ -18,5 +18,20 @@ describe('restPathFromRequest', () => {
   it('handles root rest path', () => {
     assert.equal(restPathFromRequest('/rest/v1'), '');
     assert.equal(restPathFromRequest('/rest/v1/'), '');
+  });
+});
+
+describe('shouldForwardUpstreamHeader', () => {
+  it('blocks hop-by-hop and CORS headers from PostgREST', () => {
+    assert.equal(shouldForwardUpstreamHeader('Access-Control-Allow-Origin'), false);
+    assert.equal(shouldForwardUpstreamHeader('access-control-allow-credentials'), false);
+    assert.equal(shouldForwardUpstreamHeader('transfer-encoding'), false);
+    assert.equal(shouldForwardUpstreamHeader('content-length'), false);
+  });
+
+  it('allows content-type and content-range', () => {
+    assert.equal(shouldForwardUpstreamHeader('content-type'), true);
+    assert.equal(shouldForwardUpstreamHeader('Content-Range'), true);
+    assert.equal(shouldForwardUpstreamHeader('Prefer'), true);
   });
 });

--- a/server/src/routes/restProxy.ts
+++ b/server/src/routes/restProxy.ts
@@ -14,6 +14,14 @@ const HOP_BY_HOP = new Set([
   'content-length',
 ]);
 
+/** Never copy these from PostgREST — they would clobber @fastify/cors. */
+export function shouldForwardUpstreamHeader(name: string): boolean {
+  const lower = name.toLowerCase();
+  if (HOP_BY_HOP.has(lower)) return false;
+  if (lower.startsWith('access-control-')) return false;
+  return true;
+}
+
 function buildTargetUrl(postgrestBase: string, path: string, query: string): string {
   const base = postgrestBase.replace(/\/$/, '');
   const normalizedPath = path.replace(/^\/+/, '');
@@ -62,14 +70,13 @@ async function proxyToPostgrest(
       lower === 'content-type' ||
       lower === 'accept' ||
       lower === 'accept-profile' ||
-      lower === 'content-profile'
+      lower === 'content-profile' ||
+      lower === 'apikey' ||
+      lower === 'x-client-info'
     ) {
       headers[key] = Array.isArray(value) ? value.join(',') : String(value);
     }
   }
-
-  // Anonymous requests still need a role; PostgREST uses anon when no JWT.
-  // Forward Authorization when present so RLS sees auth.uid().
 
   const init: RequestInit = {
     method: request.method,
@@ -99,8 +106,7 @@ async function proxyToPostgrest(
   reply.status(upstream.status);
 
   for (const [key, value] of upstream.headers.entries()) {
-    if (HOP_BY_HOP.has(key.toLowerCase())) continue;
-    // Content-Range / Prefer are needed for count/exact pagination parity
+    if (!shouldForwardUpstreamHeader(key)) continue;
     reply.header(key, value);
   }
 
@@ -122,11 +128,14 @@ export async function registerRestProxyRoutes(
   config: AppConfig
 ): Promise<void> {
   const handler = async (request: FastifyRequest, reply: FastifyReply) => {
+    // Let @fastify/cors answer preflight; never proxy OPTIONS to PostgREST.
+    if (request.method === 'OPTIONS') {
+      return reply.status(204).send();
+    }
     const path = restPathFromRequest(request.url);
     return proxyToPostgrest(config, request, reply, path);
   };
 
-  // Prefix plugin so nested table/RPC paths are covered without Express-style globs.
   await app.register(
     async (scope) => {
       scope.all('/', handler);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What’s going on

You’re correctly hitting self-hosted `/rest/v1/*` after flipping Backend → Self-hosted.

In the Network tab, some calls succeed (`200`), then `retro_boards?select=*,teams...` returns **400**, and later rows show **“CORS error”**. That pattern usually means:

1. A real PostgREST failure (the `400`)
2. Browser labels follow-up failures as CORS when response CORS headers are missing/wrong

## Code fix

- Rest proxy no longer forwards upstream `Access-Control-*` headers (those can clobber `@fastify/cors`)
- Explicit allowed headers (`Authorization`, `Prefer`, `Range`, `apikey`, …)
- Don’t proxy `OPTIONS` to PostgREST
- Auto-add `PUBLIC_SITE_URL` to allow-list

## Coolify check (do this too)

Set on **api**:

```bash
ALLOW_ORIGINS=https://retroscope.lovelesslabs.net
PUBLIC_SITE_URL=https://retroscope.lovelesslabs.net
```

(`ALLOW_ORIGINS` must be the **web** origin, not `retroscope-api…`.)

## After deploy

Redeploy **api**. Re-test. If anything still fails, open the first non-CORS failure (likely `retro_boards` `400`) and check the JSON body — that’s the real PostgREST error (often nested `teams(...)` embed / missing FK).

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-79](https://linear.app/dungeon-dwellers/issue/DUN-79/self-host-phase-4-docker-volume-storage-critical-edge-ports)

<div><a href="https://cursor.com/agents/bc-b116f88b-32d5-4525-b548-49821aa465ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b116f88b-32d5-4525-b548-49821aa465ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

