### PR TITLE
fix(fe): PGRST100 nested select spaces on self-hosted PostgREST

### DIFF
--- a/src/lib/backend/selfhosted/restClient.test.ts
+++ b/src/lib/backend/selfhosted/restClient.test.ts
@@ -1,5 +1,25 @@
 import { describe, expect, it, vi, afterEach } from 'vitest';
-import { buildRestUrlForTest, createRestClient } from './restClient';
+import {
+  buildRestUrlForTest,
+  createRestClient,
+  normalizePostgrestSelect,
+} from './restClient';
+
+describe('normalizePostgrestSelect', () => {
+  it('strips whitespace that PostgREST rejects inside embeds', () => {
+    const input = `
+      *,
+      teams(
+        id,
+        name,
+        team_members(user_id, role)
+      )
+    `;
+    expect(normalizePostgrestSelect(input)).toBe(
+      '*,teams(id,name,team_members(user_id,role))'
+    );
+  });
+});
 
 describe('restClient URL building', () => {
   it('builds table URLs under /rest/v1', () => {
@@ -21,6 +41,39 @@ describe('restClient URL building', () => {
 describe('restClient fluent subset', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+  });
+
+  it('normalizes multiline nested selects before requesting', async () => {
+    const calls: Array<{ url: string }> = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        calls.push({ url: String(input) });
+        return new Response(JSON.stringify({ id: '1' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      })
+    );
+
+    const client = createRestClient('https://api.example.com', () => null);
+    await client
+      .from('retro_boards')
+      .select(`
+        *,
+        teams(
+          id,
+          name,
+          team_members(user_id, role)
+        )
+      `)
+      .eq('room_id', 'PUB2Q1')
+      .single();
+
+    expect(calls[0].url).toContain(
+      'select=' + encodeURIComponent('*,teams(id,name,team_members(user_id,role))')
+    );
+    expect(calls[0].url).not.toMatch(/%20id/);
   });
 
   it('issues GET with filters and Authorization', async () => {

--- a/src/lib/backend/selfhosted/restClient.ts
+++ b/src/lib/backend/selfhosted/restClient.ts
@@ -56,6 +56,20 @@ function encodeFilterValue(value: unknown): string {
   return String(value);
 }
 
+/**
+ * PostgREST's select parser rejects whitespace inside embeds
+ * (PGRST100: unexpected ")" expecting ","). Collapse template-literal
+ * selects like `*, teams( id, name )` → `*,teams(id,name)`.
+ */
+export function normalizePostgrestSelect(columns: string): string {
+  return columns
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\s*\(\s*/g, '(')
+    .replace(/\s*\)\s*/g, ')')
+    .replace(/\s*,\s*/g, ',');
+}
+
 export class RestQueryBuilder<T = unknown> {
   private queryParams: Map<string, string> = new Map();
   private headers: Record<string, string> = {};
@@ -74,7 +88,7 @@ export class RestQueryBuilder<T = unknown> {
   ) {}
 
   select(columns: string = '*', options?: SelectOptions): this {
-    const cleanColumns = columns.replace(/\s+/g, ' ').trim();
+    const cleanColumns = normalizePostgrestSelect(columns);
     this.queryParams.set('select', cleanColumns);
     if (options?.count) {
       this.wantCount = options.count;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Cause

Self-hosted PostgREST returned **PGRST100** for:

```text
(*, teams( id, name, team_members(user_id, role) ))
```

Whitespace inside embed parentheses (from multiline template literals in `useRoomAccess`) is rejected by PostgREST’s select parser. Hosted Supabase/PostgREST was more forgiving, so this only showed up after flipping to self-hosted.

## Fix

Normalize `select()` strings in the self-hosted rest client:

`*, teams( id, name, … )` → `*,teams(id,name,…)`

## After merge

Redeploy **web** (FE change). The `retro_boards` room-access query should stop 400ing.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-79](https://linear.app/dungeon-dwellers/issue/DUN-79/self-host-phase-4-docker-volume-storage-critical-edge-ports)

<div><a href="https://cursor.com/agents/bc-b116f88b-32d5-4525-b548-49821aa465ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b116f88b-32d5-4525-b548-49821aa465ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

