### PR TITLE
feat(self-host): Phase 5 realtime via Socket.IO (DUN-80)

### DIFF
--- a/docker-compose.selfhost.prebuilt.yml
+++ b/docker-compose.selfhost.prebuilt.yml
@@ -266,6 +266,147 @@ configs:
       ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT EXECUTE ON FUNCTIONS TO service_role;
       ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT EXECUTE ON FUNCTIONS TO retroscope_app;
 
+  retroscope_realtime_sql:
+    content: |
+      -- Phase 5 (DUN-80): Postgres NOTIFY for self-hosted realtime.
+      -- Node API LISTENs on channel retroscope_changes and fans out via Socket.IO.
+      --
+      -- Coolify compose embeds this via configs.content — keep compose in sync.
+      -- SQL must stay free of dollar signs (Compose interpolates them).
+
+      CREATE OR REPLACE FUNCTION public.retroscope_notify_change()
+      RETURNS trigger
+      LANGUAGE plpgsql
+      SECURITY DEFINER
+      SET search_path = public
+      AS '
+      DECLARE
+        payload json;
+        row_new json;
+        row_old json;
+        rooms text[] := ARRAY[]::text[];
+        board_id_text text;
+        team_id_text text;
+        item_id_text text;
+        session_id_text text;
+        user_id_text text;
+        op text := TG_OP;
+      BEGIN
+        IF TG_OP = ''DELETE'' THEN
+          row_old := row_to_json(OLD);
+          row_new := NULL;
+        ELSIF TG_OP = ''INSERT'' THEN
+          row_new := row_to_json(NEW);
+          row_old := NULL;
+        ELSE
+          row_new := row_to_json(NEW);
+          row_old := row_to_json(OLD);
+        END IF;
+
+        IF TG_TABLE_NAME IN (''retro_items'', ''retro_votes'', ''retro_board_config'', ''endorsements'') THEN
+          board_id_text := COALESCE(row_new ->> ''board_id'', row_old ->> ''board_id'');
+          IF board_id_text IS NOT NULL THEN
+            rooms := array_append(rooms, ''board:'' || board_id_text);
+          END IF;
+        ELSIF TG_TABLE_NAME = ''retro_boards'' THEN
+          board_id_text := COALESCE(row_new ->> ''id'', row_old ->> ''id'');
+          team_id_text := COALESCE(row_new ->> ''team_id'', row_old ->> ''team_id'');
+          IF board_id_text IS NOT NULL THEN
+            rooms := array_append(rooms, ''board:'' || board_id_text);
+          END IF;
+          IF team_id_text IS NOT NULL THEN
+            rooms := array_append(rooms, ''team:'' || team_id_text);
+          END IF;
+        ELSIF TG_TABLE_NAME = ''retro_comments'' THEN
+          item_id_text := COALESCE(row_new ->> ''item_id'', row_old ->> ''item_id'');
+          IF item_id_text IS NOT NULL THEN
+            rooms := array_append(rooms, ''item:'' || item_id_text);
+            SELECT ri.board_id::text INTO board_id_text FROM public.retro_items ri WHERE ri.id::text = item_id_text LIMIT 1;
+            IF board_id_text IS NOT NULL THEN
+              rooms := array_append(rooms, ''board:'' || board_id_text);
+            END IF;
+          END IF;
+        ELSIF TG_TABLE_NAME = ''poker_sessions'' THEN
+          session_id_text := COALESCE(row_new ->> ''id'', row_old ->> ''id'');
+          team_id_text := COALESCE(row_new ->> ''team_id'', row_old ->> ''team_id'');
+          IF session_id_text IS NOT NULL THEN
+            rooms := array_append(rooms, ''poker:'' || session_id_text);
+          END IF;
+          IF team_id_text IS NOT NULL THEN
+            rooms := array_append(rooms, ''team:'' || team_id_text);
+          END IF;
+        ELSIF TG_TABLE_NAME IN (''poker_session_rounds'', ''poker_session_chat'', ''poker_session_chat_message_reactions'') THEN
+          session_id_text := COALESCE(row_new ->> ''session_id'', row_old ->> ''session_id'');
+          IF session_id_text IS NOT NULL THEN
+            rooms := array_append(rooms, ''poker:'' || session_id_text);
+            SELECT ps.team_id::text INTO team_id_text FROM public.poker_sessions ps WHERE ps.id::text = session_id_text LIMIT 1;
+            IF team_id_text IS NOT NULL THEN
+              rooms := array_append(rooms, ''team:'' || team_id_text);
+            END IF;
+          END IF;
+        ELSIF TG_TABLE_NAME = ''team_action_items'' THEN
+          team_id_text := COALESCE(row_new ->> ''team_id'', row_old ->> ''team_id'');
+          IF team_id_text IS NOT NULL THEN
+            rooms := array_append(rooms, ''team:'' || team_id_text);
+          END IF;
+        ELSIF TG_TABLE_NAME = ''notifications'' THEN
+          user_id_text := COALESCE(row_new ->> ''user_id'', row_old ->> ''user_id'');
+          IF user_id_text IS NOT NULL THEN
+            rooms := array_append(rooms, ''user:'' || user_id_text);
+          END IF;
+        ELSIF TG_TABLE_NAME IN (''feature_flags'', ''feature_flag_user_overrides'', ''feature_flag_team_overrides'') THEN
+          rooms := array_append(rooms, ''feature-flags'');
+        END IF;
+
+        payload := json_build_object(
+          ''schema'', TG_TABLE_SCHEMA,
+          ''table'', TG_TABLE_NAME,
+          ''event'', op,
+          ''new'', row_new,
+          ''old'', row_old,
+          ''rooms'', to_json(rooms)
+        );
+
+        PERFORM pg_notify(''retroscope_changes'', payload::text);
+
+        IF TG_OP = ''DELETE'' THEN
+          RETURN OLD;
+        END IF;
+        RETURN NEW;
+      END;
+      ';
+
+      -- Attach triggers only when the table exists (schema may be restored later).
+      SELECT format(
+        'DROP TRIGGER IF EXISTS retroscope_notify_%s ON public.%I; CREATE TRIGGER retroscope_notify_%s AFTER INSERT OR UPDATE OR DELETE ON public.%I FOR EACH ROW EXECUTE FUNCTION public.retroscope_notify_change();',
+        replace(tablename, '_', ''),
+        tablename,
+        replace(tablename, '_', ''),
+        tablename
+      )
+      FROM (VALUES
+        ('retro_items'),
+        ('retro_votes'),
+        ('retro_comments'),
+        ('retro_boards'),
+        ('retro_board_config'),
+        ('team_action_items'),
+        ('poker_sessions'),
+        ('poker_session_rounds'),
+        ('poker_session_chat'),
+        ('poker_session_chat_message_reactions'),
+        ('notifications'),
+        ('feature_flags'),
+        ('feature_flag_user_overrides'),
+        ('feature_flag_team_overrides'),
+        ('endorsements')
+      ) AS t(tablename)
+      WHERE EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = t.tablename
+      )
+      \gexec
+
 services:
   postgres:
     image: postgres:16-alpine
@@ -283,6 +424,8 @@ services:
         target: /docker-entrypoint-initdb.d/02-auth-schema.sql
       - source: retroscope_rls_sql
         target: /docker-entrypoint-initdb.d/03-rls-helpers.sql
+      - source: retroscope_realtime_sql
+        target: /docker-entrypoint-initdb.d/05-realtime-notify.sql
     expose:
       - '5432'
     healthcheck:
@@ -314,6 +457,8 @@ services:
         target: /init/02-auth-schema.sql
       - source: retroscope_rls_sql
         target: /init/03-rls-helpers.sql
+      - source: retroscope_realtime_sql
+        target: /init/05-realtime-notify.sql
     command:
       [
         'psql',
@@ -325,6 +470,8 @@ services:
         '/init/02-auth-schema.sql',
         '-f',
         '/init/03-rls-helpers.sql',
+        '-f',
+        '/init/05-realtime-notify.sql',
       ]
     depends_on:
       postgres:

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -263,6 +263,147 @@ configs:
       ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT EXECUTE ON FUNCTIONS TO service_role;
       ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT EXECUTE ON FUNCTIONS TO retroscope_app;
 
+  retroscope_realtime_sql:
+    content: |
+      -- Phase 5 (DUN-80): Postgres NOTIFY for self-hosted realtime.
+      -- Node API LISTENs on channel retroscope_changes and fans out via Socket.IO.
+      --
+      -- Coolify compose embeds this via configs.content — keep compose in sync.
+      -- SQL must stay free of dollar signs (Compose interpolates them).
+
+      CREATE OR REPLACE FUNCTION public.retroscope_notify_change()
+      RETURNS trigger
+      LANGUAGE plpgsql
+      SECURITY DEFINER
+      SET search_path = public
+      AS '
+      DECLARE
+        payload json;
+        row_new json;
+        row_old json;
+        rooms text[] := ARRAY[]::text[];
+        board_id_text text;
+        team_id_text text;
+        item_id_text text;
+        session_id_text text;
+        user_id_text text;
+        op text := TG_OP;
+      BEGIN
+        IF TG_OP = ''DELETE'' THEN
+          row_old := row_to_json(OLD);
+          row_new := NULL;
+        ELSIF TG_OP = ''INSERT'' THEN
+          row_new := row_to_json(NEW);
+          row_old := NULL;
+        ELSE
+          row_new := row_to_json(NEW);
+          row_old := row_to_json(OLD);
+        END IF;
+
+        IF TG_TABLE_NAME IN (''retro_items'', ''retro_votes'', ''retro_board_config'', ''endorsements'') THEN
+          board_id_text := COALESCE(row_new ->> ''board_id'', row_old ->> ''board_id'');
+          IF board_id_text IS NOT NULL THEN
+            rooms := array_append(rooms, ''board:'' || board_id_text);
+          END IF;
+        ELSIF TG_TABLE_NAME = ''retro_boards'' THEN
+          board_id_text := COALESCE(row_new ->> ''id'', row_old ->> ''id'');
+          team_id_text := COALESCE(row_new ->> ''team_id'', row_old ->> ''team_id'');
+          IF board_id_text IS NOT NULL THEN
+            rooms := array_append(rooms, ''board:'' || board_id_text);
+          END IF;
+          IF team_id_text IS NOT NULL THEN
+            rooms := array_append(rooms, ''team:'' || team_id_text);
+          END IF;
+        ELSIF TG_TABLE_NAME = ''retro_comments'' THEN
+          item_id_text := COALESCE(row_new ->> ''item_id'', row_old ->> ''item_id'');
+          IF item_id_text IS NOT NULL THEN
+            rooms := array_append(rooms, ''item:'' || item_id_text);
+            SELECT ri.board_id::text INTO board_id_text FROM public.retro_items ri WHERE ri.id::text = item_id_text LIMIT 1;
+            IF board_id_text IS NOT NULL THEN
+              rooms := array_append(rooms, ''board:'' || board_id_text);
+            END IF;
+          END IF;
+        ELSIF TG_TABLE_NAME = ''poker_sessions'' THEN
+          session_id_text := COALESCE(row_new ->> ''id'', row_old ->> ''id'');
+          team_id_text := COALESCE(row_new ->> ''team_id'', row_old ->> ''team_id'');
+          IF session_id_text IS NOT NULL THEN
+            rooms := array_append(rooms, ''poker:'' || session_id_text);
+          END IF;
+          IF team_id_text IS NOT NULL THEN
+            rooms := array_append(rooms, ''team:'' || team_id_text);
+          END IF;
+        ELSIF TG_TABLE_NAME IN (''poker_session_rounds'', ''poker_session_chat'', ''poker_session_chat_message_reactions'') THEN
+          session_id_text := COALESCE(row_new ->> ''session_id'', row_old ->> ''session_id'');
+          IF session_id_text IS NOT NULL THEN
+            rooms := array_append(rooms, ''poker:'' || session_id_text);
+            SELECT ps.team_id::text INTO team_id_text FROM public.poker_sessions ps WHERE ps.id::text = session_id_text LIMIT 1;
+            IF team_id_text IS NOT NULL THEN
+              rooms := array_append(rooms, ''team:'' || team_id_text);
+            END IF;
+          END IF;
+        ELSIF TG_TABLE_NAME = ''team_action_items'' THEN
+          team_id_text := COALESCE(row_new ->> ''team_id'', row_old ->> ''team_id'');
+          IF team_id_text IS NOT NULL THEN
+            rooms := array_append(rooms, ''team:'' || team_id_text);
+          END IF;
+        ELSIF TG_TABLE_NAME = ''notifications'' THEN
+          user_id_text := COALESCE(row_new ->> ''user_id'', row_old ->> ''user_id'');
+          IF user_id_text IS NOT NULL THEN
+            rooms := array_append(rooms, ''user:'' || user_id_text);
+          END IF;
+        ELSIF TG_TABLE_NAME IN (''feature_flags'', ''feature_flag_user_overrides'', ''feature_flag_team_overrides'') THEN
+          rooms := array_append(rooms, ''feature-flags'');
+        END IF;
+
+        payload := json_build_object(
+          ''schema'', TG_TABLE_SCHEMA,
+          ''table'', TG_TABLE_NAME,
+          ''event'', op,
+          ''new'', row_new,
+          ''old'', row_old,
+          ''rooms'', to_json(rooms)
+        );
+
+        PERFORM pg_notify(''retroscope_changes'', payload::text);
+
+        IF TG_OP = ''DELETE'' THEN
+          RETURN OLD;
+        END IF;
+        RETURN NEW;
+      END;
+      ';
+
+      -- Attach triggers only when the table exists (schema may be restored later).
+      SELECT format(
+        'DROP TRIGGER IF EXISTS retroscope_notify_%s ON public.%I; CREATE TRIGGER retroscope_notify_%s AFTER INSERT OR UPDATE OR DELETE ON public.%I FOR EACH ROW EXECUTE FUNCTION public.retroscope_notify_change();',
+        replace(tablename, '_', ''),
+        tablename,
+        replace(tablename, '_', ''),
+        tablename
+      )
+      FROM (VALUES
+        ('retro_items'),
+        ('retro_votes'),
+        ('retro_comments'),
+        ('retro_boards'),
+        ('retro_board_config'),
+        ('team_action_items'),
+        ('poker_sessions'),
+        ('poker_session_rounds'),
+        ('poker_session_chat'),
+        ('poker_session_chat_message_reactions'),
+        ('notifications'),
+        ('feature_flags'),
+        ('feature_flag_user_overrides'),
+        ('feature_flag_team_overrides'),
+        ('endorsements')
+      ) AS t(tablename)
+      WHERE EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = t.tablename
+      )
+      \gexec
+
 services:
   postgres:
     image: postgres:16-alpine
@@ -280,6 +421,8 @@ services:
         target: /docker-entrypoint-initdb.d/02-auth-schema.sql
       - source: retroscope_rls_sql
         target: /docker-entrypoint-initdb.d/03-rls-helpers.sql
+      - source: retroscope_realtime_sql
+        target: /docker-entrypoint-initdb.d/05-realtime-notify.sql
     expose:
       - '5432'
     healthcheck:
@@ -311,6 +454,8 @@ services:
         target: /init/02-auth-schema.sql
       - source: retroscope_rls_sql
         target: /init/03-rls-helpers.sql
+      - source: retroscope_realtime_sql
+        target: /init/05-realtime-notify.sql
     command:
       [
         'psql',
@@ -322,6 +467,8 @@ services:
         '/init/02-auth-schema.sql',
         '-f',
         '/init/03-rls-helpers.sql',
+        '-f',
+        '/init/05-realtime-notify.sql',
       ]
     depends_on:
       postgres:

--- a/documentation/plans/self-host-coverage-tracker.md
+++ b/documentation/plans/self-host-coverage-tracker.md
@@ -114,7 +114,7 @@ Storage bucket string hits via `.from` (not PostgREST tables): `avatars` (4), `r
 | Theme profile fields | src/contexts/ThemeContext.tsx | PostgREST | profiles | PostgREST | Covered | getDb() |
 | Background profile fields | src/contexts/BackgroundContext.tsx | PostgREST | profiles | PostgREST | Covered | getDb() |
 | App config reads/writes | src/contexts/FeatureFlagContext.tsx, admin/*, Billing | PostgREST | app_config | PostgREST | Not started | Includes future backend_provider |
-| Feature flags | src/contexts/FeatureFlagContext.tsx | PostgREST + Realtime | feature_flags, overrides | PostgREST + WS | Not started | channel feature-flags-realtime |
+| Feature flags | src/contexts/FeatureFlagContext.tsx | PostgREST + Realtime | feature_flags, overrides | PostgREST + WS | Covered | getDb(); Phase 5 Socket.IO |
 | Admin feature flag UI | src/components/admin/FeatureFlagManager.tsx | PostgREST + Edge | flags + admin-search-users / admin-team-members | PostgREST + Node | Covered | getDb(); P0 functions on Node |
 | Tier limits | src/components/admin/TierLimitsManager.tsx | PostgREST | app_config, feature_flags | PostgREST | Not started | |
 | TTS URL config | src/components/admin/TtsUrlManager.tsx | PostgREST | app_config | PostgREST | Not started | |
@@ -150,13 +150,13 @@ Storage bucket string hits via `.from` (not PostgREST tables): `avatars` (4), `r
 
 | Feature | File (path) | Call Type | Resource | Self-host target | Status | Notes |
 |---|---|---|---|---|---|---|
-| Retro board core | src/hooks/useRetroBoard.ts | PostgREST + Realtime + Edge | retro_*, team_action_items, notify-retro-start | PostgREST + WS + Node | Covered | CRUD via getDb(); realtime/edge still hosted |
+| Retro board core | src/hooks/useRetroBoard.ts | PostgREST + Realtime + Edge | retro_*, team_action_items, notify-retro-start | PostgREST + WS + Node | Covered | CRUD + realtime via getDb(); edge may still be hosted |
 | Team boards | src/hooks/useTeamBoards.ts | PostgREST | retro_boards, config, templates, team_default_settings | PostgREST | Covered | getDb() |
 | Room access | src/hooks/useRoomAccess.ts | PostgREST | retro_boards, config | PostgREST | Covered | getDb() |
 | User readiness | src/hooks/useUserReadiness.ts | PostgREST | retro_user_readiness | PostgREST | Covered | getDb() |
 | Retro page/room | src/pages/Retro.tsx, RetroRoom.tsx | PostgREST | retro_boards | PostgREST | Not started | |
 | Board templates | src/hooks/useBoardTemplates.ts | PostgREST | board_templates, template_columns | PostgREST | Covered | getDb() |
-| Action items UI | TeamSidebar / TeamActionItems* | PostgREST + Realtime | team_action_items | PostgREST + WS | Not started | |
+| Action items UI | TeamSidebar / TeamActionItems* | PostgREST + Realtime | team_action_items | PostgREST + WS | Covered | getDb(); Phase 5 Socket.IO |
 | Backfill action items | src/components/admin/BackfillActionItems.tsx | PostgREST | boards/columns/items/action_items | PostgREST | Not started | Admin |
 | Sentiment | src/components/retro/SentimentDisplay.tsx | Edge | analyze-board-sentiment | Node P3 | Not started | Optional |
 | Retro timer audio | src/components/retro/RetroTimer.tsx | Storage | retro-audio | Docker volume | Not started | upload + public URL |
@@ -166,15 +166,15 @@ Storage bucket string hits via `.from` (not PostgREST tables): `avatars` (4), `r
 
 | Feature | File (path) | Call Type | Resource | Self-host target | Status | Notes |
 |---|---|---|---|---|---|---|
-| Poker session | src/hooks/usePokerSession.ts | PostgREST + Realtime + Edge | sessions, rounds, members, delete-session-data, admin-send-notification | PostgREST + WS + Node | Covered | CRUD via getDb(); realtime/edge still hosted |
-| Poker history / rounds | src/hooks/usePokerSessionHistory.ts | PostgREST + Realtime | poker_session_rounds, sessions | PostgREST + WS | Covered | getDb(); realtime still hosted |
+| Poker session | src/hooks/usePokerSession.ts | PostgREST + Realtime + Edge | sessions, rounds, members, delete-session-data, admin-send-notification | PostgREST + WS + Node | Covered | CRUD + realtime via getDb(); edge may still be hosted |
+| Poker history / rounds | src/hooks/usePokerSessionHistory.ts | PostgREST + Realtime | poker_session_rounds, sessions | PostgREST + WS | Covered | getDb(); Phase 5 Socket.IO |
 | Poker table context | src/components/Neotro/PokerTableComponent/context.tsx | PostgREST + Edge | rounds, admin-send-notification | PostgREST + Node | Not started | Many round updates |
-| Poker chat | src/hooks/usePokerSessionChat.ts | PostgREST + Storage + Realtime | chat, reactions, poker-session-chat-images | PostgREST + volume + WS | Covered | CRUD + storage via getDb(); realtime still hosted |
+| Poker chat | src/hooks/usePokerSessionChat.ts | PostgREST + Storage + Realtime | chat, reactions, poker-session-chat-images | PostgREST + volume + WS | Covered | CRUD + storage + realtime via getDb() |
 | Poker helpers | src/lib/supabase/poker.ts, pokerSessionCloneSettings.ts | PostgREST | chat, sessions | PostgREST | Covered | getDb() |
 | Team poker list | src/components/team/TeamPokerSessions.tsx | PostgREST + Realtime | poker_sessions / rounds | PostgREST + WS | Not started | |
 | Poker config | src/components/Neotro/PokerConfig.tsx | PostgREST | team_members, profiles | PostgREST | Not started | |
 | Local advisor payload | src/hooks/_pokerLocalAdvisorPayload.ts | PostgREST + Edge | chat, teams, get-jira-issue | Mixed | Not started | |
-| Story points broadcast | src/lib/pokerJiraStoryPointsBroadcast.ts | Realtime | channel poker_session:* | WS | Not started | |
+| Story points broadcast | src/lib/pokerJiraStoryPointsBroadcast.ts | Realtime | channel poker_session:* | WS | Covered | getDb(); Phase 5 Socket.IO |
 
 ### Jira / Slack / billing / misc edge
 
@@ -195,7 +195,7 @@ Storage bucket string hits via `.from` (not PostgREST tables): `avatars` (4), `r
 
 | Feature | File (path) | Call Type | Resource | Self-host target | Status | Notes |
 |---|---|---|---|---|---|---|
-| Endorsements | src/hooks/useEndorsements.ts | PostgREST + Realtime | endorsements | PostgREST + WS | Not started | |
+| Endorsements | src/hooks/useEndorsements.ts | PostgREST + Realtime | endorsements | PostgREST + WS | Covered | getDb(); Phase 5 Socket.IO |
 | Endorsement types | src/hooks/useEndorsementTypes.ts | PostgREST + RPC | types, settings, seed_default_* | PostgREST + RPC | Covered | getDb() + rpc |
 | Endorsements received UI | src/components/account/EndorsementsReceived.tsx | PostgREST | endorsements + joins | PostgREST | Not started | |
 | Recent activity | src/hooks/useRecentActivity.ts, src/lib/recentActivity.ts | PostgREST | user_recent_activity (+ joins) | PostgREST | Not started | |
@@ -204,7 +204,7 @@ Storage bucket string hits via `.from` (not PostgREST tables): `avatars` (4), `r
 
 | Feature | File (path) | Call Type | Resource | Self-host target | Status | Notes |
 |---|---|---|---|---|---|---|
-| Notifications list/mark | src/hooks/useNotifications.ts | PostgREST + Realtime | notifications | PostgREST + WS | Covered | CRUD via getDb(); realtime still hosted |
+| Notifications list/mark | src/hooks/useNotifications.ts | PostgREST + Realtime | notifications | PostgREST + WS | Covered | CRUD + realtime via getDb() |
 
 ### Storage (Docker volumes — locked)
 
@@ -234,7 +234,7 @@ Storage bucket string hits via `.from` (not PostgREST tables): `avatars` (4), `r
 | Feature | File (path) | Call Type | Resource | Self-host target | Status | Notes |
 |---|---|---|---|---|---|---|
 | Backend toggle | (new) Admin Backend page | Config | app_config.backend_provider | Node + FE facade | Not started | Admin-only |
-| Data client facade | (new) src/lib/backend/* | Facade | all of the above | getDataClient() | Covered | Phase 3: getDb() + selfhosted restClient |
+| Data client facade | (new) src/lib/backend/* | Facade | all of the above | getDataClient() | Covered | Phase 3–5: getDb() + rest/storage/functions/realtime |
 | PostgREST data path | selfhosted restClient | PostgREST | local tables + RLS | Coolify-internal PostgREST | Covered | Node `/rest/v1` proxy; PostgREST internal |
 | Object storage volumes | Coolify compose | Ops | named Docker volumes | retroscope_uploads (+ buckets) | Covered | Serve/sign via Node; copy script shipped |
 | Coolify deploy | docker-compose.selfhost.yml | Ops | web/api/postgres/postgrest | Coolify resource | Covered | Phase 1–3 compose + db-init RLS helpers |

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,6 +80,7 @@
         "react-router-dom": "^7.6.2",
         "recharts": "^2.12.7",
         "remark-gfm": "^4.0.1",
+        "socket.io-client": "^4.8.3",
         "sonner": "^1.5.0",
         "tailwind-merge": "^2.5.2",
         "tailwindcss-animate": "^1.0.7",
@@ -11464,6 +11465,12 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -14699,9 +14706,9 @@
       "license": "MIT"
     },
     "node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -15039,6 +15046,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.6.tgz",
+      "integrity": "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.21.0",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/entities": {
@@ -21433,6 +21462,34 @@
         "node": ">=8"
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/sonner": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.5.0.tgz",
@@ -23015,9 +23072,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
-      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -23033,6 +23090,14 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/xstate": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "react-router-dom": "^7.6.2",
     "recharts": "^2.12.7",
     "remark-gfm": "^4.0.1",
+    "socket.io-client": "^4.8.3",
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",

--- a/server/README.md
+++ b/server/README.md
@@ -1,4 +1,4 @@
-# Retroscope API (Phase 4 — storage + P0 edge ports)
+# Retroscope API (Phase 5 — realtime Socket.IO)
 
 Fastify service for the self-hosted Coolify stack.
 
@@ -38,6 +38,7 @@ npm run import-auth-users -- --users users.json --identities identities.json
 | GET | `/storage/v1/object/public/:bucket/*` | Public object fetch |
 | POST | `/storage/v1/object/sign/:bucket/*` | Create signed URL |
 | GET | `/storage/v1/object/sign/:bucket/*` | Fetch via signed query token |
+| * | `/socket.io` | Phase 5 realtime (WebSocket); presence / broadcast / postgres_changes |
 | DELETE | `/storage/v1/object/:bucket/*` | Delete object (Bearer) |
 | POST | `/functions/v1/:name` | P0 edge ports (admin + invites); Stripe → 501 keep_on_supabase |
 
@@ -75,8 +76,14 @@ Applied by `db-init` / Postgres init:
 - `postgres/init/02-auth-schema.sql` — local `auth.users` / identities / refresh / verification
 - `postgres/init/03-rls-helpers.sql` — `auth.uid()` / `auth.role()` / `auth.jwt()` + PostgREST grants
 - `postgres/init/04-post-restore-grants.sql` — run after staging `pg_restore`
+- `postgres/init/05-realtime-notify.sql` — `pg_notify('retroscope_changes')` triggers on hot tables
 
 Access JWTs are HS256 with `role=authenticated` and `sub=<user uuid>` so PostgREST RLS matches hosted Supabase.
+
+## Realtime (Phase 5)
+
+Socket.IO on `/socket.io` with rooms `board:{id}`, `poker:{sessionId}`, `team:{id}`, `user:{id}`.
+Enable WebSocket support on the Coolify `api` domain. Admin backend-status reports `checks.realtime`.
 
 ## Staging restore
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -15,13 +15,15 @@
         "jose": "^5.10.0",
         "nodemailer": "^6.10.0",
         "pg": "^8.13.3",
+        "socket.io": "^4.8.3",
         "zod": "^3.24.2"
       },
       "devDependencies": {
         "@types/bcryptjs": "^2.4.6",
-        "@types/node": "^22.13.10",
+        "@types/node": "^22.20.1",
         "@types/nodemailer": "^6.4.17",
         "@types/pg": "^8.11.11",
+        "socket.io-client": "^4.8.3",
         "tsx": "^4.19.3",
         "typescript": "^5.8.2"
       },
@@ -689,6 +691,12 @@
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
       "license": "MIT"
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
     "node_modules/@types/bcryptjs": {
       "version": "2.4.6",
       "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
@@ -696,11 +704,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.20.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
       "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -728,11 +744,33 @@
         "pg-types": "^2.2.0"
       }
     },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/abstract-logging": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
       "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
       "license": "MIT"
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/ajv": {
       "version": "8.20.0",
@@ -821,6 +859,15 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
+    },
     "node_modules/bcryptjs": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
@@ -867,6 +914,23 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -879,6 +943,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/depd": {
@@ -897,6 +978,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.9",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.9.tgz",
+      "integrity": "sha512-clKkw4C7nJ22mGgoVcCg6V/W/TxdNyIOTr89k2ONZu81qqkddPFDF0LXcbAwhzPD8DjkiRCjzuiO6Y+fkpD4vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "@types/ws": "^8.5.12",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.21.0"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.6.tgz",
+      "integrity": "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.21.0",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/esbuild": {
@@ -1283,6 +1417,27 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
@@ -1316,6 +1471,21 @@
         "obliterator": "^2.0.4"
       }
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/nodemailer": {
       "version": "6.10.1",
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
@@ -1323,6 +1493,15 @@
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/obliterator": {
@@ -1725,6 +1904,63 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/socket.io": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz",
+      "integrity": "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.8.tgz",
+      "integrity": "sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.4.1",
+        "ws": "~8.21.0"
+      }
+    },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/sonic-boom": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
@@ -1825,8 +2061,16 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -1841,6 +2085,36 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/xtend": {

--- a/server/package.json
+++ b/server/package.json
@@ -19,13 +19,15 @@
     "jose": "^5.10.0",
     "nodemailer": "^6.10.0",
     "pg": "^8.13.3",
+    "socket.io": "^4.8.3",
     "zod": "^3.24.2"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",
-    "@types/node": "^22.13.10",
+    "@types/node": "^22.20.1",
     "@types/nodemailer": "^6.4.17",
     "@types/pg": "^8.11.11",
+    "socket.io-client": "^4.8.3",
     "tsx": "^4.19.3",
     "typescript": "^5.8.2"
   },

--- a/server/postgres/init/05-realtime-notify.sql
+++ b/server/postgres/init/05-realtime-notify.sql
@@ -1,0 +1,138 @@
+-- Phase 5 (DUN-80): Postgres NOTIFY for self-hosted realtime.
+-- Node API LISTENs on channel retroscope_changes and fans out via Socket.IO.
+--
+-- Coolify compose embeds this via configs.content — keep compose in sync.
+-- SQL must stay free of dollar signs (Compose interpolates them).
+
+CREATE OR REPLACE FUNCTION public.retroscope_notify_change()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS '
+DECLARE
+  payload json;
+  row_new json;
+  row_old json;
+  rooms text[] := ARRAY[]::text[];
+  board_id_text text;
+  team_id_text text;
+  item_id_text text;
+  session_id_text text;
+  user_id_text text;
+  op text := TG_OP;
+BEGIN
+  IF TG_OP = ''DELETE'' THEN
+    row_old := row_to_json(OLD);
+    row_new := NULL;
+  ELSIF TG_OP = ''INSERT'' THEN
+    row_new := row_to_json(NEW);
+    row_old := NULL;
+  ELSE
+    row_new := row_to_json(NEW);
+    row_old := row_to_json(OLD);
+  END IF;
+
+  IF TG_TABLE_NAME IN (''retro_items'', ''retro_votes'', ''retro_board_config'', ''endorsements'') THEN
+    board_id_text := COALESCE(row_new ->> ''board_id'', row_old ->> ''board_id'');
+    IF board_id_text IS NOT NULL THEN
+      rooms := array_append(rooms, ''board:'' || board_id_text);
+    END IF;
+  ELSIF TG_TABLE_NAME = ''retro_boards'' THEN
+    board_id_text := COALESCE(row_new ->> ''id'', row_old ->> ''id'');
+    team_id_text := COALESCE(row_new ->> ''team_id'', row_old ->> ''team_id'');
+    IF board_id_text IS NOT NULL THEN
+      rooms := array_append(rooms, ''board:'' || board_id_text);
+    END IF;
+    IF team_id_text IS NOT NULL THEN
+      rooms := array_append(rooms, ''team:'' || team_id_text);
+    END IF;
+  ELSIF TG_TABLE_NAME = ''retro_comments'' THEN
+    item_id_text := COALESCE(row_new ->> ''item_id'', row_old ->> ''item_id'');
+    IF item_id_text IS NOT NULL THEN
+      rooms := array_append(rooms, ''item:'' || item_id_text);
+      SELECT ri.board_id::text INTO board_id_text FROM public.retro_items ri WHERE ri.id::text = item_id_text LIMIT 1;
+      IF board_id_text IS NOT NULL THEN
+        rooms := array_append(rooms, ''board:'' || board_id_text);
+      END IF;
+    END IF;
+  ELSIF TG_TABLE_NAME = ''poker_sessions'' THEN
+    session_id_text := COALESCE(row_new ->> ''id'', row_old ->> ''id'');
+    team_id_text := COALESCE(row_new ->> ''team_id'', row_old ->> ''team_id'');
+    IF session_id_text IS NOT NULL THEN
+      rooms := array_append(rooms, ''poker:'' || session_id_text);
+    END IF;
+    IF team_id_text IS NOT NULL THEN
+      rooms := array_append(rooms, ''team:'' || team_id_text);
+    END IF;
+  ELSIF TG_TABLE_NAME IN (''poker_session_rounds'', ''poker_session_chat'', ''poker_session_chat_message_reactions'') THEN
+    session_id_text := COALESCE(row_new ->> ''session_id'', row_old ->> ''session_id'');
+    IF session_id_text IS NOT NULL THEN
+      rooms := array_append(rooms, ''poker:'' || session_id_text);
+      SELECT ps.team_id::text INTO team_id_text FROM public.poker_sessions ps WHERE ps.id::text = session_id_text LIMIT 1;
+      IF team_id_text IS NOT NULL THEN
+        rooms := array_append(rooms, ''team:'' || team_id_text);
+      END IF;
+    END IF;
+  ELSIF TG_TABLE_NAME = ''team_action_items'' THEN
+    team_id_text := COALESCE(row_new ->> ''team_id'', row_old ->> ''team_id'');
+    IF team_id_text IS NOT NULL THEN
+      rooms := array_append(rooms, ''team:'' || team_id_text);
+    END IF;
+  ELSIF TG_TABLE_NAME = ''notifications'' THEN
+    user_id_text := COALESCE(row_new ->> ''user_id'', row_old ->> ''user_id'');
+    IF user_id_text IS NOT NULL THEN
+      rooms := array_append(rooms, ''user:'' || user_id_text);
+    END IF;
+  ELSIF TG_TABLE_NAME IN (''feature_flags'', ''feature_flag_user_overrides'', ''feature_flag_team_overrides'') THEN
+    rooms := array_append(rooms, ''feature-flags'');
+  END IF;
+
+  payload := json_build_object(
+    ''schema'', TG_TABLE_SCHEMA,
+    ''table'', TG_TABLE_NAME,
+    ''event'', op,
+    ''new'', row_new,
+    ''old'', row_old,
+    ''rooms'', to_json(rooms)
+  );
+
+  PERFORM pg_notify(''retroscope_changes'', payload::text);
+
+  IF TG_OP = ''DELETE'' THEN
+    RETURN OLD;
+  END IF;
+  RETURN NEW;
+END;
+';
+
+-- Attach triggers only when the table exists (schema may be restored later).
+SELECT format(
+  'DROP TRIGGER IF EXISTS retroscope_notify_%s ON public.%I; CREATE TRIGGER retroscope_notify_%s AFTER INSERT OR UPDATE OR DELETE ON public.%I FOR EACH ROW EXECUTE FUNCTION public.retroscope_notify_change();',
+  replace(tablename, '_', ''),
+  tablename,
+  replace(tablename, '_', ''),
+  tablename
+)
+FROM (VALUES
+  ('retro_items'),
+  ('retro_votes'),
+  ('retro_comments'),
+  ('retro_boards'),
+  ('retro_board_config'),
+  ('team_action_items'),
+  ('poker_sessions'),
+  ('poker_session_rounds'),
+  ('poker_session_chat'),
+  ('poker_session_chat_message_reactions'),
+  ('notifications'),
+  ('feature_flags'),
+  ('feature_flag_user_overrides'),
+  ('feature_flag_team_overrides'),
+  ('endorsements')
+) AS t(tablename)
+WHERE EXISTS (
+  SELECT 1 FROM information_schema.tables
+  WHERE table_schema = 'public' AND table_name = t.tablename
+)
+\gexec

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -2,6 +2,7 @@ import Fastify from 'fastify';
 import cors from '@fastify/cors';
 import { loadConfig } from './config.js';
 import { closePool } from './lib/db.js';
+import { registerRealtime } from './realtime/index.js';
 import { registerAdminRoutes } from './routes/admin.js';
 import { registerAuthRoutes } from './routes/auth.js';
 import { registerFunctionRoutes } from './routes/functions.js';
@@ -66,9 +67,12 @@ async function main(): Promise<void> {
   await registerAuthRoutes(app, config);
   await registerRestProxyRoutes(app, config);
 
+  // Socket.IO attaches to the same HTTP server (WebSocket upgrade on /socket.io).
+  await registerRealtime(app, config);
+
   app.get('/', async () => ({
     name: 'retroscope-api',
-    phase: 4,
+    phase: 5,
     endpoints: [
       '/healthz',
       '/readyz',
@@ -85,6 +89,7 @@ async function main(): Promise<void> {
       '/api/storage/buckets',
       '/storage/v1/object/*',
       '/functions/v1/*',
+      '/socket.io',
     ],
     stripe: {
       decision: 'keep_on_supabase',

--- a/server/src/realtime/filters.ts
+++ b/server/src/realtime/filters.ts
@@ -1,0 +1,72 @@
+/**
+ * Match Supabase-style realtime filters: `col=eq.value` or `col=in.(a,b,c)`.
+ */
+
+export interface PostgresChangeEvent {
+  schema: string;
+  table: string;
+  eventType: 'INSERT' | 'UPDATE' | 'DELETE' | '*';
+  new: Record<string, unknown> | null;
+  old: Record<string, unknown> | null;
+}
+
+export interface PostgresChangeBinding {
+  event: 'INSERT' | 'UPDATE' | 'DELETE' | '*';
+  schema: string;
+  table: string;
+  filter?: string;
+}
+
+function normalizeValue(raw: string): string {
+  return raw.trim();
+}
+
+function rowValueEquals(row: Record<string, unknown>, column: string, expected: string): boolean {
+  if (!(column in row)) return false;
+  const actual = row[column];
+  if (actual === null || actual === undefined) {
+    return expected === 'null';
+  }
+  return String(actual) === expected;
+}
+
+/** Evaluate a single `col=eq.x` / `col=in.(...)` clause against a row. */
+export function matchFilterClause(row: Record<string, unknown> | null, filter?: string): boolean {
+  if (!filter) return true;
+  if (!row) return false;
+
+  const eqMatch = /^([^=]+)=eq\.(.+)$/.exec(filter);
+  if (eqMatch) {
+    const [, column, value] = eqMatch;
+    return rowValueEquals(row, column.trim(), normalizeValue(value));
+  }
+
+  const inMatch = /^([^=]+)=in\.\((.+)\)$/.exec(filter);
+  if (inMatch) {
+    const [, column, list] = inMatch;
+    const values = list.split(',').map((v) => normalizeValue(v.replace(/^"|"$/g, '')));
+    if (!(column.trim() in row)) return false;
+    const actual = row[column.trim()];
+    if (actual === null || actual === undefined) return values.includes('null');
+    return values.includes(String(actual));
+  }
+
+  // Unknown filter shape — fail closed so we do not leak rows.
+  return false;
+}
+
+export function matchPostgresBinding(
+  binding: PostgresChangeBinding,
+  change: PostgresChangeEvent
+): boolean {
+  if (binding.schema !== change.schema) return false;
+  if (binding.table !== change.table) return false;
+  if (binding.event !== '*' && binding.event !== change.eventType) return false;
+
+  const filterRow =
+    change.eventType === 'DELETE'
+      ? change.old
+      : change.new ?? change.old;
+
+  return matchFilterClause(filterRow, binding.filter);
+}

--- a/server/src/realtime/gateway.integration.test.ts
+++ b/server/src/realtime/gateway.integration.test.ts
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import Fastify from 'fastify';
+import { io as ioc, type Socket as ClientSocket } from 'socket.io-client';
+import { signAccessToken } from '../auth/jwt.js';
+import { attachRealtimeGateway, type RealtimeGateway } from './gateway.js';
+import type { AppConfig } from '../config.js';
+
+const SECRET = 'test-secret-key-with-at-least-32-chars!!';
+
+describe('realtime gateway socket protocol', () => {
+  let gateway: RealtimeGateway;
+  let baseUrl: string;
+  let token: string;
+  const clients: ClientSocket[] = [];
+
+  before(async () => {
+    const app = Fastify({ logger: false });
+    const config = {
+      NODE_ENV: 'test',
+      PORT: 0,
+      HOST: '127.0.0.1',
+      allowOrigins: ['*'],
+      JWT_SECRET: SECRET,
+      JWT_ISSUER: 'retroscope-auth',
+      JWT_ACCESS_TTL_SECONDS: 3600,
+      POSTGREST_URL: 'http://localhost:3000',
+      UPLOADS_DIR: '/tmp',
+      ALLOW_ORIGINS: '*',
+      SMTP_PORT: 587,
+      // No DATABASE_URL → LISTEN skipped
+    } as AppConfig;
+
+    gateway = await attachRealtimeGateway(app, config);
+    await app.listen({ port: 0, host: '127.0.0.1' });
+    const address = app.server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('expected TCP address');
+    }
+    baseUrl = `http://127.0.0.1:${address.port}`;
+
+    const signed = await signAccessToken({
+      secret: SECRET,
+      userId: '11111111-1111-1111-1111-111111111111',
+      email: 'qa@example.com',
+      expiresInSeconds: 3600,
+    });
+    token = signed.token;
+
+    // keep app open via gateway; close in after()
+    (globalThis as { __rtApp?: typeof app }).__rtApp = app;
+  });
+
+  after(async () => {
+    for (const c of clients) c.disconnect();
+    await gateway.close();
+    const app = (globalThis as { __rtApp?: { close: () => Promise<void> } }).__rtApp;
+    if (app) await app.close();
+  });
+
+  function connectClient(): Promise<ClientSocket> {
+    return new Promise((resolve, reject) => {
+      const socket = ioc(baseUrl, {
+        path: '/socket.io',
+        transports: ['websocket'],
+        auth: { token },
+      });
+      clients.push(socket);
+      const timer = setTimeout(() => reject(new Error('connect timeout')), 5000);
+      socket.on('connect', () => {
+        clearTimeout(timer);
+        resolve(socket);
+      });
+      socket.on('connect_error', (err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
+    });
+  }
+
+  it('subscribes and relays broadcast + presence', async () => {
+    const a = await connectClient();
+    const b = await connectClient();
+
+    await new Promise<void>((resolve, reject) => {
+      a.emit(
+        'channel:subscribe',
+        {
+          topic: 'poker_session:s1',
+          config: { presence: { key: 'user-a' } },
+          bindings: [],
+        },
+        (status: string) => (status === 'SUBSCRIBED' ? resolve() : reject(new Error(status)))
+      );
+    });
+    await new Promise<void>((resolve, reject) => {
+      b.emit(
+        'channel:subscribe',
+        {
+          topic: 'poker_session:s1',
+          config: { presence: { key: 'user-b' } },
+          bindings: [],
+        },
+        (status: string) => (status === 'SUBSCRIBED' ? resolve() : reject(new Error(status)))
+      );
+    });
+
+    const broadcastSeen = new Promise<unknown>((resolve) => {
+      b.on('broadcast', (msg) => {
+        if (msg.event === 'round_updated') resolve(msg.payload);
+      });
+    });
+
+    a.emit('broadcast:send', {
+      topic: 'poker_session:s1',
+      event: 'round_updated',
+      payload: { round_number: 2 },
+    });
+
+    assert.deepEqual(await broadcastSeen, { round_number: 2 });
+
+    const presenceSync = new Promise<Record<string, unknown>>((resolve) => {
+      b.on('presence', (msg) => {
+        if (msg.event === 'sync' && msg.state?.['user-a']) resolve(msg.state);
+      });
+    });
+
+    a.emit('presence:track', {
+      topic: 'poker_session:s1',
+      key: 'user-a',
+      payload: { user_id: 'user-a' },
+    });
+
+    const state = await presenceSync;
+    assert.ok(state['user-a']);
+  });
+});

--- a/server/src/realtime/gateway.ts
+++ b/server/src/realtime/gateway.ts
@@ -1,0 +1,391 @@
+import type { FastifyInstance } from 'fastify';
+import { Server, type Socket } from 'socket.io';
+import type { AppConfig } from '../config.js';
+import { verifyAccessToken } from '../auth/jwt.js';
+import {
+  matchPostgresBinding,
+  type PostgresChangeBinding,
+  type PostgresChangeEvent,
+} from './filters.js';
+import { PostgresChangeListener, type NotifyChangePayload } from './pgListener.js';
+import { PresenceStore, type PresencePayload } from './presence.js';
+import { channelRoom, roomsForChannelTopic, roomsForTableChange } from './rooms.js';
+
+export interface RealtimeGateway {
+  io: Server;
+  presence: PresenceStore;
+  listener: PostgresChangeListener | null;
+  close: () => Promise<void>;
+  /** True when Socket.IO is up (LISTEN may still be reconnecting). */
+  ok: () => boolean;
+}
+
+interface SocketMeta {
+  userId: string;
+  email?: string;
+  /** topic → postgres bindings registered for that channel */
+  bindings: Map<string, PostgresChangeBinding[]>;
+  /** topic → number of active FE channel instances */
+  topicRefs: Map<string, number>;
+  /** topic → presence key currently tracked by this socket */
+  presenceKeys: Map<string, string>;
+  /** topics this socket has subscribed to */
+  topics: Set<string>;
+}
+
+interface SubscribeMessage {
+  topic: string;
+  config?: {
+    presence?: { key?: string };
+  };
+  bindings?: PostgresChangeBinding[];
+}
+
+interface TrackMessage {
+  topic: string;
+  key?: string;
+  payload: PresencePayload;
+}
+
+interface BroadcastMessage {
+  topic: string;
+  event: string;
+  payload?: unknown;
+}
+
+function getMeta(socket: Socket): SocketMeta {
+  return socket.data.realtime as SocketMeta;
+}
+
+async function authenticateSocket(
+  socket: Socket,
+  config: AppConfig
+): Promise<{ userId: string; email?: string } | null> {
+  const authToken =
+    (socket.handshake.auth?.token as string | undefined) ||
+    (typeof socket.handshake.headers.authorization === 'string'
+      ? socket.handshake.headers.authorization.replace(/^Bearer\s+/i, '')
+      : undefined);
+
+  if (!authToken) {
+    return null;
+  }
+
+  if (!config.JWT_SECRET) {
+    // Dev without JWT: accept opaque token as anonymous-authenticated for dual-path smoke.
+    return { userId: 'anonymous' };
+  }
+
+  try {
+    const claims = await verifyAccessToken(authToken, config.JWT_SECRET);
+    return { userId: claims.sub, email: claims.email };
+  } catch {
+    // Dual-path: hosted Supabase JWTs are not signed with our secret.
+    // Allow connection with a stable opaque id derived from token prefix so
+    // presence still works; postgres fan-out is filter-scoped.
+    const opaque = `hosted:${authToken.slice(0, 12)}`;
+    return { userId: opaque };
+  }
+}
+
+function toClientChange(change: NotifyChangePayload): PostgresChangeEvent {
+  return {
+    schema: change.schema,
+    table: change.table,
+    eventType: change.event,
+    new: change.new,
+    old: change.old,
+  };
+}
+
+function supabaseStylePayload(change: PostgresChangeEvent) {
+  return {
+    schema: change.schema,
+    table: change.table,
+    commit_timestamp: new Date().toISOString(),
+    eventType: change.eventType,
+    new: change.new,
+    old: change.old,
+    errors: null,
+  };
+}
+
+function bindingKey(b: PostgresChangeBinding): string {
+  return `${b.event}|${b.schema}|${b.table}|${b.filter ?? ''}`;
+}
+
+function mergeBindings(
+  prev: PostgresChangeBinding[],
+  incoming: PostgresChangeBinding[]
+): PostgresChangeBinding[] {
+  const map = new Map<string, PostgresChangeBinding>();
+  for (const b of prev) map.set(bindingKey(b), b);
+  for (const b of incoming) map.set(bindingKey(b), b);
+  return [...map.values()];
+}
+
+export async function attachRealtimeGateway(
+  app: FastifyInstance,
+  config: AppConfig
+): Promise<RealtimeGateway> {
+  await app.ready();
+
+  const io = new Server(app.server, {
+    path: '/socket.io',
+    cors: {
+      origin: config.allowOrigins.includes('*') ? true : config.allowOrigins,
+      credentials: true,
+    },
+    transports: ['websocket', 'polling'],
+  });
+
+  const presence = new PresenceStore();
+  let listener: PostgresChangeListener | null = null;
+
+  const fanOutPostgresChange = (raw: NotifyChangePayload) => {
+    const change = toClientChange(raw);
+    const changeRooms = roomsForTableChange({
+      table: raw.table,
+      newRow: raw.new,
+      oldRow: raw.old,
+      extraRooms: raw.rooms,
+    });
+    const payload = supabaseStylePayload(change);
+
+    for (const socket of io.sockets.sockets.values()) {
+      const meta = socket.data.realtime as SocketMeta | undefined;
+      if (!meta) continue;
+
+      for (const [topic, bindings] of meta.bindings) {
+        if (!meta.topics.has(topic)) continue;
+        if (!bindings.some((b) => matchPostgresBinding(b, change))) continue;
+
+        // When we know logical rooms for the row, require the socket joined one.
+        // Bindings with an explicit filter may still match across rooms (e.g. in.(...)).
+        if (changeRooms.length > 0) {
+          const inChangeRoom = changeRooms.some((room) => socket.rooms.has(room));
+          const bindingHasFilter = bindings.some(
+            (b) => matchPostgresBinding(b, change) && Boolean(b.filter)
+          );
+          if (!inChangeRoom && !bindingHasFilter) continue;
+        }
+
+        socket.emit('postgres_changes', { topic, payload });
+      }
+    }
+  };
+
+  if (config.DATABASE_URL) {
+    listener = new PostgresChangeListener(config, fanOutPostgresChange, app.log);
+    await listener.start();
+  } else {
+    app.log.warn('Realtime gateway started without DATABASE_URL (no LISTEN)');
+  }
+
+  io.use(async (socket, next) => {
+    try {
+      const identity = await authenticateSocket(socket, config);
+      if (!identity) {
+        next(new Error('Unauthorized'));
+        return;
+      }
+      socket.data.realtime = {
+        userId: identity.userId,
+        email: identity.email,
+        bindings: new Map(),
+        topicRefs: new Map(),
+        presenceKeys: new Map(),
+        topics: new Set(),
+      } satisfies SocketMeta;
+      next();
+    } catch (error) {
+      next(error instanceof Error ? error : new Error('Unauthorized'));
+    }
+  });
+
+  io.on('connection', (socket) => {
+    const meta = getMeta(socket);
+    app.log.debug({ socketId: socket.id, userId: meta.userId }, 'Realtime socket connected');
+
+    socket.on('channel:subscribe', (msg: SubscribeMessage, ack?: (status: string) => void) => {
+      try {
+        if (!msg?.topic || typeof msg.topic !== 'string') {
+          ack?.('CHANNEL_ERROR');
+          return;
+        }
+        const topic = msg.topic;
+        meta.topics.add(topic);
+        meta.topicRefs.set(topic, (meta.topicRefs.get(topic) ?? 0) + 1);
+
+        const incoming = Array.isArray(msg.bindings) ? msg.bindings : [];
+        const prev = meta.bindings.get(topic) ?? [];
+        meta.bindings.set(topic, mergeBindings(prev, incoming));
+
+        for (const room of roomsForChannelTopic(topic, meta.userId)) {
+          void socket.join(room);
+        }
+
+        // Presence key hint from channel config (Supabase presence.key)
+        if (msg.config?.presence?.key) {
+          meta.presenceKeys.set(topic, msg.config.presence.key);
+        }
+
+        socket.emit('channel:status', { topic, status: 'SUBSCRIBED' });
+        ack?.('SUBSCRIBED');
+      } catch (error) {
+        app.log.warn({ err: error }, 'channel:subscribe failed');
+        ack?.('CHANNEL_ERROR');
+      }
+    });
+
+    socket.on('channel:unsubscribe', (msg: { topic?: string }) => {
+      if (!msg?.topic) return;
+      const topic = msg.topic;
+      const refs = (meta.topicRefs.get(topic) ?? 1) - 1;
+      if (refs > 0) {
+        meta.topicRefs.set(topic, refs);
+        return;
+      }
+
+      meta.topicRefs.delete(topic);
+      meta.topics.delete(topic);
+      meta.bindings.delete(topic);
+
+      const presenceKey = meta.presenceKeys.get(topic);
+      if (presenceKey) {
+        presence.untrack(topic, presenceKey, socket.id);
+        meta.presenceKeys.delete(topic);
+        io.to(channelRoom(topic)).emit('presence', {
+          topic,
+          event: 'leave',
+          key: presenceKey,
+          currentPresences: presence.state(topic),
+        });
+        io.to(channelRoom(topic)).emit('presence', {
+          topic,
+          event: 'sync',
+          state: presence.state(topic),
+        });
+      }
+
+      for (const room of roomsForChannelTopic(topic, meta.userId)) {
+        void socket.leave(room);
+      }
+    });
+
+    socket.on('presence:track', (msg: TrackMessage, ack?: (ok: boolean) => void) => {
+      try {
+        if (!msg?.topic) {
+          ack?.(false);
+          return;
+        }
+        const key =
+          (typeof msg.key === 'string' && msg.key) ||
+          meta.presenceKeys.get(msg.topic) ||
+          meta.userId;
+        meta.presenceKeys.set(msg.topic, key);
+        presence.track(msg.topic, key, socket.id, msg.payload ?? {});
+
+        io.to(channelRoom(msg.topic)).emit('presence', {
+          topic: msg.topic,
+          event: 'join',
+          key,
+          newPresences: { [key]: [msg.payload ?? {}] },
+          currentPresences: presence.state(msg.topic),
+        });
+        io.to(channelRoom(msg.topic)).emit('presence', {
+          topic: msg.topic,
+          event: 'sync',
+          state: presence.state(msg.topic),
+        });
+        ack?.(true);
+      } catch {
+        ack?.(false);
+      }
+    });
+
+    socket.on('presence:untrack', (msg: { topic?: string }, ack?: (ok: boolean) => void) => {
+      try {
+        if (!msg?.topic) {
+          ack?.(false);
+          return;
+        }
+        const key = meta.presenceKeys.get(msg.topic) || meta.userId;
+        presence.untrack(msg.topic, key, socket.id);
+        meta.presenceKeys.delete(msg.topic);
+        io.to(channelRoom(msg.topic)).emit('presence', {
+          topic: msg.topic,
+          event: 'leave',
+          key,
+          currentPresences: presence.state(msg.topic),
+        });
+        io.to(channelRoom(msg.topic)).emit('presence', {
+          topic: msg.topic,
+          event: 'sync',
+          state: presence.state(msg.topic),
+        });
+        ack?.(true);
+      } catch {
+        ack?.(false);
+      }
+    });
+
+    socket.on('broadcast:send', (msg: BroadcastMessage, ack?: (ok: boolean) => void) => {
+      try {
+        if (!msg?.topic || !msg.event) {
+          ack?.(false);
+          return;
+        }
+        io.to(channelRoom(msg.topic)).emit('broadcast', {
+          topic: msg.topic,
+          event: msg.event,
+          payload: msg.payload,
+        });
+        ack?.(true);
+      } catch {
+        ack?.(false);
+      }
+    });
+
+    socket.on('disconnect', () => {
+      const affected = presence.untrackSocket(socket.id);
+      const topics = new Set(affected.map((a) => a.topic));
+      for (const topic of topics) {
+        const keys = affected.filter((a) => a.topic === topic).map((a) => a.key);
+        for (const key of keys) {
+          io.to(channelRoom(topic)).emit('presence', {
+            topic,
+            event: 'leave',
+            key,
+            currentPresences: presence.state(topic),
+          });
+        }
+        io.to(channelRoom(topic)).emit('presence', {
+          topic,
+          event: 'sync',
+          state: presence.state(topic),
+        });
+      }
+    });
+  });
+
+  const gateway: RealtimeGateway = {
+    io,
+    presence,
+    listener,
+    ok: () => true,
+    close: async () => {
+      await listener?.stop();
+      await new Promise<void>((resolve) => {
+        io.close(() => resolve());
+      });
+    },
+  };
+
+  app.addHook('onClose', async () => {
+    await gateway.close();
+  });
+
+  app.log.info('Realtime Socket.IO gateway attached at /socket.io');
+  return gateway;
+}

--- a/server/src/realtime/index.ts
+++ b/server/src/realtime/index.ts
@@ -1,0 +1,38 @@
+import type { Server } from 'socket.io';
+import type { FastifyInstance } from 'fastify';
+import type { AppConfig } from '../config.js';
+import { attachRealtimeGateway, type RealtimeGateway } from './gateway.js';
+
+export type { RealtimeGateway } from './gateway.js';
+export { matchFilterClause, matchPostgresBinding } from './filters.js';
+export { roomsForChannelTopic, roomsForTableChange, channelRoom } from './rooms.js';
+export { PresenceStore } from './presence.js';
+
+let gateway: RealtimeGateway | null = null;
+
+export function getRealtimeGateway(): RealtimeGateway | null {
+  return gateway;
+}
+
+export async function registerRealtime(app: FastifyInstance, config: AppConfig): Promise<RealtimeGateway> {
+  gateway = await attachRealtimeGateway(app, config);
+  return gateway;
+}
+
+export function realtimeHealth(): { ok: boolean; error?: string } {
+  if (!gateway) {
+    return { ok: false, error: 'Realtime gateway not started' };
+  }
+  if (gateway.listener && !gateway.listener.listening) {
+    return { ok: false, error: 'Postgres LISTEN not connected' };
+  }
+  if (!gateway.listener) {
+    return { ok: true, error: 'Socket.IO up; LISTEN skipped (no DATABASE_URL)' };
+  }
+  return { ok: true };
+}
+
+/** Test helper */
+export function getRealtimeIo(): Server | null {
+  return gateway?.io ?? null;
+}

--- a/server/src/realtime/pgListener.ts
+++ b/server/src/realtime/pgListener.ts
@@ -1,0 +1,127 @@
+import type pg from 'pg';
+import type { AppConfig } from '../config.js';
+import { getPool } from '../lib/db.js';
+
+export const REALTIME_NOTIFY_CHANNEL = 'retroscope_changes';
+
+export interface NotifyChangePayload {
+  schema: string;
+  table: string;
+  event: 'INSERT' | 'UPDATE' | 'DELETE';
+  new: Record<string, unknown> | null;
+  old: Record<string, unknown> | null;
+  /** Optional rooms computed in SQL (board lookup for comments, team for rounds). */
+  rooms?: string[];
+}
+
+export type NotifyHandler = (change: NotifyChangePayload) => void;
+
+type RealtimeLog = {
+  info: (obj: unknown, msg?: string) => void;
+  warn: (obj: unknown, msg?: string) => void;
+  error: (obj: unknown, msg?: string) => void;
+};
+
+/**
+ * Dedicated Postgres connection that LISTENs for trigger NOTIFY payloads.
+ */
+export class PostgresChangeListener {
+  private client: pg.PoolClient | null = null;
+  private stopped = false;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(
+    private readonly config: AppConfig,
+    private readonly onChange: NotifyHandler,
+    private readonly log: RealtimeLog
+  ) {}
+
+  async start(): Promise<void> {
+    this.stopped = false;
+    await this.connect();
+  }
+
+  async stop(): Promise<void> {
+    this.stopped = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.client) {
+      try {
+        this.client.removeAllListeners('notification');
+        this.client.removeAllListeners('error');
+        await this.client.query(`UNLISTEN ${REALTIME_NOTIFY_CHANNEL}`);
+      } catch {
+        // ignore
+      }
+      this.client.release();
+      this.client = null;
+    }
+  }
+
+  get listening(): boolean {
+    return this.client !== null && !this.stopped;
+  }
+
+  private async connect(): Promise<void> {
+    if (this.stopped) return;
+
+    const pool = getPool(this.config);
+    if (!pool) {
+      this.log.warn('Realtime LISTEN skipped: DATABASE_URL not configured');
+      return;
+    }
+
+    try {
+      const client = await pool.connect();
+      this.client = client;
+
+      client.on('notification', (msg) => {
+        if (msg.channel !== REALTIME_NOTIFY_CHANNEL || !msg.payload) return;
+        try {
+          const parsed = JSON.parse(msg.payload) as NotifyChangePayload;
+          if (!parsed?.table || !parsed?.event) return;
+          this.onChange({
+            schema: parsed.schema || 'public',
+            table: parsed.table,
+            event: parsed.event,
+            new: parsed.new ?? null,
+            old: parsed.old ?? null,
+            rooms: parsed.rooms,
+          });
+        } catch (error) {
+          this.log.warn({ err: error, payload: msg.payload }, 'Invalid realtime NOTIFY payload');
+        }
+      });
+
+      client.on('error', (err) => {
+        this.log.error({ err }, 'Realtime LISTEN client error');
+        void this.scheduleReconnect();
+      });
+
+      await client.query(`LISTEN ${REALTIME_NOTIFY_CHANNEL}`);
+      this.log.info({ channel: REALTIME_NOTIFY_CHANNEL }, 'Realtime LISTEN started');
+    } catch (error) {
+      this.log.error({ err: error }, 'Failed to start realtime LISTEN');
+      void this.scheduleReconnect();
+    }
+  }
+
+  private async scheduleReconnect(): Promise<void> {
+    if (this.stopped) return;
+    if (this.client) {
+      try {
+        this.client.release(true);
+      } catch {
+        // ignore
+      }
+      this.client = null;
+    }
+    if (this.reconnectTimer) return;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      void this.connect();
+    }, 2_000);
+  }
+}

--- a/server/src/realtime/presence.ts
+++ b/server/src/realtime/presence.ts
@@ -1,0 +1,82 @@
+/**
+ * In-memory presence for a single Node API instance.
+ * Scale-out later can swap this for a Redis adapter.
+ */
+
+export type PresencePayload = Record<string, unknown>;
+
+/** presenceState shape matches Supabase: { [key]: PresencePayload[] } */
+export type PresenceState = Record<string, PresencePayload[]>;
+
+interface TrackedPresence {
+  key: string;
+  payload: PresencePayload;
+  socketId: string;
+}
+
+export class PresenceStore {
+  /** topic → key → socketId → payload (multiple sockets can share a presence key) */
+  private byTopic = new Map<string, Map<string, Map<string, PresencePayload>>>();
+
+  track(topic: string, key: string, socketId: string, payload: PresencePayload): void {
+    let keys = this.byTopic.get(topic);
+    if (!keys) {
+      keys = new Map();
+      this.byTopic.set(topic, keys);
+    }
+    let sockets = keys.get(key);
+    if (!sockets) {
+      sockets = new Map();
+      keys.set(key, sockets);
+    }
+    sockets.set(socketId, payload);
+  }
+
+  untrack(topic: string, key: string, socketId: string): boolean {
+    const keys = this.byTopic.get(topic);
+    if (!keys) return false;
+    const sockets = keys.get(key);
+    if (!sockets) return false;
+    const existed = sockets.delete(socketId);
+    if (sockets.size === 0) keys.delete(key);
+    if (keys.size === 0) this.byTopic.delete(topic);
+    return existed;
+  }
+
+  /** Remove all presence entries for a disconnected socket. Returns affected topics. */
+  untrackSocket(socketId: string): Array<{ topic: string; key: string }> {
+    const affected: Array<{ topic: string; key: string }> = [];
+    for (const [topic, keys] of this.byTopic) {
+      for (const [key, sockets] of keys) {
+        if (sockets.delete(socketId)) {
+          affected.push({ topic, key });
+          if (sockets.size === 0) keys.delete(key);
+        }
+      }
+      if (keys.size === 0) this.byTopic.delete(topic);
+    }
+    return affected;
+  }
+
+  state(topic: string): PresenceState {
+    const keys = this.byTopic.get(topic);
+    if (!keys) return {};
+    const result: PresenceState = {};
+    for (const [key, sockets] of keys) {
+      result[key] = [...sockets.values()];
+    }
+    return result;
+  }
+
+  list(topic: string): TrackedPresence[] {
+    const keys = this.byTopic.get(topic);
+    if (!keys) return [];
+    const out: TrackedPresence[] = [];
+    for (const [key, sockets] of keys) {
+      for (const [socketId, payload] of sockets) {
+        out.push({ key, payload, socketId });
+      }
+    }
+    return out;
+  }
+}

--- a/server/src/realtime/realtime.test.ts
+++ b/server/src/realtime/realtime.test.ts
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { matchFilterClause, matchPostgresBinding } from './filters.js';
+import { roomsForChannelTopic, roomsForTableChange } from './rooms.js';
+import { PresenceStore } from './presence.js';
+
+describe('matchFilterClause', () => {
+  it('matches eq filters', () => {
+    assert.equal(matchFilterClause({ board_id: 'abc' }, 'board_id=eq.abc'), true);
+    assert.equal(matchFilterClause({ board_id: 'abc' }, 'board_id=eq.xyz'), false);
+  });
+
+  it('matches in filters', () => {
+    assert.equal(matchFilterClause({ session_id: 's2' }, 'session_id=in.(s1,s2,s3)'), true);
+    assert.equal(matchFilterClause({ session_id: 's9' }, 'session_id=in.(s1,s2)'), false);
+  });
+
+  it('allows empty filter', () => {
+    assert.equal(matchFilterClause({ a: 1 }, undefined), true);
+  });
+});
+
+describe('matchPostgresBinding', () => {
+  it('respects event and table', () => {
+    const binding = {
+      event: '*' as const,
+      schema: 'public',
+      table: 'retro_votes',
+      filter: 'board_id=eq.b1',
+    };
+    assert.equal(
+      matchPostgresBinding(binding, {
+        schema: 'public',
+        table: 'retro_votes',
+        eventType: 'INSERT',
+        new: { board_id: 'b1', id: 'v1' },
+        old: null,
+      }),
+      true
+    );
+    assert.equal(
+      matchPostgresBinding(binding, {
+        schema: 'public',
+        table: 'retro_items',
+        eventType: 'INSERT',
+        new: { board_id: 'b1' },
+        old: null,
+      }),
+      false
+    );
+  });
+
+  it('uses old row for DELETE', () => {
+    const binding = {
+      event: 'DELETE' as const,
+      schema: 'public',
+      table: 'notifications',
+      filter: 'user_id=eq.u1',
+    };
+    assert.equal(
+      matchPostgresBinding(binding, {
+        schema: 'public',
+        table: 'notifications',
+        eventType: 'DELETE',
+        new: null,
+        old: { user_id: 'u1', id: 'n1' },
+      }),
+      true
+    );
+  });
+});
+
+describe('roomsForChannelTopic', () => {
+  it('maps retro and poker topics', () => {
+    const retro = roomsForChannelTopic('retro-board-b1');
+    assert.ok(retro.includes('channel:retro-board-b1'));
+    assert.ok(retro.includes('board:b1'));
+
+    const poker = roomsForChannelTopic('poker_session:s1');
+    assert.ok(poker.includes('poker:s1'));
+
+    const notif = roomsForChannelTopic('realtime:notifications', 'u1');
+    assert.ok(notif.includes('user:u1'));
+  });
+});
+
+describe('roomsForTableChange', () => {
+  it('derives board and poker rooms', () => {
+    assert.deepEqual(
+      roomsForTableChange({
+        table: 'retro_votes',
+        newRow: { board_id: 'b1' },
+        oldRow: null,
+      }),
+      ['board:b1']
+    );
+    const rooms = roomsForTableChange({
+      table: 'poker_session_rounds',
+      newRow: { session_id: 's1' },
+      oldRow: null,
+      extraRooms: ['team:t1'],
+    });
+    assert.ok(rooms.includes('poker:s1'));
+    assert.ok(rooms.includes('team:t1'));
+  });
+});
+
+describe('PresenceStore', () => {
+  it('tracks sync and leave', () => {
+    const store = new PresenceStore();
+    store.track('retro-board-1', 'user-a', 'sock1', { user_id: 'user-a' });
+    store.track('retro-board-1', 'user-b', 'sock2', { user_id: 'user-b' });
+    assert.deepEqual(Object.keys(store.state('retro-board-1')).sort(), ['user-a', 'user-b']);
+    store.untrackSocket('sock1');
+    assert.deepEqual(Object.keys(store.state('retro-board-1')), ['user-b']);
+  });
+});

--- a/server/src/realtime/rooms.ts
+++ b/server/src/realtime/rooms.ts
@@ -1,0 +1,123 @@
+/**
+ * Map FE channel topics + table changes onto Socket.IO / logical rooms.
+ * Rooms: `channel:{topic}`, `board:{id}`, `poker:{sessionId}`, `team:{id}`, `user:{id}`, `item:{id}`, `feature-flags`
+ */
+
+export function channelRoom(topic: string): string {
+  return `channel:${topic}`;
+}
+
+/** Logical rooms a client should join when subscribing to a channel topic. */
+export function roomsForChannelTopic(topic: string, userId?: string | null): string[] {
+  const rooms = new Set<string>([channelRoom(topic)]);
+
+  let match: RegExpMatchArray | null;
+
+  if ((match = topic.match(/^retro-board-(.+)$/))) {
+    rooms.add(`board:${match[1]}`);
+  } else if ((match = topic.match(/^poker_session:(.+)$/))) {
+    rooms.add(`poker:${match[1]}`);
+  } else if ((match = topic.match(/^poker_session_rounds-changes-for-(.+)$/))) {
+    rooms.add(`poker:${match[1]}`);
+  } else if ((match = topic.match(/^poker_chat:(.+)$/))) {
+    rooms.add(`poker:${match[1]}`);
+  } else if ((match = topic.match(/^poker_chat_reactions:(.+)$/))) {
+    rooms.add(`poker:${match[1]}`);
+  } else if ((match = topic.match(/^team-action-items-(.+)$/))) {
+    rooms.add(`team:${match[1]}`);
+  } else if ((match = topic.match(/^team-action-items-tab-(.+)$/))) {
+    rooms.add(`team:${match[1]}`);
+  } else if ((match = topic.match(/^team-poker-sessions-(.+)$/))) {
+    rooms.add(`team:${match[1]}`);
+  } else if ((match = topic.match(/^team-poker-rounds-([0-9a-fA-F-]{36})/))) {
+    rooms.add(`team:${match[1]}`);
+  } else if ((match = topic.match(/^endorsements-(.+)$/))) {
+    rooms.add(`board:${match[1]}`);
+  } else if ((match = topic.match(/^tai-comments-(.+)$/))) {
+    rooms.add(`item:${match[1]}`);
+  } else if (topic === 'feature-flags-realtime') {
+    rooms.add('feature-flags');
+  } else if (topic === 'realtime:notifications' && userId) {
+    rooms.add(`user:${userId}`);
+  }
+
+  return [...rooms];
+}
+
+function idOf(row: Record<string, unknown> | null | undefined, key: string): string | null {
+  if (!row) return null;
+  const value = row[key];
+  if (value === null || value === undefined) return null;
+  return String(value);
+}
+
+/**
+ * Derive fan-out rooms for a postgres change. Uses NEW for INSERT/UPDATE and OLD for DELETE.
+ * Callers may pass `extraRooms` (e.g. board id looked up from retro_items for comments).
+ */
+export function roomsForTableChange(params: {
+  table: string;
+  newRow: Record<string, unknown> | null;
+  oldRow: Record<string, unknown> | null;
+  extraRooms?: string[];
+}): string[] {
+  const row = params.newRow ?? params.oldRow;
+  const rooms = new Set<string>(params.extraRooms ?? []);
+
+  switch (params.table) {
+    case 'retro_items':
+    case 'retro_votes':
+    case 'retro_board_config':
+    case 'endorsements': {
+      const boardId = idOf(row, 'board_id');
+      if (boardId) rooms.add(`board:${boardId}`);
+      break;
+    }
+    case 'retro_comments': {
+      const itemId = idOf(row, 'item_id');
+      if (itemId) rooms.add(`item:${itemId}`);
+      break;
+    }
+    case 'retro_boards': {
+      const boardId = idOf(row, 'id');
+      const teamId = idOf(row, 'team_id');
+      if (boardId) rooms.add(`board:${boardId}`);
+      if (teamId) rooms.add(`team:${teamId}`);
+      break;
+    }
+    case 'poker_sessions': {
+      const sessionId = idOf(row, 'id');
+      const teamId = idOf(row, 'team_id');
+      if (sessionId) rooms.add(`poker:${sessionId}`);
+      if (teamId) rooms.add(`team:${teamId}`);
+      break;
+    }
+    case 'poker_session_rounds':
+    case 'poker_session_chat':
+    case 'poker_session_chat_message_reactions': {
+      const sessionId = idOf(row, 'session_id');
+      if (sessionId) rooms.add(`poker:${sessionId}`);
+      break;
+    }
+    case 'team_action_items': {
+      const teamId = idOf(row, 'team_id');
+      if (teamId) rooms.add(`team:${teamId}`);
+      break;
+    }
+    case 'notifications': {
+      const userId = idOf(row, 'user_id');
+      if (userId) rooms.add(`user:${userId}`);
+      break;
+    }
+    case 'feature_flags':
+    case 'feature_flag_user_overrides':
+    case 'feature_flag_team_overrides': {
+      rooms.add('feature-flags');
+      break;
+    }
+    default:
+      break;
+  }
+
+  return [...rooms];
+}

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -5,6 +5,7 @@ import { checkPostgrest } from '../lib/postgrest.js';
 import { extractBearer } from '../lib/requestAuth.js';
 import { requireAdminForMigrate } from '../lib/migrateAuth.js';
 import { verifyAccessToken } from '../auth/jwt.js';
+import { realtimeHealth } from '../realtime/index.js';
 import {
   getMigrateCapability,
   MigrateError,
@@ -56,7 +57,7 @@ export async function registerAdminRoutes(app: FastifyInstance, config: AppConfi
         },
         postgres,
         postgrest,
-        realtime: { ok: false, error: 'Not implemented until Phase 5' },
+        realtime: realtimeHealth(),
       },
       timestamp: new Date().toISOString(),
     };

--- a/src/components/admin/BackendProviderToggle.tsx
+++ b/src/components/admin/BackendProviderToggle.tsx
@@ -175,7 +175,7 @@ export const BackendProviderToggle: React.FC = () => {
           title: 'Backend provider saved',
           description:
             saved.mode === 'selfhosted'
-              ? 'Global mode is self-hosted: auth uses Node /auth/v1/*; table CRUD uses local PostgREST via /rest/v1 (realtime still hosted until Phase 5).'
+              ? 'Global mode is self-hosted: auth uses Node /auth/v1/*; table CRUD uses local PostgREST via /rest/v1; realtime uses Socket.IO on the API.'
               : 'Global mode is hosted Supabase for auth and data.',
         });
       }

--- a/src/components/team/TeamActionItems.tsx
+++ b/src/components/team/TeamActionItems.tsx
@@ -3,7 +3,7 @@ import { useSearchParams } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Check } from 'lucide-react';
-import { supabase } from '@/integrations/supabase/client';
+import { getDb } from '@/lib/backend/getDataClient';
 import { processMentionsForDisplay } from '@/components/shared/TiptapEditorWithMentions';
 import { TeamActionItemsComments } from '@/components/team/TeamActionItemsComments';
 import { useTeamData } from '@/contexts/TeamDataContext';
@@ -41,7 +41,7 @@ export const TeamActionItems: React.FC<TeamActionItemsProps> = ({ teamId }) => {
   React.useEffect(() => {
     if (!teamId) return;
     
-    const channel = supabase.channel(`team-action-items-tab-${teamId}`)
+    const channel = getDb().channel(`team-action-items-tab-${teamId}`)
       .on('postgres_changes', { 
         event: '*', 
         schema: 'public', 
@@ -53,7 +53,7 @@ export const TeamActionItems: React.FC<TeamActionItemsProps> = ({ teamId }) => {
       .subscribe();
     
     return () => { 
-      supabase.removeChannel(channel); 
+      getDb().removeChannel(channel); 
     };
   }, [teamId, refetch]);
 
@@ -84,12 +84,12 @@ export const TeamActionItems: React.FC<TeamActionItemsProps> = ({ teamId }) => {
   }, [visible]);
 
   const markDone = async (id: string, next: boolean) => {
-    await supabase.from('team_action_items').update({ done: next, done_at: next ? new Date().toISOString() : null }).eq('id', id);
+    await getDb().from('team_action_items').update({ done: next, done_at: next ? new Date().toISOString() : null }).eq('id', id);
     refetch();
   };
 
   const assign = async (id: string, userId: string | null) => {
-    await supabase.from('team_action_items').update({ assigned_to: userId }).eq('id', id);
+    await getDb().from('team_action_items').update({ assigned_to: userId }).eq('id', id);
     refetch();
   };
 

--- a/src/components/team/TeamActionItemsComments.tsx
+++ b/src/components/team/TeamActionItemsComments.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Send, Trash2, MessageSquare } from 'lucide-react';
-import { supabase } from '@/integrations/supabase/client';
+import { getDb } from '@/lib/backend/getDataClient';
 import { TiptapEditorWithMentions, processMentionsForDisplay } from '@/components/shared/TiptapEditorWithMentions';
 import { UserAvatar } from '@/components/ui/UserAvatar';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
@@ -24,7 +24,7 @@ export const TeamActionItemsComments: React.FC<Props> = ({ sourceItemId, teamId 
 
   // Set up realtime updates
   useEffect(() => {
-    const channel = supabase.channel(`tai-comments-${sourceItemId}`)
+    const channel = getDb().channel(`tai-comments-${sourceItemId}`)
       .on('postgres_changes', { 
         event: '*', 
         schema: 'public', 
@@ -35,7 +35,7 @@ export const TeamActionItemsComments: React.FC<Props> = ({ sourceItemId, teamId 
       })
       .subscribe();
     return () => { 
-      supabase.removeChannel(channel); 
+      getDb().removeChannel(channel); 
     };
   }, [sourceItemId, refetch]);
 
@@ -51,7 +51,7 @@ export const TeamActionItemsComments: React.FC<Props> = ({ sourceItemId, teamId 
   const addComment = async () => {
     if (!content.trim()) return;
     const author = profile?.full_name || user?.email || 'Anonymous';
-    const { error } = await supabase
+    const { error } = await getDb()
       .from('retro_comments')
       .insert([{ item_id: sourceItemId, text: content, author, author_id: user?.id || null }]);
     if (!error) {
@@ -61,7 +61,7 @@ export const TeamActionItemsComments: React.FC<Props> = ({ sourceItemId, teamId 
   };
 
   const deleteComment = async (id: string) => {
-    await supabase.from('retro_comments').delete().eq('id', id);
+    await getDb().from('retro_comments').delete().eq('id', id);
     refetch(); // Refetch comments after deleting
   };
 

--- a/src/components/team/TeamPokerSessions.tsx
+++ b/src/components/team/TeamPokerSessions.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { supabase } from '@/integrations/supabase/client';
+import { getDb } from '@/lib/backend/getDataClient';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
@@ -190,7 +190,7 @@ export const TeamPokerSessions: React.FC<TeamPokerSessionsProps> = ({
   useEffect(() => {
     const fetchSessions = async () => {
       setLoading(true);
-      const { data, error } = await supabase
+      const { data, error } = await getDb()
         .from('poker_sessions')
         .select(
           `id, room_id, created_at,
@@ -215,7 +215,7 @@ export const TeamPokerSessions: React.FC<TeamPokerSessionsProps> = ({
 
     fetchSessions();
 
-    const channelSessions = supabase
+    const channelSessions = getDb()
       .channel(`team-poker-sessions-${teamId}`)
       .on('postgres_changes', {
         event: '*',
@@ -228,7 +228,7 @@ export const TeamPokerSessions: React.FC<TeamPokerSessionsProps> = ({
       .subscribe();
 
     return () => {
-      supabase.removeChannel(channelSessions);
+      getDb().removeChannel(channelSessions);
     };
   }, [teamId]);
 
@@ -242,7 +242,7 @@ export const TeamPokerSessions: React.FC<TeamPokerSessionsProps> = ({
     if (!sessionIdsKey) return;
 
     const fetchSessions = async () => {
-      const { data, error } = await supabase
+      const { data, error } = await getDb()
         .from('poker_sessions')
         .select(
           `id, room_id, created_at,
@@ -270,7 +270,7 @@ export const TeamPokerSessions: React.FC<TeamPokerSessionsProps> = ({
         ? `session_id=eq.${ids[0]}`
         : `session_id=in.(${ids.join(',')})`;
 
-    const channelRounds = supabase
+    const channelRounds = getDb()
       .channel(`team-poker-rounds-${teamId}-${sessionIdsKey}`)
       .on(
         'postgres_changes',
@@ -287,7 +287,7 @@ export const TeamPokerSessions: React.FC<TeamPokerSessionsProps> = ({
       .subscribe();
 
     return () => {
-      supabase.removeChannel(channelRounds);
+      getDb().removeChannel(channelRounds);
     };
   }, [teamId, sessionIdsKey]);
 
@@ -300,7 +300,7 @@ export const TeamPokerSessions: React.FC<TeamPokerSessionsProps> = ({
     optimisticPendingDeleteIds.current.add(id);
     setSessions((prev) => prev.filter((s) => s.id !== id));
 
-    const { error } = await supabase.from('poker_sessions').delete().eq('id', id);
+    const { error } = await getDb().from('poker_sessions').delete().eq('id', id);
     optimisticPendingDeleteIds.current.delete(id);
 
     if (error) {

--- a/src/components/team/TeamSidebar.tsx
+++ b/src/components/team/TeamSidebar.tsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Users, Calendar, FolderOpen, Check } from 'lucide-react';
-import { supabase } from '@/integrations/supabase/client';
+import { getDb } from '@/lib/backend/getDataClient';
 import { Button } from '@/components/ui/button';
 import { processMentionsForDisplay } from '@/components/shared/TiptapEditorWithMentions';
 import { useTeamMembers } from '@/hooks/useTeamMembers';
@@ -24,7 +24,7 @@ export const TeamSidebar: React.FC<TeamSidebarProps> = ({ team, boardCount, memb
   useEffect(() => {
     let isMounted = true;
     const load = async () => {
-      const { data } = await supabase
+      const { data } = await getDb()
         .from('team_action_items')
         .select('id, text, assigned_to')
         .eq('team_id', team.id)
@@ -33,7 +33,7 @@ export const TeamSidebar: React.FC<TeamSidebarProps> = ({ team, boardCount, memb
       if (isMounted) setOpenActions(data || []);
     };
     load();
-    const channel = supabase.channel(`team-action-items-${team.id}`)
+    const channel = getDb().channel(`team-action-items-${team.id}`)
       .on('postgres_changes', { event: '*', schema: 'public', table: 'team_action_items', filter: `team_id=eq.${team.id}` }, (payload) => {
         const n = payload.new as any; const o = payload.old as any;
         setOpenActions(prev => {
@@ -51,14 +51,14 @@ export const TeamSidebar: React.FC<TeamSidebarProps> = ({ team, boardCount, memb
         });
       })
       .subscribe();
-    return () => { isMounted = false; supabase.removeChannel(channel); };
+    return () => { isMounted = false; getDb().removeChannel(channel); };
   }, [team.id]);
 
   const markDone = async (id: string) => {
     const prev = openActions;
     // Optimistic remove
     setOpenActions(curr => curr.filter(i => i.id !== id));
-    const { error } = await supabase
+    const { error } = await getDb()
       .from('team_action_items')
       .update({ done: true, done_at: new Date().toISOString() })
       .eq('id', id);
@@ -71,7 +71,7 @@ export const TeamSidebar: React.FC<TeamSidebarProps> = ({ team, boardCount, memb
   const assign = async (id: string, userId: string | null) => {
     // Optimistic
     setOpenActions(curr => curr.map(i => i.id === id ? { ...i, assigned_to: userId } : i));
-    const { error } = await supabase
+    const { error } = await getDb()
       .from('team_action_items')
       .update({ assigned_to: userId })
       .eq('id', id);

--- a/src/contexts/FeatureFlagContext.tsx
+++ b/src/contexts/FeatureFlagContext.tsx
@@ -1,6 +1,5 @@
 import React, { createContext, useState, useContext, useEffect, useCallback } from 'react';
-import { supabase } from '@/integrations/supabase/client';
-import { RealtimeChannel } from '@supabase/supabase-js';
+import { getDb } from '@/lib/backend/getDataClient';
 import { useSubscription } from '@/hooks/useSubscription';
 import { useAuth } from '@/hooks/useAuth';
 import { useLocation } from 'react-router-dom';
@@ -40,7 +39,7 @@ export const FeatureFlagProvider: React.FC<{ children: React.ReactNode }> = ({ c
     useEffect(() => {
         const fetchTierFlags = async () => {
             try {
-                const { data, error } = await supabase
+                const { data, error } = await getDb()
                     .from('app_config')
                     .select('value')
                     .eq('key', 'tier_limits')
@@ -66,12 +65,12 @@ export const FeatureFlagProvider: React.FC<{ children: React.ReactNode }> = ({ c
         const activeTeamId = activeTeamIdFromRoute();
         try {
             const [{ data: userData, error: userError }, teamResult] = await Promise.all([
-                supabase
+                getDb()
                     .from('feature_flag_user_overrides')
                     .select('flag_name, state')
                     .eq('user_id', userId),
                 activeTeamId
-                    ? supabase
+                    ? getDb()
                         .from('feature_flag_team_overrides')
                         .select('flag_name, state')
                         .eq('team_id', activeTeamId)
@@ -105,13 +104,14 @@ export const FeatureFlagProvider: React.FC<{ children: React.ReactNode }> = ({ c
     }, [profile?.id, activeTeamIdFromRoute]);
 
     useEffect(() => {
-        let channel: RealtimeChannel;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        let channel: any;
 
         const setupFlags = async () => {
             setLoading(true);
             try {
                 const [{ data, error }] = await Promise.all([
-                    supabase
+                    getDb()
                     .from('feature_flags')
                     .select('flag_name, is_enabled'),
                     loadOverrides(),
@@ -130,7 +130,7 @@ export const FeatureFlagProvider: React.FC<{ children: React.ReactNode }> = ({ c
                 setLoading(false);
             }
 
-            channel = supabase
+            channel = getDb()
                 .channel('feature-flags-realtime')
                 .on(
                     'postgres_changes',
@@ -179,7 +179,7 @@ export const FeatureFlagProvider: React.FC<{ children: React.ReactNode }> = ({ c
 
         return () => {
             if (channel) {
-                supabase.removeChannel(channel);
+                getDb().removeChannel(channel);
             }
         };
     }, [loadOverrides]);

--- a/src/hooks/use-jira-ticket-metadata.ts
+++ b/src/hooks/use-jira-ticket-metadata.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { supabase } from '@/integrations/supabase/client';
+import { getDb } from '@/lib/backend/getDataClient';
 import type { PokerSessionRound } from '@/hooks/usePokerSessionHistory';
 import { isSyntheticRoundTicket } from '@/lib/pokerRoundTicketPlaceholder';
 import { POKER_JIRA_STORY_POINTS_BROADCAST_EVENT } from '@/lib/pokerJiraStoryPointsBroadcast';
@@ -85,7 +86,7 @@ export function useJiraTicketMetadata(
   useEffect(() => {
     if (!sessionId) return;
 
-    const channel = supabase.channel(`poker_session:${sessionId}`);
+    const channel = getDb().channel(`poker_session:${sessionId}`);
     channel.on(
       'broadcast',
       { event: POKER_JIRA_STORY_POINTS_BROADCAST_EVENT },
@@ -102,7 +103,7 @@ export function useJiraTicketMetadata(
     );
     channel.subscribe();
     return () => {
-      supabase.removeChannel(channel);
+      getDb().removeChannel(channel);
     };
   }, [sessionId]);
 

--- a/src/hooks/useEndorsements.ts
+++ b/src/hooks/useEndorsements.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { supabase } from '@/integrations/supabase/client';
+import { getDb } from '@/lib/backend/getDataClient';
 import { useAuth } from '@/hooks/useAuth';
 import { useToast } from '@/hooks/use-toast';
 
@@ -26,7 +26,7 @@ export function useEndorsements(boardId: string | null, teamId: string | null) {
   const fetchEndorsements = useCallback(async () => {
     if (!boardId || !teamId) return;
     try {
-      const { data, error } = await supabase
+      const { data, error } = await getDb()
         .from('endorsements')
         .select('*')
         .eq('board_id', boardId)
@@ -48,7 +48,7 @@ export function useEndorsements(boardId: string | null, teamId: string | null) {
   useEffect(() => {
     if (!boardId || !teamId || !effectiveUserId) return;
 
-    const channel = supabase
+    const channel = getDb()
       .channel(`endorsements-${boardId}`)
       .on(
         'postgres_changes',
@@ -83,13 +83,13 @@ export function useEndorsements(boardId: string | null, teamId: string | null) {
       .subscribe();
 
     return () => {
-      supabase.removeChannel(channel);
+      getDb().removeChannel(channel);
     };
   }, [boardId, teamId, effectiveUserId]);
 
   const giveEndorsement = useCallback(async (toUserId: string, endorsementTypeId: string) => {
     if (!boardId || !teamId || !effectiveUserId) return;
-    const { error } = await supabase
+    const { error } = await getDb()
       .from('endorsements')
       .insert({
         board_id: boardId,
@@ -112,7 +112,7 @@ export function useEndorsements(boardId: string | null, teamId: string | null) {
   const revokeEndorsement = useCallback(async (endorsementId: string) => {
     // Optimistic update
     setEndorsements(prev => prev.filter(e => e.id !== endorsementId));
-    const { error } = await supabase
+    const { error } = await getDb()
       .from('endorsements')
       .delete()
       .eq('id', endorsementId);

--- a/src/lib/backend/getDataClient.ts
+++ b/src/lib/backend/getDataClient.ts
@@ -99,9 +99,9 @@ export function getDb(): DataClient {
 /**
  * Facade for choosing hosted Supabase vs self-hosted clients.
  *
- * Phase 4: when mode is selfhosted, `.from()` / `.rpc()` hit local PostgREST
- * via Node `/rest/v1`, `.storage` hits Docker volume routes, and P0
- * `.functions` hit Node `/functions/v1/*`. Realtime still hosted until Phase 5.
+ * Phase 5: when mode is selfhosted, `.from()` / `.rpc()` hit local PostgREST
+ * via Node `/rest/v1`, `.storage` hits Docker volume routes, P0 `.functions`
+ * hit Node `/functions/v1/*`, and `.channel()` uses the Socket.IO realtime adapter.
  */
 export async function getDataClient(): Promise<ResolvedBackendClient> {
   const config = cachedConfig ?? (await fetchBackendProviderConfig());

--- a/src/lib/backend/selfhosted/dataClient.ts
+++ b/src/lib/backend/selfhosted/dataClient.ts
@@ -1,4 +1,3 @@
-import { supabase } from '@/integrations/supabase/client';
 import { getAuthClient, getCachedAuthBackendMode } from '@/lib/auth/client';
 import {
   createFunctionsClient,
@@ -9,26 +8,34 @@ import {
   type SelfHostedRestClient,
 } from '@/lib/backend/selfhosted/restClient';
 import {
+  createRealtimeClient,
+  type SelfHostedRealtimeChannel,
+  type SelfHostedRealtimeClient,
+} from '@/lib/backend/selfhosted/realtimeClient';
+import {
   createStorageClient,
   type SelfHostedStorageClient,
 } from '@/lib/backend/selfhosted/storageClient';
 
 /**
- * Hybrid self-hosted data client (Phase 4):
+ * Hybrid self-hosted data client (Phase 5):
  * - `.from()` / `.rpc()` → local PostgREST via Node `/rest/v1`
  * - `.storage` → Node Docker volume (`/storage/v1/object/*`)
  * - `.functions` → Node P0 ports (`/functions/v1/*`); Stripe/Jira/Slack may 501
- * - `.channel()` → hosted Supabase temporarily (Phase 5 realtime)
+ * - `.channel()` → Socket.IO realtime adapter (Phase 5)
  * - `.auth` → FE auth facade (Node `/auth/v1` when mode is selfhosted)
  */
 export type SelfHostedDataClient = SelfHostedRestClient & {
   auth: ReturnType<typeof getAuthClient>;
-  channel: typeof supabase.channel;
-  removeChannel: typeof supabase.removeChannel;
-  getChannels: typeof supabase.getChannels;
+  channel: (
+    topic: string,
+    opts?: Parameters<SelfHostedRealtimeClient['channel']>[1]
+  ) => SelfHostedRealtimeChannel;
+  removeChannel: (channel: SelfHostedRealtimeChannel) => Promise<'ok' | 'timed out' | 'error'>;
+  getChannels: () => SelfHostedRealtimeChannel[];
   functions: SelfHostedFunctionsClient;
   storage: SelfHostedStorageClient;
-  realtime: typeof supabase.realtime;
+  realtime: SelfHostedRealtimeClient;
 };
 
 async function resolveAccessToken(): Promise<string | null> {
@@ -44,6 +51,7 @@ export function createSelfHostedDataClient(apiBaseUrl: string): SelfHostedDataCl
   const rest = createRestClient(apiBaseUrl, resolveAccessToken);
   const storage = createStorageClient(apiBaseUrl, resolveAccessToken);
   const functions = createFunctionsClient(apiBaseUrl, resolveAccessToken);
+  const realtime = createRealtimeClient(apiBaseUrl, resolveAccessToken);
 
   return {
     from: rest.from,
@@ -51,14 +59,12 @@ export function createSelfHostedDataClient(apiBaseUrl: string): SelfHostedDataCl
     get auth() {
       return getAuthClient();
     },
-    channel: (...args: Parameters<typeof supabase.channel>) => supabase.channel(...args),
-    removeChannel: (...args: Parameters<typeof supabase.removeChannel>) =>
-      supabase.removeChannel(...args),
-    getChannels: (...args: Parameters<typeof supabase.getChannels>) =>
-      supabase.getChannels(...args),
+    channel: (topic, opts) => realtime.channel(topic, opts),
+    removeChannel: (channel) => realtime.removeChannel(channel),
+    getChannels: () => realtime.getChannels(),
     functions,
     storage,
-    realtime: supabase.realtime,
+    realtime,
   };
 }
 

--- a/src/lib/backend/selfhosted/realtimeClient.test.ts
+++ b/src/lib/backend/selfhosted/realtimeClient.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  SelfHostedRealtimeChannel,
+  SelfHostedRealtimeClient,
+} from './realtimeClient';
+
+describe('SelfHostedRealtimeChannel local filtering', () => {
+  it('invokes postgres_changes callbacks that match filters', () => {
+    const client = {
+      ensureConnected: vi.fn(),
+      registerChannel: vi.fn(),
+      getSocket: vi.fn(() => null),
+      getChannels: vi.fn(() => []),
+    } as unknown as SelfHostedRealtimeClient;
+
+    const channel = new SelfHostedRealtimeChannel('retro-board-b1', client);
+    const seen: string[] = [];
+    channel.on(
+      'postgres_changes',
+      { event: 'INSERT', schema: 'public', table: 'retro_votes', filter: 'board_id=eq.b1' },
+      (payload) => {
+        seen.push(String(payload.new.id));
+      }
+    );
+
+    channel.handlePostgres({
+      schema: 'public',
+      table: 'retro_votes',
+      eventType: 'INSERT',
+      new: { id: 'v1', board_id: 'b1' },
+      old: {},
+    });
+    channel.handlePostgres({
+      schema: 'public',
+      table: 'retro_votes',
+      eventType: 'INSERT',
+      new: { id: 'v2', board_id: 'other' },
+      old: {},
+    });
+
+    expect(seen).toEqual(['v1']);
+  });
+
+  it('routes broadcast events by name', () => {
+    const client = {
+      ensureConnected: vi.fn(),
+      registerChannel: vi.fn(),
+      getSocket: vi.fn(() => null),
+      getChannels: vi.fn(() => []),
+    } as unknown as SelfHostedRealtimeClient;
+
+    const channel = new SelfHostedRealtimeChannel('poker_session:s1', client);
+    const events: string[] = [];
+    channel.on('broadcast', { event: 'round_updated' }, ({ event }) => {
+      events.push(event);
+    });
+    channel.handleBroadcast('round_updated', { x: 1 });
+    channel.handleBroadcast('other', { x: 2 });
+    expect(events).toEqual(['round_updated']);
+  });
+
+  it('updates presenceState on sync', () => {
+    const client = {
+      ensureConnected: vi.fn(),
+      registerChannel: vi.fn(),
+      getSocket: vi.fn(() => null),
+      getChannels: vi.fn(() => []),
+    } as unknown as SelfHostedRealtimeClient;
+
+    const channel = new SelfHostedRealtimeChannel('retro-board-b1', client, {
+      config: { presence: { key: 'u1' } },
+    });
+    let synced = false;
+    channel.on('presence', { event: 'sync' }, () => {
+      synced = true;
+    });
+    channel.handlePresence({
+      event: 'sync',
+      state: { u1: [{ user_id: 'u1' }] },
+    });
+    expect(synced).toBe(true);
+    expect(channel.presenceState()).toEqual({ u1: [{ user_id: 'u1' }] });
+  });
+});

--- a/src/lib/backend/selfhosted/realtimeClient.ts
+++ b/src/lib/backend/selfhosted/realtimeClient.ts
@@ -1,0 +1,387 @@
+import { io, type Socket } from 'socket.io-client';
+
+export type RealtimeChannelStatus =
+  | 'SUBSCRIBED'
+  | 'TIMED_OUT'
+  | 'CHANNEL_ERROR'
+  | 'CLOSED';
+
+type PostgresEvent = 'INSERT' | 'UPDATE' | 'DELETE' | '*';
+
+export interface PostgresChangeFilter {
+  event: PostgresEvent;
+  schema: string;
+  table: string;
+  filter?: string;
+}
+
+export interface PostgresChangePayload {
+  schema: string;
+  table: string;
+  commit_timestamp?: string;
+  eventType: 'INSERT' | 'UPDATE' | 'DELETE';
+  new: Record<string, unknown>;
+  old: Record<string, unknown>;
+  errors?: unknown;
+}
+
+type PresenceEvent = 'sync' | 'join' | 'leave';
+type BroadcastCallback = (message: { event: string; payload: unknown }) => void;
+type PresenceCallback = (data: {
+  key?: string;
+  newPresences?: Record<string, unknown[]>;
+  leftPresences?: Record<string, unknown[]>;
+  currentPresences?: Record<string, unknown[]>;
+}) => void;
+type PostgresCallback = (payload: PostgresChangePayload) => void;
+type SubscribeCallback = (status: RealtimeChannelStatus, err?: Error) => void | Promise<void>;
+
+interface ChannelConfig {
+  config?: {
+    presence?: { key?: string };
+  };
+}
+
+interface Binding {
+  type: 'postgres_changes' | 'presence' | 'broadcast';
+  filter: PostgresChangeFilter | { event: string } | { event: PresenceEvent };
+  callback: PostgresCallback | PresenceCallback | BroadcastCallback;
+}
+
+/**
+ * Minimal Supabase-compatible RealtimeChannel used by retro/poker hooks.
+ */
+export class SelfHostedRealtimeChannel {
+  private bindings: Binding[] = [];
+  private joined = false;
+  private presenceKey: string | undefined;
+  private localPresenceState: Record<string, Record<string, unknown>[]> = {};
+  private status: RealtimeChannelStatus | 'CLOSED' = 'CLOSED';
+
+  constructor(
+    public readonly topic: string,
+    private readonly client: SelfHostedRealtimeClient,
+    private readonly channelConfig?: ChannelConfig
+  ) {
+    this.presenceKey = channelConfig?.config?.presence?.key;
+  }
+
+  on(
+    type: 'postgres_changes',
+    filter: PostgresChangeFilter,
+    callback: PostgresCallback
+  ): this;
+  on(type: 'presence', filter: { event: PresenceEvent }, callback: PresenceCallback): this;
+  on(type: 'broadcast', filter: { event: string }, callback: BroadcastCallback): this;
+  on(
+    type: 'postgres_changes' | 'presence' | 'broadcast',
+    filter: PostgresChangeFilter | { event: string } | { event: PresenceEvent },
+    callback: PostgresCallback | PresenceCallback | BroadcastCallback
+  ): this {
+    this.bindings.push({ type, filter, callback });
+    return this;
+  }
+
+  subscribe(callback?: SubscribeCallback): this {
+    void this.client.ensureConnected().then(async (socket) => {
+      if (!socket) {
+        this.status = 'CHANNEL_ERROR';
+        await callback?.('CHANNEL_ERROR', new Error('No realtime socket'));
+        return;
+      }
+
+      const pgBindings = this.bindings
+        .filter((b) => b.type === 'postgres_changes')
+        .map((b) => b.filter as PostgresChangeFilter);
+
+      socket.emit(
+        'channel:subscribe',
+        {
+          topic: this.topic,
+          config: this.channelConfig?.config,
+          bindings: pgBindings,
+        },
+        async (status: string) => {
+          if (status === 'SUBSCRIBED') {
+            this.joined = true;
+            this.status = 'SUBSCRIBED';
+            this.client.registerChannel(this);
+            await callback?.('SUBSCRIBED');
+          } else {
+            this.status = 'CHANNEL_ERROR';
+            await callback?.('CHANNEL_ERROR');
+          }
+        }
+      );
+    });
+    return this;
+  }
+
+  async track(payload: Record<string, unknown>): Promise<'ok' | 'timed out' | 'error'> {
+    const socket = await this.client.ensureConnected();
+    if (!socket || !this.joined) return 'error';
+    return new Promise((resolve) => {
+      socket.emit(
+        'presence:track',
+        { topic: this.topic, key: this.presenceKey, payload },
+        (ok: boolean) => resolve(ok ? 'ok' : 'error')
+      );
+    });
+  }
+
+  async untrack(): Promise<'ok' | 'timed out' | 'error'> {
+    const socket = await this.client.ensureConnected();
+    if (!socket) return 'error';
+    return new Promise((resolve) => {
+      socket.emit('presence:untrack', { topic: this.topic }, (ok: boolean) =>
+        resolve(ok ? 'ok' : 'error')
+      );
+    });
+  }
+
+  presenceState(): Record<string, Record<string, unknown>[]> {
+    return this.localPresenceState;
+  }
+
+  async send(args: {
+    type: 'broadcast';
+    event: string;
+    payload?: unknown;
+  }): Promise<'ok' | 'timed out' | 'error'> {
+    const socket = await this.client.ensureConnected();
+    if (!socket || !this.joined) return 'error';
+    return new Promise((resolve) => {
+      socket.emit(
+        'broadcast:send',
+        { topic: this.topic, event: args.event, payload: args.payload },
+        (ok: boolean) => resolve(ok ? 'ok' : 'error')
+      );
+    });
+  }
+
+  /** @internal */
+  handlePostgres(payload: PostgresChangePayload): void {
+    for (const binding of this.bindings) {
+      if (binding.type !== 'postgres_changes') continue;
+      const filter = binding.filter as PostgresChangeFilter;
+      if (filter.schema !== payload.schema || filter.table !== payload.table) continue;
+      if (filter.event !== '*' && filter.event !== payload.eventType) continue;
+      if (filter.filter) {
+        const row =
+          payload.eventType === 'DELETE' ? payload.old : payload.new ?? payload.old;
+        if (!matchClientFilter(row, filter.filter)) continue;
+      }
+      (binding.callback as PostgresCallback)(payload);
+    }
+  }
+
+  /** @internal */
+  handlePresence(msg: {
+    event: PresenceEvent;
+    key?: string;
+    state?: Record<string, Record<string, unknown>[]>;
+    newPresences?: Record<string, unknown[]>;
+    leftPresences?: Record<string, unknown[]>;
+    currentPresences?: Record<string, unknown[]>;
+  }): void {
+    if (msg.state) {
+      this.localPresenceState = msg.state;
+    } else if (msg.currentPresences) {
+      this.localPresenceState = msg.currentPresences as Record<string, Record<string, unknown>[]>;
+    }
+
+    for (const binding of this.bindings) {
+      if (binding.type !== 'presence') continue;
+      const filter = binding.filter as { event: PresenceEvent };
+      if (filter.event !== msg.event) continue;
+      (binding.callback as PresenceCallback)({
+        key: msg.key,
+        newPresences: msg.newPresences,
+        leftPresences: msg.leftPresences,
+        currentPresences: msg.currentPresences ?? this.localPresenceState,
+      });
+    }
+  }
+
+  /** @internal */
+  handleBroadcast(event: string, payload: unknown): void {
+    for (const binding of this.bindings) {
+      if (binding.type !== 'broadcast') continue;
+      const filter = binding.filter as { event: string };
+      if (filter.event !== event) continue;
+      (binding.callback as BroadcastCallback)({ event, payload });
+    }
+  }
+
+  get isJoined(): boolean {
+    return this.joined;
+  }
+
+  /** @internal */
+  async teardown(): Promise<void> {
+    const socket = this.client.getSocket();
+    const siblingsStillJoined = this.client
+      .getChannels()
+      .some((c) => c !== this && c.topic === this.topic && c.isJoined);
+    if (socket && this.joined && !siblingsStillJoined) {
+      socket.emit('channel:unsubscribe', { topic: this.topic });
+    }
+    this.joined = false;
+    this.status = 'CLOSED';
+    this.bindings = [];
+  }
+}
+
+function matchClientFilter(row: Record<string, unknown> | null | undefined, filter: string): boolean {
+  if (!row) return false;
+  const eqMatch = /^([^=]+)=eq\.(.+)$/.exec(filter);
+  if (eqMatch) {
+    const [, column, value] = eqMatch;
+    return String(row[column.trim()]) === value.trim();
+  }
+  const inMatch = /^([^=]+)=in\.\((.+)\)$/.exec(filter);
+  if (inMatch) {
+    const [, column, list] = inMatch;
+    const values = list.split(',').map((v) => v.trim().replace(/^"|"$/g, ''));
+    return values.includes(String(row[column.trim()]));
+  }
+  return true;
+}
+
+export class SelfHostedRealtimeClient {
+  private socket: Socket | null = null;
+  private connecting: Promise<Socket | null> | null = null;
+  private channels: SelfHostedRealtimeChannel[] = [];
+
+  constructor(
+    private readonly apiBaseUrl: string,
+    private readonly getAccessToken: () => Promise<string | null> | string | null
+  ) {}
+
+  channel(topic: string, opts?: ChannelConfig): SelfHostedRealtimeChannel {
+    // Always create a new channel instance (Supabase allows multiple joins on one topic).
+    const channel = new SelfHostedRealtimeChannel(topic, this, opts);
+    this.channels.push(channel);
+    return channel;
+  }
+
+  async removeChannel(channel: SelfHostedRealtimeChannel): Promise<'ok' | 'timed out' | 'error'> {
+    await channel.teardown();
+    this.channels = this.channels.filter((c) => c !== channel);
+    return 'ok';
+  }
+
+  getChannels(): SelfHostedRealtimeChannel[] {
+    return [...this.channels];
+  }
+
+  getSocket(): Socket | null {
+    return this.socket;
+  }
+
+  /** @internal */
+  registerChannel(_channel: SelfHostedRealtimeChannel): void {
+    // Channel already tracked at construction; keep hook for subscribe ack.
+  }
+
+  async ensureConnected(): Promise<Socket | null> {
+    if (this.socket?.connected) return this.socket;
+    if (this.connecting) return this.connecting;
+
+    this.connecting = (async () => {
+      const token = await this.getAccessToken();
+      const base = this.apiBaseUrl.replace(/\/$/, '');
+
+      const socket = io(base, {
+        path: '/socket.io',
+        transports: ['websocket', 'polling'],
+        auth: { token: token ?? '' },
+        autoConnect: true,
+        reconnection: true,
+      });
+
+      this.socket = socket;
+      this.bindSocketHandlers(socket);
+
+      try {
+        await new Promise<void>((resolve, reject) => {
+          const timer = setTimeout(() => {
+            reject(new Error('Realtime connection timed out'));
+          }, 10_000);
+          socket.once('connect', () => {
+            clearTimeout(timer);
+            resolve();
+          });
+          socket.once('connect_error', (err) => {
+            clearTimeout(timer);
+            reject(err);
+          });
+        });
+      } catch (err) {
+        console.warn('[selfhosted realtime] connect failed', err);
+        socket.disconnect();
+        this.socket = null;
+        return null;
+      }
+
+      return this.socket;
+    })().finally(() => {
+      this.connecting = null;
+    });
+
+    return this.connecting;
+  }
+
+  private channelsForTopic(topic: string): SelfHostedRealtimeChannel[] {
+    return this.channels.filter((c) => c.topic === topic);
+  }
+
+  private bindSocketHandlers(socket: Socket): void {
+    socket.on('postgres_changes', (msg: { topic: string; payload: PostgresChangePayload }) => {
+      for (const channel of this.channelsForTopic(msg.topic)) {
+        channel.handlePostgres(msg.payload);
+      }
+    });
+
+    socket.on(
+      'presence',
+      (msg: {
+        topic: string;
+        event: PresenceEvent;
+        key?: string;
+        state?: Record<string, Record<string, unknown>[]>;
+        newPresences?: Record<string, unknown[]>;
+        currentPresences?: Record<string, unknown[]>;
+      }) => {
+        for (const channel of this.channelsForTopic(msg.topic)) {
+          channel.handlePresence(msg);
+        }
+      }
+    );
+
+    socket.on('broadcast', (msg: { topic: string; event: string; payload: unknown }) => {
+      for (const channel of this.channelsForTopic(msg.topic)) {
+        channel.handleBroadcast(msg.event, msg.payload);
+      }
+    });
+
+    socket.on('channel:status', (msg: { topic: string; status: RealtimeChannelStatus }) => {
+      if (msg.status === 'CHANNEL_ERROR') {
+        console.warn('[selfhosted realtime] channel error', msg.topic);
+      }
+    });
+  }
+
+  disconnect(): void {
+    this.socket?.disconnect();
+    this.socket = null;
+    this.channels = [];
+  }
+}
+
+export function createRealtimeClient(
+  apiBaseUrl: string,
+  getAccessToken: () => Promise<string | null> | string | null
+): SelfHostedRealtimeClient {
+  return new SelfHostedRealtimeClient(apiBaseUrl, getAccessToken);
+}

--- a/src/lib/pokerJiraStoryPointsBroadcast.ts
+++ b/src/lib/pokerJiraStoryPointsBroadcast.ts
@@ -1,4 +1,4 @@
-import { supabase } from '@/integrations/supabase/client';
+import { getDb } from '@/lib/backend/getDataClient';
 
 /** Broadcast on `poker_session:${sessionId}` so all clients refresh story-point labels without refetching Jira. */
 export const POKER_JIRA_STORY_POINTS_BROADCAST_EVENT = 'jira_story_points_updated';
@@ -7,7 +7,7 @@ export async function broadcastPokerSessionJiraStoryPoints(
   sessionId: string,
   payload: { issueKey: string; points: number | null }
 ): Promise<void> {
-  const channel = supabase.channel(`poker_session:${sessionId}`);
+  const channel = getDb().channel(`poker_session:${sessionId}`);
   try {
     await new Promise<void>((resolve, reject) => {
       channel.subscribe((status) => {
@@ -23,6 +23,6 @@ export async function broadcastPokerSessionJiraStoryPoints(
       payload,
     });
   } finally {
-    supabase.removeChannel(channel);
+    getDb().removeChannel(channel);
   }
 }

--- a/tasks/tasks-self-host-node-postgres.md
+++ b/tasks/tasks-self-host-node-postgres.md
@@ -67,10 +67,10 @@ Status values: Not started | In progress | Blocked | In review | Done
 
 | # | Task Name | Task Description | Status | Blocked By | Notes |
 |---|---|---|---|---|---|
-| 5.1 | WebSocket gateway | Socket.IO + room model for boards/sessions/users | Not started | 1.1, 3.2 | |
-| 5.2 | Postgres notify hooks | Triggers or LISTEN on hot tables | Not started | 5.1 | |
-| 5.3 | FE realtime adapter | Subset of supabase channel/presence/broadcast API | Not started | 5.1, 1.3 | |
-| 5.4 | Collaborative QA | Retro voting + poker presence/rounds under self-hosted mode | Not started | 5.3 | |
+| 5.1 | WebSocket gateway | Socket.IO + room model for boards/sessions/users | Done | 1.1, 3.2 | `/socket.io` on Node API; rooms `board:`/`poker:`/`team:`/`user:` |
+| 5.2 | Postgres notify hooks | Triggers or LISTEN on hot tables | Done | 5.1 | `05-realtime-notify.sql` → `retroscope_changes` |
+| 5.3 | FE realtime adapter | Subset of supabase channel/presence/broadcast API | Done | 5.1, 1.3 | `selfhosted/realtimeClient.ts` wired via `getDb()` |
+| 5.4 | Collaborative QA | Retro voting + poker presence/rounds under self-hosted mode | In progress | 5.3 | Unit tests + adapter parity; full dual-client QA on Coolify |
 
 ### Phase 6 — Cutover
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **DUN-80 / Phase 5** self-hosted realtime so collaborative retro + poker work when `backend_provider=selfhosted`, without Supabase Realtime.

### Server
- Socket.IO gateway on `/socket.io` with rooms `board:{id}`, `poker:{sessionId}`, `team:{id}`, `user:{id}`
- In-memory presence + broadcast relay
- Postgres `LISTEN retroscope_changes` fan-out for `postgres_changes`
- Trigger SQL in `server/postgres/init/05-realtime-notify.sql` (embedded in Coolify compose `db-init`)
- Admin `backend-status` now reports realtime health

### Frontend
- `src/lib/backend/selfhosted/realtimeClient.ts` — Supabase-compatible subset (`channel` / `on(postgres_changes|presence|broadcast)` / `track` / `send` / `subscribe`)
- Wired through `createSelfHostedDataClient` / `getDb()`
- Migrated remaining `.channel()` call sites off direct hosted Supabase

### Testing
- Server: 46 passed (Socket.IO broadcast/presence integration included); 3 auth DB integration tests cancelled (no local Postgres here)
- FE: vitest realtime adapter tests passed (filter / broadcast / presence)
- Full dual-browser Coolify QA still recommended for Phase 5.4 soak

### Deploy notes
- Enable **WebSocket** on the Coolify API domain
- Redeploy so `db-init` applies `05-realtime-notify.sql` (requires public tables already restored)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-80](https://linear.app/dungeon-dwellers/issue/DUN-80/self-host-phase-5-self-hosted-realtime-retro-poker)

<div><a href="https://cursor.com/agents/bc-6b0a924d-59d8-4b56-bf5f-cd9982aaf547?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b0a924d-59d8-4b56-bf5f-cd9982aaf547&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

