### PR TITLE
fix(api): Fastify crash on Phase 5 realtime startup

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -2,7 +2,7 @@ import Fastify from 'fastify';
 import cors from '@fastify/cors';
 import { loadConfig } from './config.js';
 import { closePool } from './lib/db.js';
-import { registerRealtime } from './realtime/index.js';
+import { getRealtimeGateway, registerRealtime } from './realtime/index.js';
 import { registerAdminRoutes } from './routes/admin.js';
 import { registerAuthRoutes } from './routes/auth.js';
 import { registerFunctionRoutes } from './routes/functions.js';
@@ -67,9 +67,6 @@ async function main(): Promise<void> {
   await registerAuthRoutes(app, config);
   await registerRestProxyRoutes(app, config);
 
-  // Socket.IO attaches to the same HTTP server (WebSocket upgrade on /socket.io).
-  await registerRealtime(app, config);
-
   app.get('/', async () => ({
     name: 'retroscope-api',
     phase: 5,
@@ -97,6 +94,11 @@ async function main(): Promise<void> {
     },
   }));
 
+  // Register before listen/ready — Fastify rejects addHook after the instance has started.
+  app.addHook('onClose', async () => {
+    await getRealtimeGateway()?.close();
+  });
+
   const shutdown = async (signal: string) => {
     app.log.info({ signal }, 'Shutting down');
     await app.close();
@@ -109,6 +111,9 @@ async function main(): Promise<void> {
 
   await app.listen({ port: config.PORT, host: config.HOST });
   app.log.info(`Retroscope API listening on ${config.HOST}:${config.PORT}`);
+
+  // Attach Socket.IO to the listening HTTP server (WebSocket upgrade on /socket.io).
+  await registerRealtime(app, config);
 }
 
 main().catch((error) => {

--- a/server/src/realtime/boot-order.test.ts
+++ b/server/src/realtime/boot-order.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { after, describe, it } from 'node:test';
+import Fastify from 'fastify';
+import cors from '@fastify/cors';
+import { attachRealtimeGateway } from './gateway.js';
+import type { AppConfig } from '../config.js';
+
+/**
+ * Regression for FST_ERR_INSTANCE_ALREADY_LISTENING:
+ * Socket.IO must attach after listen; hooks/routes must be registered before.
+ */
+describe('realtime Fastify boot order', () => {
+  const apps: Array<{ close: () => Promise<void> }> = [];
+
+  after(async () => {
+    for (const app of apps) {
+      await app.close().catch(() => undefined);
+    }
+  });
+
+  it('boots like production: routes → onClose hook → listen → attach Socket.IO', async () => {
+    const app = Fastify({ logger: false });
+    apps.push(app);
+
+    await app.register(cors, { origin: true });
+    app.get('/healthz', async () => ({ status: 'healthy' }));
+    app.get('/', async () => ({ phase: 5 }));
+
+    let closed = false;
+    let gatewayClose: (() => Promise<void>) | null = null;
+    app.addHook('onClose', async () => {
+      closed = true;
+      await gatewayClose?.();
+    });
+
+    await app.listen({ port: 0, host: '127.0.0.1' });
+
+    const gateway = await attachRealtimeGateway(app, {
+      NODE_ENV: 'test',
+      PORT: 0,
+      HOST: '127.0.0.1',
+      allowOrigins: ['*'],
+      JWT_SECRET: 'test-secret-key-with-at-least-32-chars!!',
+      JWT_ISSUER: 'retroscope-auth',
+      JWT_ACCESS_TTL_SECONDS: 3600,
+      POSTGREST_URL: 'http://localhost:3000',
+      UPLOADS_DIR: '/tmp',
+      ALLOW_ORIGINS: '*',
+      SMTP_PORT: 587,
+    } as AppConfig);
+    gatewayClose = () => gateway.close();
+
+    const address = app.server.address();
+    assert.ok(address && typeof address !== 'string');
+    const res = await fetch(`http://127.0.0.1:${address.port}/healthz`);
+    assert.equal(res.status, 200);
+
+    await app.close();
+    assert.equal(closed, true);
+  });
+});

--- a/server/src/realtime/gateway.integration.test.ts
+++ b/server/src/realtime/gateway.integration.test.ts
@@ -31,8 +31,8 @@ describe('realtime gateway socket protocol', () => {
       // No DATABASE_URL → LISTEN skipped
     } as AppConfig;
 
-    gateway = await attachRealtimeGateway(app, config);
     await app.listen({ port: 0, host: '127.0.0.1' });
+    gateway = await attachRealtimeGateway(app, config);
     const address = app.server.address();
     if (!address || typeof address === 'string') {
       throw new Error('expected TCP address');

--- a/server/src/realtime/gateway.ts
+++ b/server/src/realtime/gateway.ts
@@ -128,7 +128,11 @@ export async function attachRealtimeGateway(
   app: FastifyInstance,
   config: AppConfig
 ): Promise<RealtimeGateway> {
-  await app.ready();
+  // Must run after app.listen() so app.server exists and Fastify has finished booting.
+  // Do not call app.ready()/addHook here — Fastify rejects both after start/boot.
+  if (!app.server) {
+    throw new Error('Realtime gateway requires app.server; call after app.listen()');
+  }
 
   const io = new Server(app.server, {
     path: '/socket.io',
@@ -381,10 +385,6 @@ export async function attachRealtimeGateway(
       });
     },
   };
-
-  app.addHook('onClose', async () => {
-    await gateway.close();
-  });
 
   app.log.info('Realtime Socket.IO gateway attached at /socket.io');
   return gateway;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After merging Phase 5 (#198), the API crashed on boot:

```
FastifyError: Fastify instance is already listening. Cannot call "addHook"!
  at attachRealtimeGateway (...)
```

Root cause: the realtime gateway called `app.ready()` then `app.addHook('onClose')`, and `index.ts` also registered routes after that. Fastify rejects hook/route registration after the instance has booted/started.

## Fix

- Register all HTTP routes + `onClose` **before** `listen`
- Attach Socket.IO **after** `app.listen()` using the live `app.server`
- Remove `ready()` / `addHook` from `attachRealtimeGateway`
- Add a boot-order regression test

## Test plan

- [x] `npm run typecheck` in `server/`
- [x] realtime unit + gateway integration + boot-order tests pass
- [ ] Coolify redeploy: `/healthz` healthy, API logs show `Realtime Socket.IO gateway attached`
- [ ] Admin Backend realtime chip OK under `selfhosted`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-80](https://linear.app/dungeon-dwellers/issue/DUN-80/self-host-phase-5-self-hosted-realtime-retro-poker)

<div><a href="https://cursor.com/agents/bc-6b0a924d-59d8-4b56-bf5f-cd9982aaf547?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b0a924d-59d8-4b56-bf5f-cd9982aaf547&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

