### PR TITLE
fix(api): backend-provider PUT blocked by app_config RLS

### DIFF
--- a/COOLIFY_SELFHOST.md
+++ b/COOLIFY_SELFHOST.md
@@ -173,6 +173,8 @@ Init SQL applied on every Coolify deploy via `db-init`:
 - `server/postgres/init/01-roles.sql` — `anon` / `authenticated` / `service_role` / `authenticator`
 - `server/postgres/init/02-auth-schema.sql` — local auth tables
 - `server/postgres/init/03-rls-helpers.sql` — `auth.uid()` / `auth.role()` / `auth.jwt()` + grants
+- `server/postgres/init/05-realtime-notify.sql` — realtime NOTIFY triggers
+- `server/postgres/init/06-app-config-server.sql` — Node helpers to upsert/read `app_config` (bypasses admin-only RLS)
 
 After restore, confirm:
 

--- a/docker-compose.selfhost.prebuilt.yml
+++ b/docker-compose.selfhost.prebuilt.yml
@@ -406,6 +406,45 @@ configs:
         WHERE table_schema = 'public' AND table_name = t.tablename
       )
       \gexec
+  # Keep in sync with server/postgres/init/06-app-config-server.sql
+  # (SQL must stay free of `$` — Compose interpolates them).
+  retroscope_app_config_sql:
+    content: |
+      -- Trusted server helpers for Node API app_config reads/writes.
+      -- Local PostgREST RLS on app_config is admin-only; retroscope_app has no JWT
+      -- claims, so plain SELECT/INSERT hits RLS. These SECURITY DEFINER functions
+      -- run as the owner (postgres via db-init) and bypass RLS for the API only.
+      --
+      -- Coolify compose embeds this via configs.content — keep compose in sync.
+      -- SQL must stay free of dollar signs (Compose interpolates them).
+
+      CREATE OR REPLACE FUNCTION public.server_get_app_config(p_key text)
+      RETURNS text
+      LANGUAGE sql
+      SECURITY DEFINER
+      SET search_path = public
+      STABLE
+      AS '
+        SELECT value FROM public.app_config WHERE key = p_key LIMIT 1;
+      ';
+
+      CREATE OR REPLACE FUNCTION public.server_upsert_app_config(p_key text, p_value text)
+      RETURNS void
+      LANGUAGE plpgsql
+      SECURITY DEFINER
+      SET search_path = public
+      AS '
+      BEGIN
+        INSERT INTO public.app_config (key, value)
+        VALUES (p_key, p_value)
+        ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value;
+      END;
+      ';
+
+      REVOKE ALL ON FUNCTION public.server_get_app_config(text) FROM PUBLIC;
+      REVOKE ALL ON FUNCTION public.server_upsert_app_config(text, text) FROM PUBLIC;
+      GRANT EXECUTE ON FUNCTION public.server_get_app_config(text) TO retroscope_app;
+      GRANT EXECUTE ON FUNCTION public.server_upsert_app_config(text, text) TO retroscope_app;
 
 services:
   postgres:
@@ -426,6 +465,8 @@ services:
         target: /docker-entrypoint-initdb.d/03-rls-helpers.sql
       - source: retroscope_realtime_sql
         target: /docker-entrypoint-initdb.d/05-realtime-notify.sql
+      - source: retroscope_app_config_sql
+        target: /docker-entrypoint-initdb.d/06-app-config-server.sql
     expose:
       - '5432'
     healthcheck:
@@ -459,6 +500,8 @@ services:
         target: /init/03-rls-helpers.sql
       - source: retroscope_realtime_sql
         target: /init/05-realtime-notify.sql
+      - source: retroscope_app_config_sql
+        target: /init/06-app-config-server.sql
     command:
       [
         'psql',
@@ -472,6 +515,8 @@ services:
         '/init/03-rls-helpers.sql',
         '-f',
         '/init/05-realtime-notify.sql',
+        '-f',
+        '/init/06-app-config-server.sql',
       ]
     depends_on:
       postgres:

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -403,6 +403,45 @@ configs:
         WHERE table_schema = 'public' AND table_name = t.tablename
       )
       \gexec
+  # Keep in sync with server/postgres/init/06-app-config-server.sql
+  # (SQL must stay free of `$` — Compose interpolates them).
+  retroscope_app_config_sql:
+    content: |
+      -- Trusted server helpers for Node API app_config reads/writes.
+      -- Local PostgREST RLS on app_config is admin-only; retroscope_app has no JWT
+      -- claims, so plain SELECT/INSERT hits RLS. These SECURITY DEFINER functions
+      -- run as the owner (postgres via db-init) and bypass RLS for the API only.
+      --
+      -- Coolify compose embeds this via configs.content — keep compose in sync.
+      -- SQL must stay free of dollar signs (Compose interpolates them).
+
+      CREATE OR REPLACE FUNCTION public.server_get_app_config(p_key text)
+      RETURNS text
+      LANGUAGE sql
+      SECURITY DEFINER
+      SET search_path = public
+      STABLE
+      AS '
+        SELECT value FROM public.app_config WHERE key = p_key LIMIT 1;
+      ';
+
+      CREATE OR REPLACE FUNCTION public.server_upsert_app_config(p_key text, p_value text)
+      RETURNS void
+      LANGUAGE plpgsql
+      SECURITY DEFINER
+      SET search_path = public
+      AS '
+      BEGIN
+        INSERT INTO public.app_config (key, value)
+        VALUES (p_key, p_value)
+        ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value;
+      END;
+      ';
+
+      REVOKE ALL ON FUNCTION public.server_get_app_config(text) FROM PUBLIC;
+      REVOKE ALL ON FUNCTION public.server_upsert_app_config(text, text) FROM PUBLIC;
+      GRANT EXECUTE ON FUNCTION public.server_get_app_config(text) TO retroscope_app;
+      GRANT EXECUTE ON FUNCTION public.server_upsert_app_config(text, text) TO retroscope_app;
 
 services:
   postgres:
@@ -423,6 +462,8 @@ services:
         target: /docker-entrypoint-initdb.d/03-rls-helpers.sql
       - source: retroscope_realtime_sql
         target: /docker-entrypoint-initdb.d/05-realtime-notify.sql
+      - source: retroscope_app_config_sql
+        target: /docker-entrypoint-initdb.d/06-app-config-server.sql
     expose:
       - '5432'
     healthcheck:
@@ -456,6 +497,8 @@ services:
         target: /init/03-rls-helpers.sql
       - source: retroscope_realtime_sql
         target: /init/05-realtime-notify.sql
+      - source: retroscope_app_config_sql
+        target: /init/06-app-config-server.sql
     command:
       [
         'psql',
@@ -469,6 +512,8 @@ services:
         '/init/03-rls-helpers.sql',
         '-f',
         '/init/05-realtime-notify.sql',
+        '-f',
+        '/init/06-app-config-server.sql',
       ]
     depends_on:
       postgres:

--- a/server/README.md
+++ b/server/README.md
@@ -77,6 +77,7 @@ Applied by `db-init` / Postgres init:
 - `postgres/init/03-rls-helpers.sql` — `auth.uid()` / `auth.role()` / `auth.jwt()` + PostgREST grants
 - `postgres/init/04-post-restore-grants.sql` — run after staging `pg_restore`
 - `postgres/init/05-realtime-notify.sql` — `pg_notify('retroscope_changes')` triggers on hot tables
+- `postgres/init/06-app-config-server.sql` — SECURITY DEFINER helpers so Node can read/write `app_config` despite admin-only RLS
 
 Access JWTs are HS256 with `role=authenticated` and `sub=<user uuid>` so PostgREST RLS matches hosted Supabase.
 

--- a/server/postgres/init/06-app-config-server.sql
+++ b/server/postgres/init/06-app-config-server.sql
@@ -1,0 +1,35 @@
+-- Trusted server helpers for Node API app_config reads/writes.
+-- Local PostgREST RLS on app_config is admin-only; retroscope_app has no JWT
+-- claims, so plain SELECT/INSERT hits RLS. These SECURITY DEFINER functions
+-- run as the owner (postgres via db-init) and bypass RLS for the API only.
+--
+-- Coolify compose embeds this via configs.content — keep compose in sync.
+-- SQL must stay free of dollar signs (Compose interpolates them).
+
+CREATE OR REPLACE FUNCTION public.server_get_app_config(p_key text)
+RETURNS text
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+STABLE
+AS '
+  SELECT value FROM public.app_config WHERE key = p_key LIMIT 1;
+';
+
+CREATE OR REPLACE FUNCTION public.server_upsert_app_config(p_key text, p_value text)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS '
+BEGIN
+  INSERT INTO public.app_config (key, value)
+  VALUES (p_key, p_value)
+  ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value;
+END;
+';
+
+REVOKE ALL ON FUNCTION public.server_get_app_config(text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.server_upsert_app_config(text, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.server_get_app_config(text) TO retroscope_app;
+GRANT EXECUTE ON FUNCTION public.server_upsert_app_config(text, text) TO retroscope_app;

--- a/server/src/routes/backendProvider.test.ts
+++ b/server/src/routes/backendProvider.test.ts
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { after, before, describe, it } from 'node:test';
+import Fastify from 'fastify';
+import { registerBackendProviderRoutes } from './backendProvider.js';
+import type { AppConfig } from '../config.js';
+
+const JWT_SECRET = 'backend-provider-test-secret-32chars!';
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function baseConfig(overrides: Partial<AppConfig> = {}): AppConfig {
+  return {
+    NODE_ENV: 'test',
+    PORT: 3000,
+    HOST: '127.0.0.1',
+    JWT_SECRET,
+    SELF_HOSTED_API_BASE_URL: 'https://api.example.test',
+    JWT_ISSUER: 'retroscope-auth',
+    JWT_ACCESS_TTL_SECONDS: 3600,
+    ALLOW_ORIGINS: '*',
+    POSTGREST_URL: 'http://postgrest:3000',
+    SMTP_PORT: 587,
+    UPLOADS_DIR: '/tmp/uploads',
+    allowOrigins: ['*'],
+    ...overrides,
+  } as AppConfig;
+}
+
+describe('backend provider routes', () => {
+  let app: ReturnType<typeof Fastify>;
+
+  before(async () => {
+    app = Fastify();
+    await registerBackendProviderRoutes(
+      app,
+      baseConfig({ BACKEND_PROVIDER_MODE: 'selfhosted' })
+    );
+    await app.ready();
+  });
+
+  after(async () => {
+    await app.close();
+  });
+
+  it('GET falls back to env when database is unavailable', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/backend-provider' });
+    assert.equal(res.statusCode, 200);
+    const body = res.json() as {
+      mode: string;
+      selfHostedApiBaseUrl: string;
+      source: string;
+    };
+    assert.equal(body.mode, 'selfhosted');
+    assert.equal(body.source, 'env');
+    assert.equal(body.selfHostedApiBaseUrl, 'https://api.example.test');
+  });
+
+  it('PUT requires Authorization', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/backend-provider',
+      payload: { mode: 'selfhosted', selfHostedApiBaseUrl: 'https://api.example.test' },
+    });
+    assert.equal(res.statusCode, 401);
+  });
+
+  it('PUT returns 500 when DATABASE_URL is not configured', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/backend-provider',
+      headers: { authorization: 'Bearer any-token' },
+      payload: { mode: 'selfhosted', selfHostedApiBaseUrl: 'https://api.example.test' },
+    });
+    assert.equal(res.statusCode, 500);
+    const body = res.json() as { error: string };
+    assert.match(body.error, /DATABASE_URL/i);
+  });
+});
+
+describe('app_config server SQL', () => {
+  it('stays free of dollar signs for Coolify compose embeds', async () => {
+    const sqlPath = path.resolve(
+      __dirname,
+      '../../postgres/init/06-app-config-server.sql'
+    );
+    const sql = await readFile(sqlPath, 'utf8');
+    assert.equal(sql.includes('$'), false, 'SQL must not contain $ for Compose interpolation');
+    assert.match(sql, /server_upsert_app_config/);
+    assert.match(sql, /server_get_app_config/);
+    assert.match(sql, /SECURITY DEFINER/);
+  });
+});

--- a/server/src/routes/backendProvider.ts
+++ b/server/src/routes/backendProvider.ts
@@ -38,11 +38,12 @@ async function readProviderFromDb(
   const pool = getPool(config);
   if (!pool) return null;
   try {
-    const result = await pool.query<{ value: string }>(
-      'select value from public.app_config where key = $1 limit 1',
+    // SECURITY DEFINER helper bypasses admin-only RLS (see 06-app-config-server.sql).
+    const result = await pool.query<{ value: string | null }>(
+      'select public.server_get_app_config($1) as value',
       [CONFIG_KEY]
     );
-    return parseStoredValue(result.rows[0]?.value, config.SELF_HOSTED_API_BASE_URL ?? '');
+    return parseStoredValue(result.rows[0]?.value ?? null, config.SELF_HOSTED_API_BASE_URL ?? '');
   } catch {
     return null;
   }
@@ -60,12 +61,9 @@ async function writeProviderToDb(
     mode: payload.mode,
     selfHostedApiBaseUrl: payload.selfHostedApiBaseUrl,
   });
-  await pool.query(
-    `insert into public.app_config (key, value)
-     values ($1, $2)
-     on conflict (key) do update set value = excluded.value`,
-    [CONFIG_KEY, value]
-  );
+  // SECURITY DEFINER helper — plain insert/update is blocked by app_config RLS for
+  // retroscope_app (no auth.uid() admin claim on the Node pool connection).
+  await pool.query('select public.server_upsert_app_config($1, $2)', [CONFIG_KEY, value]);
 }
 
 /**

--- a/src/lib/backend/config.ts
+++ b/src/lib/backend/config.ts
@@ -89,50 +89,58 @@ export async function saveBackendProviderConfig(
     mode: config.mode,
     selfHostedApiBaseUrl: config.selfHostedApiBaseUrl ?? '',
   });
+  const apiBase = (config.selfHostedApiBaseUrl || getViteApiBaseUrl()).replace(/\/$/, '');
 
+  // Persist to the self-hosted API first when configured. Non-admins cannot read
+  // hosted app_config (RLS), so GET /api/backend-provider is the shared source of
+  // truth for dual-path clients.
+  if (apiBase) {
+    const { data: sessionData } = await supabase.auth.getSession();
+    const token = sessionData.session?.access_token;
+    let authToken = token;
+    try {
+      const raw = localStorage.getItem('retroscope.selfhosted.session');
+      if (raw) {
+        const parsed = JSON.parse(raw) as { access_token?: string };
+        if (parsed.access_token) authToken = parsed.access_token;
+      }
+    } catch {
+      // ignore
+    }
+    if (!authToken) {
+      throw new Error('Sign in required to save backend provider');
+    }
+    const res = await fetch(`${apiBase}/api/backend-provider`, {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${authToken}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({
+        mode: config.mode,
+        selfHostedApiBaseUrl: config.selfHostedApiBaseUrl ?? apiBase,
+      }),
+    });
+    if (!res.ok) {
+      let message = `Failed to save backend provider (${res.status})`;
+      try {
+        const body = (await res.json()) as { error?: string };
+        if (body.error) message = body.error;
+      } catch {
+        // ignore parse errors
+      }
+      throw new Error(message);
+    }
+  }
+
+  // Mirror onto hosted Supabase so admins still reading app_config see the same mode.
   const { error } = await supabase
     .from('app_config')
     .upsert({ key: BACKEND_PROVIDER_CONFIG_KEY, value }, { onConflict: 'key' });
 
-  if (error) {
+  if (error && !apiBase) {
     throw error;
-  }
-
-  // Mirror onto the self-hosted API so non-admins (blocked by hosted RLS) still
-  // observe the same mode via GET /api/backend-provider.
-  const apiBase = (config.selfHostedApiBaseUrl || getViteApiBaseUrl()).replace(/\/$/, '');
-  if (apiBase) {
-    try {
-      const { data: sessionData } = await supabase.auth.getSession();
-      const token = sessionData.session?.access_token;
-      // Prefer selfhosted session token when already in that mode.
-      let authToken = token;
-      try {
-        const raw = localStorage.getItem('retroscope.selfhosted.session');
-        if (raw) {
-          const parsed = JSON.parse(raw) as { access_token?: string };
-          if (parsed.access_token) authToken = parsed.access_token;
-        }
-      } catch {
-        // ignore
-      }
-      if (authToken) {
-        await fetch(`${apiBase}/api/backend-provider`, {
-          method: 'PUT',
-          headers: {
-            Authorization: `Bearer ${authToken}`,
-            'Content-Type': 'application/json',
-            Accept: 'application/json',
-          },
-          body: JSON.stringify({
-            mode: config.mode,
-            selfHostedApiBaseUrl: config.selfHostedApiBaseUrl ?? apiBase,
-          }),
-        });
-      }
-    } catch {
-      // Hosted save already succeeded; mirror is best-effort.
-    }
   }
 
   return {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Saving **Admin → Backend → Selfhosted (all users)** returned 500 on `PUT /api/backend-provider`:

```json
{"error":"new row violates row-level security policy for table \"app_config\""}
```

The Node API connects as `retroscope_app` with no JWT/`auth.uid()` claims. Local `app_config` RLS only allows admin inserts/updates, so the mirror write failed. Plain SELECT for the public GET advertisement was also blocked by the same policies.

## Fix

- Add `server/postgres/init/06-app-config-server.sql` with `SECURITY DEFINER` helpers:
  - `server_get_app_config`
  - `server_upsert_app_config`
- Wire helpers into Coolify `db-init` embeds (`docker-compose.selfhost.yml` + `.prebuilt.yml`)
- Call those helpers from `PUT`/`GET` `/api/backend-provider`
- FE `saveBackendProviderConfig` now requires the API write to succeed when `VITE_API_BASE_URL` / API URL is set (hosted upsert remains a secondary mirror)

## Deploy note

Redeploy so `db-init` applies `06-app-config-server.sql` (or paste that file into the Coolify postgres terminal as `postgres`). API-only redeploy without the SQL will still fail until the functions exist.

## Test plan

- [x] Unit tests for backend-provider routes + Coolify `$`-free SQL check
- [ ] After deploy: Admin → Backend → Selfhosted (all users) succeeds
- [ ] `GET /api/backend-provider` returns `mode: selfhosted`, `source: database`
- [ ] Non-admin and admin both resolve to selfhosted (no split-brain)

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DUN-80](https://linear.app/dungeon-dwellers/issue/DUN-80/self-host-phase-5-self-hosted-realtime-retro-poker)

<div><a href="https://cursor.com/agents/bc-6b0a924d-59d8-4b56-bf5f-cd9982aaf547?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b0a924d-59d8-4b56-bf5f-cd9982aaf547&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

